### PR TITLE
improve git-workflow skill description + add skill-review CI

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,14 @@
+name: Skill Review
+on:
+  pull_request:
+    paths: ['**/SKILL.md']
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@14b47c8420ff9ac9a12c30ed4b89ce0e9d0355ae # main

--- a/pydantic_deep/bundled_skills/git-workflow/SKILL.md
+++ b/pydantic_deep/bundled_skills/git-workflow/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: git-workflow
-description: "Git operations: commits, branches, PRs, and conflict resolution"
+description: >
+  Create and amend commits, manage branches, open pull requests, and resolve
+  merge conflicts. Use when the user mentions "git", "commit", "branch",
+  "merge", "pull request", "rebase", "push", "checkout", or "staged changes".
 tags: [git, workflow]
 version: "1.0.0"
 ---


### PR DESCRIPTION
hey @vstorm-co, thanks for building pydantic-deepagents. really like the "production-grade agents in 10 lines" approach with the pydantic-ai foundation. Kudos on approaching `500` stars! I've just starred it.

ran your git-workflow skill through agent evals and spotted a quick win that took it from `~66%` to `~100%` performance:

- rewrote description with concrete actions + trigger terms like _"git"_, _"commit"_, _"branch"_, _"merge"_, _"pull request"_, _"rebase"_ so agents reliably match user requests to this skill

also added a lightweight GitHub Action that auto-reviews any skill.md changed in a PR (includes min permissions, uses a pinned action version, only posts a review comment).

this means that it gives you and your contributors an instant quality signal before you have to review yourself (no signup, no tokens needed).

these were easy changes to bring the skill in line with what **performs well against Anthropic's best practices**. honest disclosure, I work at tessl.io where we build tooling around this. not a pitch, just fixes that were straightforward to make! happy to answer any questions on the changes.