### PR TITLE
docs: add `deepagents` link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ agent = create_deep_agent(history_processors=[processor])
 - **[pydantic-ai-backend](https://github.com/vstorm-co/pydantic-ai-backend)** - File storage and sandbox backends (extracted from pydantic-deep)
 - **[pydantic-ai-todo](https://github.com/vstorm-co/pydantic-ai-todo)** - Task planning toolset (extracted from pydantic-deep)
 - **[fastapi-fullstack](https://github.com/vstorm-co/full-stack-fastapi-nextjs-llm-template)** - Full-stack AI app template with pydantic-deep
+- **[deepagents](https://github.com/langchain-ai/deepagents)** - Deep Agent implementation built on LangChain and LangGraph
 
 ## Development
 


### PR DESCRIPTION
Adds a reference to [LangChain's  `deepagents`](https://github.com/langchain-ai/deepagents) in the "Related Projects" section of the `README.md`.

## Justification
Since `pydantic-deepagents` was inspired by the patterns established in LangChain's `deepagents` (but built for the Pydantic-AI ecosystem), it is helpful for users to have a direct link to the prior art/alternative implementation for comparison.

https://www.blog.langchain.com/deep-agents/

## Disclaimers
*Full disclosure: I work at LangChain on the Deep Agents team.* I am opening this purely to help cross-reference the ecosystem tools, as I've seen your project mentioned as the "Pydantic-native alternative" to ours (which looks great, by the way!).
