### PR TITLE
fix: pass Model objects through to subagents instead of discarding them

### DIFF
--- a/pydantic_deep/agent.py
+++ b/pydantic_deep/agent.py
@@ -509,8 +509,8 @@ def create_deep_agent(  # noqa: C901
         all_toolsets.append(console_toolset)
 
     if include_subagents:
-        # For subagents, convert model to string if it's a Model instance
-        subagent_model = model if isinstance(model, str) else DEFAULT_MODEL
+        # Pass model through to subagents (supports both str and Model objects)
+        subagent_model = model or DEFAULT_MODEL
 
         # Create toolsets factory for subagents - they get console, todo, and extra tools
         _retries = retries  # capture for closure


### PR DESCRIPTION
When `create_deep_agent(model=TestModel())` was called, the model was dropped because `isinstance(model, str)` was False, causing a fallback to DEFAULT_MODEL ("openai:gpt-4.1"). This broke TestModel usage and any other Model object (e.g. AnthropicModel).

Change the guard to `model or DEFAULT_MODEL` so Model objects are passed through to `create_subagent_toolset`. Requires the matching fix in subagents-pydantic-ai to widen `default_model: str` to `str | Model`.

Works together with https://github.com/vstorm-co/subagents-pydantic-ai/pull/15