### PR TITLE
feat: add installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.6] - 2026-04-11
+
+### Added
+
+- **One-command installer (`install.sh`)** — macOS and Linux users can now install pydantic-deep without knowing
+  Python or pip. A single curl command installs uv (if missing) and then the CLI:
+  ```bash
+  curl -fsSL https://raw.githubusercontent.com/vstorm-co/pydantic-deep/main/install.sh | bash
+  ```
+  The script auto-detects uv, falls back to installing it via `astral.sh/uv`, then runs
+  `uv tool install "pydantic-deep[cli]"`. Verifies the installation and prints PATH instructions
+  if the binary is not immediately discoverable
+- **`pydantic-deep update` command** — self-update command that upgrades to the latest PyPI release.
+  Uses `uv tool upgrade pydantic-deep` when uv is available; falls back to
+  `pip install --upgrade "pydantic-deep[cli]"` otherwise
+- **Startup update notifications** — on every CLI invocation the tool silently checks PyPI for a newer
+  version and prints a one-line notice when one is found:
+  ```
+  Update available: v0.3.6 → v0.3.7  Run: pydantic-deep update
+  ```
+  The check is backed by a 24-hour file cache (`~/.pydantic-deep/update_check.json`) so the network
+  is only hit once per day. A 2-second timeout ensures the check never blocks startup
+
 ## [0.3.5] - 2026-04-10
 
 ### Added

