### PR TITLE
docs: improve repo structure and docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,83 @@
+name: Bug Report
+description: Report a bug or unexpected behaviour in pydantic-deep
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report!
+        Please fill out this form **in English** so maintainers and the community can help effectively.
+        For **security vulnerabilities**, do NOT use this form — email **security@vstorm.co** instead (see [SECURITY.md](https://github.com/vstorm-co/pydantic-deepagents/blob/main/SECURITY.md)).
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+      placeholder: "When I call create_deep_agent() with X, it raises Y instead of Z."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal code or steps to reproduce the problem.
+      placeholder: |
+        1. Install pydantic-deep==X.Y.Z
+        2. Run the following code:
+           ```python
+           from pydantic_deep import create_deep_agent
+           ...
+           ```
+        3. Observe the error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behaviour
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behaviour
+      description: What actually happened? Include the full error message and traceback.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: pydantic-deep Version
+      placeholder: "0.3.11"
+    validations:
+      required: true
+
+  - type: input
+    id: python
+    attributes:
+      label: Python Version
+      placeholder: "3.12.0"
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      placeholder: "macOS 14.4 / Ubuntu 22.04 / Windows 11"
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, logs, or screenshots that might help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/vstorm-co/pydantic-deepagents/blob/main/SECURITY.md
+    about: >
+      Do NOT open a public issue for security vulnerabilities.
+      Please email security@vstorm.co instead (see SECURITY.md for details).
+  - name: Documentation
+    url: https://vstorm-co.github.io/pydantic-deepagents/
+    about: Check the documentation first — your question may already be answered there.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for pydantic-deep
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement!
+        Please describe your request **in English** so maintainers and the community can evaluate it effectively.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem or limitation are you trying to solve? Why does it matter?
+      placeholder: "I find it difficult to X because the current API does Y, which means I have to Z."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the feature or change you would like to see. Include a rough API sketch if applicable.
+      placeholder: |
+        Add a `foo` parameter to `create_deep_agent()` that allows...
+        ```python
+        agent = create_deep_agent(foo=True)
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Have you considered any workarounds or alternative solutions?
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, links, or references that might help evaluate this request.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Summary
+
+<!-- What does this PR do? What problem does it solve? -->
+
+## Changes
+
+<!-- List the key changes made in this PR -->
+-
+-
+
+## Testing
+
+<!-- Describe how you tested your changes -->
+
+- [ ] New tests added for any new functionality (required — `make test` enforces 100% coverage)
+- [ ] All tests pass locally: `make test`
+- [ ] Linting passes: `make lint`
+- [ ] Type checking passes: `make typecheck`
+- [ ] Security scan passes: `make security`
+- [ ] Full check suite passes: `make all`
+
+## Related Issues
+
+<!-- Link to any related issues: "Fixes #123" or "Closes #456" -->
+
+## Notes for Reviewers
+
+<!-- Anything the reviewer should pay special attention to? -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,24 @@ jobs:
         with:
           file: coverage.lcov
 
+  security:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --python 3.12 --group lint
+
+      - name: Run Bandit security scanner
+        run: uv run bandit -r pydantic_deep -x tests -ll
+
   docs:
     name: Build Documentation
     runs-on: ubuntu-latest
@@ -109,7 +127,7 @@ jobs:
   all-checks:
     name: All Checks Passed
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test, docs]
+    needs: [lint, typecheck, security, test, docs]
     steps:
       - name: All checks passed
         run: echo "All CI checks passed successfully!"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.12] - 2026-04-13
+
+### Added
+
+- **Bandit security scanner** — [Bandit](https://bandit.readthedocs.io/) is now part of the development toolchain and CI pipeline. It runs on every commit via the new `security` job in GitHub Actions and is also available locally via `make security`. The scanner checks production code (`pydantic_deep/`) for common Python security vulnerabilities (CWE-listed issues). No medium- or high-severity findings block a merge.
+- **GitHub Issue Templates** — structured forms for bug reports and feature requests guide contributors to provide the right information. Blank issues are disabled; the config redirects security reports to `security@vstorm.co`.
+- **Pull Request Template** — a checklist-based PR template ensures contributors verify tests, linting, type checking, and the security scan before requesting review.
+
+### Fixed
+
+- **MD5 `usedforsecurity` flag (`StuckLoopDetection`)** — `hashlib.md5()` calls used for tool-call fingerprinting in `stuck_loop.py` now pass `usedforsecurity=False`, correctly signalling that the hash is used for deduplication (not cryptographic security). This resolves a Bandit B324 High-severity finding.
+
+### Changed
+
+- **CONTRIBUTING.md** — expanded with an explicit test policy (new functionality requires tests; 100 % coverage is enforced mechanically), a coding-standards reference table (Ruff, Pyright, MyPy, Bandit with `pyproject.toml` links), English-language requirement, API docs pointer, and a static-analysis section documenting all quality gates.
+- **`make all`** — now includes `make security` (Bandit scan) in addition to the existing format → lint → typecheck → testcov sequence.
+
 ## [0.3.11] - 2026-04-13
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,14 @@
 # Contributing to pydantic-deep
 
-Thanks for your interest in contributing!
+Thanks for your interest in contributing! Bug reports, enhancement proposals, and code contributions are all welcome. **All communication and contributions must be in English** so that maintainers and the wider community can review them effectively.
+
+## Getting Help / Reporting Issues
+
+- **Bug reports & feature requests** — [open a GitHub Issue](https://github.com/vstorm-co/pydantic-deepagents/issues)
+- **Security vulnerabilities** — email **security@vstorm.co** (do NOT use public Issues; see [SECURITY.md](SECURITY.md))
+- **Questions & discussion** — GitHub Issues are the primary discussion channel and are publicly searchable
+
+All issues and pull requests are archived publicly on GitHub and can be referenced by URL.
 
 ## Development Setup
 
@@ -10,59 +18,99 @@ cd pydantic-deepagents
 make install
 ```
 
+Prerequisites: [uv](https://github.com/astral-sh/uv) (Python package manager) and [pre-commit](https://pre-commit.com/).
+
 ## Running Tests
 
+The automated test suite uses [pytest](https://pytest.org/) and can be invoked in the standard way:
+
 ```bash
-make test        # Run tests with coverage
-make all         # Run lint + typecheck + test
+pytest                   # standard pytest invocation
+make test                # run tests with coverage report
+make all                 # lint + typecheck + security scan + test
 ```
 
-## Requirements
-
-All PRs must meet these requirements:
-
-- **100% test coverage** — no exceptions
-- **Pass Pyright** — `make typecheck`
-- **Pass MyPy** — `make typecheck-mypy`
-- **Pass Ruff** — `make lint`
-
-## Quick Commands
-
-| Command | Description |
-|---------|-------------|
-| `make install` | Install dependencies |
-| `make test` | Run tests with coverage |
-| `make lint` | Run Ruff linter |
-| `make typecheck` | Run Pyright |
-| `make typecheck-mypy` | Run MyPy |
-| `make all` | Run all checks |
-| `make docs-serve` | Serve docs locally |
-
-## Running Specific Tests
+Run specific tests:
 
 ```bash
-# Single test
+# Single test function
 uv run pytest tests/test_agent.py::test_function_name -v
 
-# Single file
+# Single test file
 uv run pytest tests/test_agent.py -v
 
 # With debug output
 uv run pytest tests/test_agent.py -v -s
 ```
 
-## Code Style
+## Coding Standards
 
-- We use [Ruff](https://github.com/astral-sh/ruff) for linting and formatting
-- Run `make lint` to check and `uv run ruff format .` to auto-format
-- Follow existing patterns in the codebase
+All code must conform to the standards defined in [`pyproject.toml`](pyproject.toml). The full configuration lives there; the key tools are:
+
+| Tool | Purpose | Run with |
+|------|---------|---------|
+| [Ruff](https://github.com/astral-sh/ruff) | Linting + formatting (E, F, I, UP, B, SIM, Q, C90 rules) | `make lint` |
+| [Pyright](https://github.com/microsoft/pyright) | Static type checking | `make typecheck` |
+| [MyPy](https://mypy.readthedocs.io/) | Strict static type checking | `make typecheck-mypy` |
+| [Bandit](https://bandit.readthedocs.io/) | Security-focused static analysis | `make security` |
+| [Codespell](https://github.com/codespell-project/codespell) | Spell checking | via `pre-commit` |
+
+All of these tools are FLOSS. The project can be built, tested, and checked using only free and open-source software.
+
+## Requirements for Acceptable Contributions
+
+All pull requests **must** satisfy the following before merging:
+
+- **100% test coverage** — no exceptions (`make test` enforces this via `coverage fail_under = 100`)
+- **Pass Pyright** — `make typecheck`
+- **Pass MyPy** — `make typecheck-mypy`
+- **Pass Ruff** — `make lint` (formatting + linting)
+- **Pass Bandit** — `make security` (no unresolved medium/high severity findings)
+- **Pass all CI checks** — the GitHub Actions pipeline must be green
+
+## Test Policy
+
+> **As major new functionality is added to the project, tests of that functionality MUST be added to the automated test suite.**
+
+This is enforced mechanically: `coverage fail_under = 100` in `pyproject.toml` means that untested code causes `make test` to fail. There are no exceptions. If you add a function, add a test. If you add a branch, test both sides.
+
+Use `# pragma: no cover` only for genuinely untestable code (e.g., platform-specific branches that cannot be reached in the test environment). Maintainers will ask for justification on every `pragma: no cover` annotation during review.
+
+## Quick Reference
+
+| Command | Description |
+|---------|-------------|
+| `make install` | Install dependencies + pre-commit hooks |
+| `make test` | Run tests with coverage |
+| `make lint` | Run Ruff (format + lint) |
+| `make typecheck` | Run Pyright |
+| `make typecheck-mypy` | Run MyPy |
+| `make security` | Run Bandit security scanner |
+| `make all` | Run all checks |
+| `make docs-serve` | Serve docs locally at http://localhost:8000 |
+
+## Static Analysis & Security
+
+We run multiple layers of static analysis on every commit and in CI:
+
+- **Ruff** — catches bugs, code style issues, and common anti-patterns
+- **Pyright / MyPy** — strict type checking eliminates entire categories of runtime errors
+- **Bandit** — security-focused scanner that checks for common Python security issues (e.g., unsafe subprocess usage, SQL injection patterns, insecure random number generation)
+
+Medium- and high-severity Bandit findings block merges. Any finding that is a false positive must be marked with a `# nosec` comment and a justification.
+
+## API Documentation
+
+The external interface of the library is documented in the [API Reference](https://vstorm-co.github.io/pydantic-deepagents/api/). When adding or changing public APIs, update the docstrings — the API reference is auto-generated from them via `mkdocstrings`.
 
 ## Pull Request Process
 
 1. Fork the repo and create your branch from `main`
-2. Make your changes
-3. Ensure `make all` passes
-4. Submit a PR with a clear description
+2. Make your changes, **including tests** for any new functionality
+3. Ensure `make all` passes locally before pushing
+4. Submit a PR with a clear description of what changed and why
+5. The PR title should follow the [Conventional Commits](https://www.conventionalcommits.org/) style (`feat:`, `fix:`, `docs:`, etc.)
+6. A maintainer will review and merge; PRs are typically reviewed within a few business days
 
 ## Questions?
 

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,10 @@ typecheck: typecheck-pyright ## Run static type checking
 .PHONY: typecheck-both
 typecheck-both: typecheck-pyright typecheck-mypy ## Run static type checking with both Pyright and Mypy
 
+.PHONY: security
+security: ## Run Bandit security scanner on production code
+	uv run bandit -r pydantic_deep -x tests -ll
+
 .PHONY: test
 test: ## Run tests and collect coverage data
 	@# To test using a specific version of python, run 'make install-all-python' then set environment variable PYTEST_PYTHON=3.10 or similar
@@ -78,7 +82,7 @@ docs-serve: ## Build and serve the documentation
 	uv run mkdocs serve
 
 .PHONY: all
-all: format lint typecheck testcov ## Run code formatting, linting, static type checks, and tests with coverage report generation
+all: format lint typecheck security testcov ## Run code formatting, linting, static type checks, security scan, and tests with coverage report generation
 
 .PHONY: help
 help: ## Show this help (usage: make help)

--- a/pydantic_deep/capabilities/stuck_loop.py
+++ b/pydantic_deep/capabilities/stuck_loop.py
@@ -56,7 +56,7 @@ def _hash_args(args: dict[str, Any]) -> str:
         serialized = json.dumps(args, sort_keys=True, default=str)
     except (TypeError, ValueError):  # pragma: no cover
         serialized = str(args)
-    return hashlib.md5(serialized.encode()).hexdigest()
+    return hashlib.md5(serialized.encode(), usedforsecurity=False).hexdigest()
 
 
 def _hash_result(result: Any) -> str:
@@ -68,7 +68,7 @@ def _hash_result(result: Any) -> str:
             serialized = json.dumps(result, sort_keys=True, default=str)
     except (TypeError, ValueError):  # pragma: no cover
         serialized = str(result)
-    return hashlib.md5(serialized.encode()).hexdigest()
+    return hashlib.md5(serialized.encode(), usedforsecurity=False).hexdigest()
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-deep"
-version = "0.3.11"
+version = "0.3.12"
 description = "Batteries-included agent harness for Python — tool-calling, sandboxed execution, multi-agent teams, and unlimited context on Pydantic AI"
 readme = "README.md"
 keywords = [
@@ -120,11 +120,13 @@ dev = [
     "build>=1.3.0",
     "twine>=6.2.0",
     "pre-commit>=4.5.1",
+    "griffe>=1.15.0",
 ]
 lint = [
     "ruff>=0.8.0",
     "pyright>=1.1.0",
     "mypy>=1.0.0",
+    "bandit>=1.8.0",
 ]
 docs = [
     "mkdocs>=1.6.0",


### PR DESCRIPTION
## [0.3.12] - 2026-04-13

### Added

- **Bandit security scanner** — [Bandit](https://bandit.readthedocs.io/) is now part of the development toolchain and CI pipeline. It runs on every commit via the new `security` job in GitHub Actions and is also available locally via `make security`. The scanner checks production code (`pydantic_deep/`) for common Python security vulnerabilities (CWE-listed issues). No medium- or high-severity findings block a merge.
- **GitHub Issue Templates** — structured forms for bug reports and feature requests guide contributors to provide the right information. Blank issues are disabled; the config redirects security reports to `security@vstorm.co`.
- **Pull Request Template** — a checklist-based PR template ensures contributors verify tests, linting, type checking, and the security scan before requesting review.

### Fixed

- **MD5 `usedforsecurity` flag (`StuckLoopDetection`)** — `hashlib.md5()` calls used for tool-call fingerprinting in `stuck_loop.py` now pass `usedforsecurity=False`, correctly signalling that the hash is used for deduplication (not cryptographic security). This resolves a Bandit B324 High-severity finding.

### Changed

- **CONTRIBUTING.md** — expanded with an explicit test policy (new functionality requires tests; 100 % coverage is enforced mechanically), a coding-standards reference table (Ruff, Pyright, MyPy, Bandit with `pyproject.toml` links), English-language requirement, API docs pointer, and a static-analysis section documenting all quality gates.
- **`make all`** — now includes `make security` (Bandit scan) in addition to the existing format → lint → typecheck → testcov sequence.
