### PR TITLE
chore: update subagents-pydantic-ai version from 0.0.3 to 0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.16] - 2025-02-12
+
+### Changed
+
+- Updated `subagents-pydantic-ai` dependency from `>=0.0.3` to `>=0.0.4` — fixes `AttributeError: 'Agent' object has no attribute '_register_toolset'` compatibility issue with pydantic-ai >= 1.38 ([subagents-pydantic-ai#5](https://github.com/vstorm-co/subagents-pydantic-ai/issues/5))
+- Removed `_register_toolset` mock from test fixtures (`tests/conftest.py`) — no longer needed after subagents fix
+
 ## [0.2.15] - 2025-02-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-deep"
-version = "0.2.15"
+version = "0.2.16"
 description = "Deep Agent framework built on Pydantic-ai with planning, filesystem, and subagent capabilities"
 readme = "README.md"
 license = "MIT"
@@ -27,7 +27,7 @@ dependencies = [
     "pydantic-ai-todo>=0.1.5",
     "pydantic-ai-backend[console]>=0.1.6",
     "summarization-pydantic-ai>=0.0.2",
-    "subagents-pydantic-ai>=0.0.3",
+    "subagents-pydantic-ai>=0.0.4",
     "pydantic>=2.0",
     "chardet>=5.0.0",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,6 @@ from pydantic_deep.deps import DeepAgentDeps
 def mock_subagent_agent():
     """Mock the Agent class in subagents_pydantic_ai to avoid needing API keys."""
     mock_agent = MagicMock()
-    mock_agent._register_toolset = MagicMock()
     with patch("subagents_pydantic_ai.toolset.Agent", return_value=mock_agent):
         yield mock_agent
 


### PR DESCRIPTION
## [0.2.16] - 2025-02-12

### Changed

- Updated `subagents-pydantic-ai` dependency from `>=0.0.3` to `>=0.0.4` — fixes `AttributeError: 'Agent' object has no attribute '_register_toolset'` compatibility issue with pydantic-ai >= 1.38 ([subagents-pydantic-ai#5](https://github.com/vstorm-co/subagents-pydantic-ai/issues/5))
- Removed `_register_toolset` mock from test fixtures (`tests/conftest.py`) — no longer needed after subagents fix
