### PR TITLE
Enhance byte reading for UTF-8 sequences

### DIFF
--- a/cli/interactive.py
+++ b/cli/interactive.py
@@ -1400,8 +1400,35 @@ def _read_raw_key() -> str:
         new[6][termios.VMIN] = 1
         new[6][termios.VTIME] = 0
         termios.tcsetattr(fd, termios.TCSADRAIN, new)
+        
+        # Read first byte
+        first_byte = os.read(fd, 1)
+        if not first_byte:
+            return ""
 
-        ch = os.read(fd, 1).decode("utf-8", errors="replace")
+        # Determine UTF-8 sequence length
+        byte_val = first_byte[0]
+        if byte_val & 0x80 == 0:
+            num_bytes = 1
+        elif byte_val & 0xE0 == 0xC0:
+            num_bytes = 2
+        elif byte_val & 0xF0 == 0xE0:
+            num_bytes = 3
+        elif byte_val & 0xF8 == 0xF0:
+            num_bytes = 4
+        else:
+            num_bytes = 1  # Invalid start byte, fall back
+
+        # Read remaining bytes
+        full_bytes = first_byte
+        for _ in range(num_bytes - 1):
+            full_bytes += os.read(fd, 1)
+
+        try:
+            ch = full_bytes.decode("utf-8")
+        except UnicodeDecodeError:
+            ch = full_bytes.decode("utf-8", errors="replace")
+
         if ch == "\x1b":
             if _sel.select([fd], [], [], 0.05)[0]:
                 ch2 = os.read(fd, 1).decode("utf-8", errors="replace")


### PR DESCRIPTION
## Changes

### Summary

Fixed a bug in the CLI's interactive mode where Chinese characters and other multi-byte UTF-8 characters appeared as garbled text when typed.

### Business Context
The CLI uses a custom "raw mode" input handler to enable instant triggers like `/` for commands and `@` for file mentions. Previously, this handler read and
      decoded input one byte at a time, which is incompatible with multi-byte UTF-8 sequences used by Chinese, Japanese, Korean, and many other languages.

### Changes

- Modified `_read_raw_key` in `cli/interactive.py` to correctly handle UTF-8 multi-byte sequences.
- Implemented logic to inspect the first byte of an input and determine the expected sequence length (1-4 bytes) based on UTF-8 bit patterns.
- Updated the reader to fetch the full byte sequence before attempting to decode, ensuring that multi-byte characters are reconstructed correctly before being
      displayed or buffered.

### Verification

1. Run `pydantic-deep chat`.
2. Type Chinese characters (e.g., "你好").
3. **Before fix:** Each Chinese character would appear as three replacement characters (e.g., ``).
4. **After fix:** Characters appear correctly in the terminal prompt and are sent to the LLM without corruption.
5. Verified that standard ASCII characters, slash commands, and arrow-key navigation still function as expected.

### Linked Issues

N/A