--- a/apps/cli/main.py
+++ b/apps/cli/main.py
@@ -96,6 +96,17 @@ def _main_callback(
     if logfire_enabled:
         _setup_logfire()
 
+    # Non-blocking update notification (uses 24-hour file cache)
+    from apps.cli.update import check_for_update
+
+    _upd = check_for_update()
+    if _upd:
+        Console().print(
+            f"[yellow]Update available:[/yellow] "
+            f"v{_upd.current} → [bold]v{_upd.latest}[/bold]  "
+            f"Run: [cyan]pydantic-deep update[/cyan]"
+        )
+
     # Default: launch TUI when no subcommand is given
     if ctx.invoked_subcommand is None:
         from apps.cli.init import ensure_initialized
@@ -747,6 +758,15 @@ def threads_export(
         typer.echo(f"# Thread: {session_dir.name}\n\nMessages: {len(messages)}\n")
         for msg in messages:
             typer.echo(f"---\n{msg}\n")
+
+
+@app.command()
+def update() -> None:
+    """Update pydantic-deep to the latest version."""
+    from apps.cli.update import run_update
+
+    Console().print("Updating pydantic-deep...")
+    raise typer.Exit(run_update())
 
 
 def main() -> None:

--- a/apps/cli/update.py
+++ b/apps/cli/update.py
@@ -1,0 +1,119 @@
+"""Version checking and self-update functionality for pydantic-deep CLI."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, NamedTuple
+
+PYPI_URL = "https://pypi.org/pypi/pydantic-deep/json"
+_CHECK_INTERVAL_SECS: int = 86_400  # 24 hours
+
+
+class UpdateInfo(NamedTuple):
+    current: str
+    latest: str
+
+
+def _get_cache_path() -> Path:
+    return Path.home() / ".pydantic-deep" / "update_check.json"
+
+
+def _version_gt(a: str, b: str) -> bool:
+    """Return True if version string *a* is greater than *b*.
+
+    Only numeric dot-separated components are compared, so pre-release
+    suffixes (e.g. ``0.4.0a1``) are stripped automatically.
+    """
+
+    def _parts(v: str) -> tuple[int, ...]:
+        return tuple(int(x) for x in v.split(".") if x.isdigit())
+
+    return _parts(a) > _parts(b)
+
+
+def _load_cache(cache_path: Path) -> dict[str, Any] | None:
+    """Return cached version data if still fresh (< 24 h), else ``None``."""
+    try:
+        data: dict[str, Any] = json.loads(cache_path.read_text())
+        checked_at = datetime.fromisoformat(data["checked_at"])
+        age = (datetime.now(timezone.utc) - checked_at).total_seconds()
+        if age < _CHECK_INTERVAL_SECS:
+            return data
+    except Exception:
+        pass
+    return None
+
+
+def _save_cache(latest_version: str, cache_path: Path) -> None:
+    """Persist *latest_version* and a timestamp to *cache_path*."""
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(
+            json.dumps(
+                {
+                    "version": latest_version,
+                    "checked_at": datetime.now(timezone.utc).isoformat(),
+                }
+            )
+        )
+    except Exception:
+        pass
+
+
+def _fetch_latest_version() -> str | None:
+    """Fetch the latest pydantic-deep version from PyPI (2-second timeout)."""
+    try:
+        with urllib.request.urlopen(PYPI_URL, timeout=2) as resp:
+            data: dict[str, Any] = json.loads(resp.read())
+            return str(data["info"]["version"])
+    except Exception:
+        return None
+
+
+def _find_uv() -> str | None:
+    """Return path to the ``uv`` executable if available, else ``None``."""
+    return shutil.which("uv")
+
+
+def check_for_update(cache_path: Path | None = None) -> UpdateInfo | None:
+    """Check if a newer version of pydantic-deep is available on PyPI.
+
+    Uses a 24-hour file-based cache so the network is only hit once per day.
+    Returns ``None`` when already up-to-date or when the check cannot be
+    completed (e.g. no internet access).
+    """
+    from pydantic_deep import __version__
+
+    path = cache_path if cache_path is not None else _get_cache_path()
+    cached = _load_cache(path)
+    if cached:
+        latest = cached["version"]
+    else:
+        latest = _fetch_latest_version()
+        if latest is None:
+            return None
+        _save_cache(latest, path)
+
+    if _version_gt(latest, __version__):
+        return UpdateInfo(current=__version__, latest=latest)
+    return None
+
+
+def run_update() -> int:
+    """Upgrade pydantic-deep to the latest version.
+
+    Uses ``uv tool upgrade`` when uv is available, otherwise falls back to
+    ``pip install --upgrade``.  Returns the subprocess exit code.
+    """
+    uv = _find_uv()
+    if uv:
+        return subprocess.run([uv, "tool", "upgrade", "pydantic-deep"]).returncode
+    return subprocess.run(
+        [sys.executable, "-m", "pip", "install", "--upgrade", "pydantic-deep[cli]"]
+    ).returncode

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -4,14 +4,20 @@ The pydantic-deep CLI gives you a Claude Code-style AI coding assistant in your 
 
 ## Installation
 
+### One command (macOS & Linux — recommended)
+
 ```bash
-pip install pydantic-deep[cli]
+curl -fsSL https://raw.githubusercontent.com/vstorm-co/pydantic-deep/main/install.sh | bash
 ```
 
-Or with [uv](https://docs.astral.sh/uv/):
+Installs [uv](https://docs.astral.sh/uv/) if needed, then runs `uv tool install "pydantic-deep[cli]"`. No Python knowledge required.
+
+### pip / uv
 
 ```bash
-uv pip install pydantic-deep[cli]
+pip install "pydantic-deep[cli]"
+# or
+uv tool install "pydantic-deep[cli]"
 ```
 
 ## Quick Start
@@ -117,6 +123,22 @@ pydantic-deep threads export abc12345 -f json # Export as JSON
 pydantic-deep config show                     # Show current config
 pydantic-deep config set model anthropic:claude-sonnet-4-6
 ```
+
+### `update` — Self-Update
+
+```bash
+pydantic-deep update
+```
+
+Upgrades to the latest PyPI release. Uses `uv tool upgrade` when uv is available, otherwise falls back to pip.
+
+When a newer version is available, pydantic-deep shows a one-line notification at startup:
+
+```
+Update available: v0.3.6 → v0.3.7  Run: pydantic-deep update
+```
+
+The version check is cached for 24 hours — PyPI is never queried more than once per day.
 
 ## TUI Features
 
@@ -312,7 +334,8 @@ Logs include agent lifecycle events, tool calls with timing, command dispatches,
 
 ```
 apps/cli/
-├── main.py              — Typer entry point (tui, run, init, skills, threads, config)
+├── main.py              — Typer entry point (tui, run, init, skills, threads, config, update)
+├── update.py            — Version checking and self-update (PyPI cache, uv/pip upgrade)
 ├── run.py               — Headless runner (execute_headless)
 ├── tui.py               — TUI launcher (run_tui, run_preview)
 ├── app.py               — DeepApp (Textual App root)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,17 +1,44 @@
 # Installation
 
-## Requirements
+## CLI — One Command (macOS & Linux)
+
+The fastest way to get the terminal assistant — no Python knowledge required:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/vstorm-co/pydantic-deep/main/install.sh | bash
+```
+
+The script installs [uv](https://docs.astral.sh/uv/) automatically if it is not already present,
+then runs `uv tool install "pydantic-deep[cli]"`. Once installed, launch with:
+
+```bash
+pydantic-deep
+```
+
+To update to the latest release at any time:
+
+```bash
+pydantic-deep update
+```
+
+---
+
+## Framework — Python Package
+
+If you are using pydantic-deep as a library (not just the CLI):
+
+### Requirements
 
 - Python 3.10+
 - [uv](https://docs.astral.sh/uv/) (recommended) or pip
 
-## Install with uv (recommended)
+### Install with uv (recommended)
 
 ```bash
 uv add pydantic-deep
 ```
 
-## Install with pip
+### Install with pip
 
 ```bash
 pip install pydantic-deep

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# pydantic-deep installer
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/vstorm-co/pydantic-deep/main/install.sh | bash
+
+set -euo pipefail
+
+BOLD='\033[1m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+DIM='\033[2m'
+RESET='\033[0m'
+
+say()  { printf "${BOLD}  pydantic-deep${RESET}  %s\n" "$*"; }
+ok()   { printf "${GREEN}  ✓${RESET}  %s\n" "$*"; }
+warn() { printf "${YELLOW}  !${RESET}  %s\n" "$*"; }
+fail() { printf "${RED}  ✗${RESET}  %s\n" "$*"; exit 1; }
+
+echo ""
+printf "${BOLD}  pydantic-deep — installer${RESET}\n"
+printf "  ─────────────────────────────\n"
+echo ""
+
+# ── OS check ──────────────────────────────────────────────────────────────────
+OS="$(uname -s 2>/dev/null || echo unknown)"
+case "${OS}" in
+    Linux* | Darwin*) ;;
+    *) fail "Unsupported OS: ${OS}. Only macOS and Linux are supported." ;;
+esac
+
+# ── Step 1: ensure uv is available ────────────────────────────────────────────
+if command -v uv &>/dev/null; then
+    ok "uv found: $(uv --version)"
+else
+    say "Installing uv (fast Python package manager)..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+
+    # Source newly installed uv into current session
+    for _dir in "$HOME/.local/bin" "$HOME/.cargo/bin"; do
+        [ -d "$_dir" ] && export PATH="$_dir:$PATH"
+    done
+    [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
+
+    if ! command -v uv &>/dev/null; then
+        fail "uv installation failed. See: https://docs.astral.sh/uv/getting-started/installation/"
+    fi
+    ok "uv installed: $(uv --version)"
+fi
+
+echo ""
+
+# ── Step 2: install pydantic-deep ─────────────────────────────────────────────
+say "Installing pydantic-deep CLI..."
+uv tool install "pydantic-deep[cli]" --upgrade
+
+echo ""
+
+# ── Step 3: verify ────────────────────────────────────────────────────────────
+# uv tool executables land in ~/.local/bin — add it for immediate verification
+export PATH="$HOME/.local/bin:$PATH"
+
+if command -v pydantic-deep &>/dev/null; then
+    VERSION="$(pydantic-deep --version 2>&1 | head -1)"
+    ok "${VERSION} installed successfully!"
+    echo ""
+    printf "  ${BOLD}Get started:${RESET}\n"
+    echo ""
+    printf "    ${BOLD}pydantic-deep${RESET}          # launch interactive TUI\n"
+    printf "    ${BOLD}pydantic-deep --help${RESET}   # see all commands\n"
+    echo ""
+else
+    echo ""
+    warn "pydantic-deep was installed but is not yet in your PATH."
+    warn "Add this line to your shell config (~/.zshrc or ~/.bashrc):"
+    echo ""
+    printf "    export PATH=\"\$HOME/.local/bin:\$PATH\"\n"
+    echo ""
+    warn "Then run:  source ~/.zshrc   (or restart your terminal)"
+    echo ""
+fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-deep"
-version = "0.3.5"
+version = "0.3.6"
 description = "Deep Agent framework built on Pydantic-ai with planning, filesystem, and subagent capabilities"
 readme = "README.md"
 license = "MIT"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,13 @@ from pydantic_deep.deps import DeepAgentDeps
 
 
 @pytest.fixture(autouse=True)
+def mock_update_check():
+    """Skip PyPI version checks in all tests to avoid network calls."""
+    with patch("apps.cli.update.check_for_update", return_value=None):
+        yield
+
+
+@pytest.fixture(autouse=True)
 def mock_subagent_agent():
     """Mock the Agent class in subagents_pydantic_ai to avoid needing API keys."""
     mock_agent = MagicMock()

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from apps.cli.main import app
+from apps.cli.update import UpdateInfo
 
 runner = CliRunner()
 
@@ -213,3 +214,43 @@ class TestThreadsDelete:
 
         # Session directory should be removed
         assert not session_dir.exists()
+
+
+class TestUpdateCommand:
+    """Tests for 'update' command."""
+
+    def test_update_succeeds(self) -> None:
+        with patch("apps.cli.update.run_update", return_value=0):
+            result = runner.invoke(app, ["update"])
+        assert result.exit_code == 0
+        assert "Updating" in result.output
+
+    def test_update_propagates_nonzero_exit_code(self) -> None:
+        with patch("apps.cli.update.run_update", return_value=1):
+            result = runner.invoke(app, ["update"])
+        assert result.exit_code == 1
+
+    def test_update_help(self) -> None:
+        result = runner.invoke(app, ["update", "--help"])
+        assert result.exit_code == 0
+        assert "latest" in result.output.lower()
+
+
+class TestVersionNotification:
+    """Tests for the update notification shown at startup."""
+
+    def test_shows_notification_when_update_available(self) -> None:
+        upd = UpdateInfo(current="0.1.0", latest="1.0.0")
+        with patch("apps.cli.update.check_for_update", return_value=upd):
+            with patch("apps.cli.config.DEFAULT_CONFIG_PATH", Path("/tmp/nonexistent/config.toml")):
+                result = runner.invoke(app, ["config", "show"])
+        assert result.exit_code == 0
+        assert "Update available" in result.output
+        assert "1.0.0" in result.output
+
+    def test_no_output_when_up_to_date(self) -> None:
+        with patch("apps.cli.update.check_for_update", return_value=None):
+            with patch("apps.cli.config.DEFAULT_CONFIG_PATH", Path("/tmp/nonexistent/config.toml")):
+                result = runner.invoke(app, ["config", "show"])
+        assert result.exit_code == 0
+        assert "Update available" not in result.output

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -241,16 +241,20 @@ class TestVersionNotification:
 
     def test_shows_notification_when_update_available(self) -> None:
         upd = UpdateInfo(current="0.1.0", latest="1.0.0")
-        with patch("apps.cli.update.check_for_update", return_value=upd):
-            with patch("apps.cli.config.DEFAULT_CONFIG_PATH", Path("/tmp/nonexistent/config.toml")):
-                result = runner.invoke(app, ["config", "show"])
+        with (
+            patch("apps.cli.update.check_for_update", return_value=upd),
+            patch("apps.cli.config.DEFAULT_CONFIG_PATH", Path("/tmp/nonexistent/config.toml")),
+        ):
+            result = runner.invoke(app, ["config", "show"])
         assert result.exit_code == 0
         assert "Update available" in result.output
         assert "1.0.0" in result.output
 
     def test_no_output_when_up_to_date(self) -> None:
-        with patch("apps.cli.update.check_for_update", return_value=None):
-            with patch("apps.cli.config.DEFAULT_CONFIG_PATH", Path("/tmp/nonexistent/config.toml")):
-                result = runner.invoke(app, ["config", "show"])
+        with (
+            patch("apps.cli.update.check_for_update", return_value=None),
+            patch("apps.cli.config.DEFAULT_CONFIG_PATH", Path("/tmp/nonexistent/config.toml")),
+        ):
+            result = runner.invoke(app, ["config", "show"])
         assert result.exit_code == 0
         assert "Update available" not in result.output

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -1,0 +1,237 @@
+"""Tests for CLI update-checking and self-update functionality."""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.cli.update import (
+    UpdateInfo,
+    _fetch_latest_version,
+    _find_uv,
+    _get_cache_path,
+    _load_cache,
+    _save_cache,
+    _version_gt,
+    check_for_update,
+    run_update,
+)
+
+
+# ── _get_cache_path ───────────────────────────────────────────────────────────
+
+
+class TestGetCachePath:
+    def test_returns_path_under_home(self) -> None:
+        path = _get_cache_path()
+        assert path.name == "update_check.json"
+        assert ".pydantic-deep" in str(path)
+
+
+# ── _version_gt ───────────────────────────────────────────────────────────────
+
+
+class TestVersionGt:
+    def test_greater_patch(self) -> None:
+        assert _version_gt("0.3.6", "0.3.5") is True
+
+    def test_greater_minor(self) -> None:
+        assert _version_gt("0.4.0", "0.3.5") is True
+
+    def test_greater_major(self) -> None:
+        assert _version_gt("1.0.0", "0.9.9") is True
+
+    def test_less(self) -> None:
+        assert _version_gt("0.3.0", "0.3.5") is False
+
+    def test_equal(self) -> None:
+        assert _version_gt("0.3.5", "0.3.5") is False
+
+    def test_prerelease_stripped(self) -> None:
+        # "0.4.0a1" numeric parts → (0, 4, 0), same as "0.4.0"
+        assert _version_gt("0.4.0a1", "0.3.5") is True
+
+    def test_empty_strings(self) -> None:
+        assert _version_gt("", "") is False
+
+    def test_non_numeric(self) -> None:
+        assert _version_gt("bad", "also-bad") is False
+
+
+# ── _load_cache ───────────────────────────────────────────────────────────────
+
+
+class TestLoadCache:
+    def test_fresh_cache_returned(self, tmp_path: Path) -> None:
+        cache = tmp_path / "update_check.json"
+        cache.write_text(
+            json.dumps(
+                {
+                    "version": "1.0.0",
+                    "checked_at": datetime.now(timezone.utc).isoformat(),
+                }
+            )
+        )
+        result = _load_cache(cache)
+        assert result is not None
+        assert result["version"] == "1.0.0"
+
+    def test_stale_cache_returns_none(self, tmp_path: Path) -> None:
+        cache = tmp_path / "update_check.json"
+        old = (datetime.now(timezone.utc) - timedelta(hours=25)).isoformat()
+        cache.write_text(json.dumps({"version": "1.0.0", "checked_at": old}))
+        assert _load_cache(cache) is None
+
+    def test_missing_file_returns_none(self, tmp_path: Path) -> None:
+        assert _load_cache(tmp_path / "nonexistent.json") is None
+
+    def test_corrupted_json_returns_none(self, tmp_path: Path) -> None:
+        cache = tmp_path / "update_check.json"
+        cache.write_text("not valid json!!!")
+        assert _load_cache(cache) is None
+
+    def test_missing_key_returns_none(self, tmp_path: Path) -> None:
+        cache = tmp_path / "update_check.json"
+        cache.write_text(json.dumps({"version": "1.0.0"}))  # no checked_at
+        assert _load_cache(cache) is None
+
+
+# ── _save_cache ───────────────────────────────────────────────────────────────
+
+
+class TestSaveCache:
+    def test_writes_version_and_timestamp(self, tmp_path: Path) -> None:
+        cache = tmp_path / "sub" / "update_check.json"
+        _save_cache("1.2.3", cache)
+        data = json.loads(cache.read_text())
+        assert data["version"] == "1.2.3"
+        assert "checked_at" in data
+
+    def test_silently_ignores_write_error(self, tmp_path: Path) -> None:
+        # Make parent a file so mkdir fails — should not raise
+        blocker = tmp_path / "blocker"
+        blocker.write_text("I am a file")
+        _save_cache("1.0.0", blocker / "update_check.json")
+
+
+# ── _fetch_latest_version ────────────────────────────────────────────────────
+
+
+class TestFetchLatestVersion:
+    def test_parses_pypi_response(self) -> None:
+        body = json.dumps({"info": {"version": "9.9.9"}}).encode()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = body
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            assert _fetch_latest_version() == "9.9.9"
+
+    def test_returns_none_on_network_error(self) -> None:
+        with patch("urllib.request.urlopen", side_effect=OSError("timeout")):
+            assert _fetch_latest_version() is None
+
+
+# ── _find_uv ─────────────────────────────────────────────────────────────────
+
+
+class TestFindUv:
+    def test_returns_path_when_found(self) -> None:
+        with patch("shutil.which", return_value="/usr/bin/uv"):
+            assert _find_uv() == "/usr/bin/uv"
+
+    def test_returns_none_when_not_found(self) -> None:
+        with patch("shutil.which", return_value=None):
+            assert _find_uv() is None
+
+
+# ── check_for_update ──────────────────────────────────────────────────────────
+
+
+class TestCheckForUpdate:
+    def test_update_available_from_fresh_cache(self, tmp_path: Path) -> None:
+        cache = tmp_path / "update_check.json"
+        cache.write_text(
+            json.dumps(
+                {
+                    "version": "99.0.0",
+                    "checked_at": datetime.now(timezone.utc).isoformat(),
+                }
+            )
+        )
+        with patch("pydantic_deep.__version__", "0.1.0"):
+            result = check_for_update(cache)
+        assert result == UpdateInfo(current="0.1.0", latest="99.0.0")
+
+    def test_no_update_from_fresh_cache(self, tmp_path: Path) -> None:
+        cache = tmp_path / "update_check.json"
+        cache.write_text(
+            json.dumps(
+                {
+                    "version": "0.1.0",
+                    "checked_at": datetime.now(timezone.utc).isoformat(),
+                }
+            )
+        )
+        with patch("pydantic_deep.__version__", "99.0.0"):
+            assert check_for_update(cache) is None
+
+    def test_fetches_from_pypi_when_no_cache(self, tmp_path: Path) -> None:
+        cache = tmp_path / "update_check.json"
+        with patch("apps.cli.update._fetch_latest_version", return_value="99.0.0"):
+            with patch("pydantic_deep.__version__", "0.1.0"):
+                result = check_for_update(cache)
+        assert result is not None
+        assert result.latest == "99.0.0"
+        # Cache should now be written
+        assert cache.exists()
+
+    def test_returns_none_when_fetch_fails(self, tmp_path: Path) -> None:
+        cache = tmp_path / "update_check.json"
+        with patch("apps.cli.update._fetch_latest_version", return_value=None):
+            assert check_for_update(cache) is None
+
+    def test_uses_default_cache_path_when_none_given(self) -> None:
+        with patch("apps.cli.update._load_cache", return_value=None):
+            with patch("apps.cli.update._fetch_latest_version", return_value=None):
+                result = check_for_update()
+        assert result is None
+
+
+# ── run_update ────────────────────────────────────────────────────────────────
+
+
+class TestRunUpdate:
+    def test_uses_uv_when_available(self) -> None:
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        with patch("apps.cli.update._find_uv", return_value="/usr/bin/uv"):
+            with patch("subprocess.run", return_value=mock_proc) as mock_run:
+                code = run_update()
+        assert code == 0
+        mock_run.assert_called_once_with(["/usr/bin/uv", "tool", "upgrade", "pydantic-deep"])
+
+    def test_falls_back_to_pip_without_uv(self) -> None:
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        with patch("apps.cli.update._find_uv", return_value=None):
+            with patch("subprocess.run", return_value=mock_proc) as mock_run:
+                code = run_update()
+        assert code == 0
+        args = mock_run.call_args[0][0]
+        assert args[0] == sys.executable
+        assert "pip" in args
+        assert "pydantic-deep[cli]" in args
+
+    def test_propagates_nonzero_exit_code(self) -> None:
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        with patch("apps.cli.update._find_uv", return_value="/usr/bin/uv"):
+            with patch("subprocess.run", return_value=mock_proc):
+                assert run_update() == 1

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -8,8 +8,6 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from apps.cli.update import (
     UpdateInfo,
     _fetch_latest_version,
@@ -21,7 +19,6 @@ from apps.cli.update import (
     check_for_update,
     run_update,
 )
-
 
 # ── _get_cache_path ───────────────────────────────────────────────────────────
 
@@ -184,9 +181,11 @@ class TestCheckForUpdate:
 
     def test_fetches_from_pypi_when_no_cache(self, tmp_path: Path) -> None:
         cache = tmp_path / "update_check.json"
-        with patch("apps.cli.update._fetch_latest_version", return_value="99.0.0"):
-            with patch("pydantic_deep.__version__", "0.1.0"):
-                result = check_for_update(cache)
+        with (
+            patch("apps.cli.update._fetch_latest_version", return_value="99.0.0"),
+            patch("pydantic_deep.__version__", "0.1.0"),
+        ):
+            result = check_for_update(cache)
         assert result is not None
         assert result.latest == "99.0.0"
         # Cache should now be written
@@ -198,9 +197,11 @@ class TestCheckForUpdate:
             assert check_for_update(cache) is None
 
     def test_uses_default_cache_path_when_none_given(self) -> None:
-        with patch("apps.cli.update._load_cache", return_value=None):
-            with patch("apps.cli.update._fetch_latest_version", return_value=None):
-                result = check_for_update()
+        with (
+            patch("apps.cli.update._load_cache", return_value=None),
+            patch("apps.cli.update._fetch_latest_version", return_value=None),
+        ):
+            result = check_for_update()
         assert result is None
 
 
@@ -211,18 +212,22 @@ class TestRunUpdate:
     def test_uses_uv_when_available(self) -> None:
         mock_proc = MagicMock()
         mock_proc.returncode = 0
-        with patch("apps.cli.update._find_uv", return_value="/usr/bin/uv"):
-            with patch("subprocess.run", return_value=mock_proc) as mock_run:
-                code = run_update()
+        with (
+            patch("apps.cli.update._find_uv", return_value="/usr/bin/uv"),
+            patch("subprocess.run", return_value=mock_proc) as mock_run,
+        ):
+            code = run_update()
         assert code == 0
         mock_run.assert_called_once_with(["/usr/bin/uv", "tool", "upgrade", "pydantic-deep"])
 
     def test_falls_back_to_pip_without_uv(self) -> None:
         mock_proc = MagicMock()
         mock_proc.returncode = 0
-        with patch("apps.cli.update._find_uv", return_value=None):
-            with patch("subprocess.run", return_value=mock_proc) as mock_run:
-                code = run_update()
+        with (
+            patch("apps.cli.update._find_uv", return_value=None),
+            patch("subprocess.run", return_value=mock_proc) as mock_run,
+        ):
+            code = run_update()
         assert code == 0
         args = mock_run.call_args[0][0]
         assert args[0] == sys.executable
@@ -232,6 +237,8 @@ class TestRunUpdate:
     def test_propagates_nonzero_exit_code(self) -> None:
         mock_proc = MagicMock()
         mock_proc.returncode = 1
-        with patch("apps.cli.update._find_uv", return_value="/usr/bin/uv"):
-            with patch("subprocess.run", return_value=mock_proc):
-                assert run_update() == 1
+        with (
+            patch("apps.cli.update._find_uv", return_value="/usr/bin/uv"),
+            patch("subprocess.run", return_value=mock_proc),
+        ):
+            assert run_update() == 1


### PR DESCRIPTION
## [0.3.6] - 2026-04-11

### Added

- **One-command installer (`install.sh`)** — macOS and Linux users can now install pydantic-deep without knowing
  Python or pip. A single curl command installs uv (if missing) and then the CLI:
  ```bash
  curl -fsSL https://raw.githubusercontent.com/vstorm-co/pydantic-deep/main/install.sh | bash
  ```
  The script auto-detects uv, falls back to installing it via `astral.sh/uv`, then runs
  `uv tool install "pydantic-deep[cli]"`. Verifies the installation and prints PATH instructions
  if the binary is not immediately discoverable
- **`pydantic-deep update` command** — self-update command that upgrades to the latest PyPI release.
  Uses `uv tool upgrade pydantic-deep` when uv is available; falls back to
  `pip install --upgrade "pydantic-deep[cli]"` otherwise
- **Startup update notifications** — on every CLI invocation the tool silently checks PyPI for a newer
  version and prints a one-line notice when one is found:
  ```
  Update available: v0.3.6 → v0.3.7  Run: pydantic-deep update
  ```
  The check is backed by a 24-hour file cache (`~/.pydantic-deep/update_check.json`) so the network
  is only hit once per day. A 2-second timeout ensures the check never blocks startup
