### PR TITLE
feat: add liteparse toolset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.17] - 2026-04-22
+
+### Added
+
+- **`LiteparseToolset` — document parsing via [LiteParse](https://github.com/run-llama/liteparse)**
+  - New toolset at `pydantic_deep.toolsets.liteparse`
+  - Tools: `parse_document` (text extraction) and `screenshot_document` (per-page images)
+  - Reads files from any backend as bytes — works with `StateBackend`, `LocalBackend`, `DockerSandbox`
+  - Optional OCR via built-in Tesseract or pluggable HTTP server (PaddleOCR, EasyOCR)
+  - Lazy parser initialization — the Node.js CLI is found/installed on first tool call
+  - Configurable: `ocr_enabled`, `ocr_language`, `ocr_server_url`, `dpi`, `max_pages`
+  - Graceful error messages when the `liteparse` package or Node.js CLI is not installed
+  - Enabled via `include_liteparse=True` in `create_deep_agent()`
+
+- **`liteparse` optional extra in `pyproject.toml`**
+  - `pip install pydantic-deep[liteparse]` installs the Python wrapper
+  - Node.js >= 18 and `npm install -g @llamaindex/liteparse` are required separately
+
 ## [0.3.16] - 2026-04-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 
 ## What's New
 
+- **2026-04-22** &nbsp;**v0.3.17** — LiteParse document parsing toolset (`include_liteparse=True`). Parse PDFs, DOCX, XLSX and more locally with optional OCR.
 - **2026-04-22** &nbsp;**v0.3.16** — `instructions=` now replaces `BASE_PROMPT` directly. Use `f"{BASE_PROMPT}\n\n..."` to extend it. Subagents still get `BASE_PROMPT` automatically.
 - **2026-04-12** &nbsp;**v0.3.8** — Stuck loop detection, context limit warnings for the model, expanded context file discovery (CLAUDE.md, .cursorrules, etc.), eviction & orphan repair migrated to capabilities hooks.
 - **2026-04-11** &nbsp;**v0.3.6** — One-command installer + self-update: `curl -fsSL .../install.sh | bash` installs everything automatically. New `pydantic-deep update` command. Startup update notifications with 24-hour PyPI cache.
@@ -81,6 +82,10 @@ Pydantic Deep Agents is an **agent harness** — the complete infrastructure tha
 <tr>
 <td><b>📚 Skills system</b></td>
 <td>Domain-specific knowledge loaded on demand from SKILL.md files. Built-in skills: code-review, refactor, test-writer, git-workflow, and more.</td>
+</tr>
+<tr>
+<td><b>📄 Document parsing</b></td>
+<td>Parse PDFs, DOCX, XLSX, PPTX, and images with optional OCR via LiteParse. Runs locally — no cloud services required.</td>
 </tr>
 <tr>
 <td><b>🔌 MCP</b></td>
@@ -223,6 +228,7 @@ agent = create_deep_agent(
     include_memory=True,        # Persistent memory across sessions
     include_plan=True,          # Structured planning before execution
     include_teams=True,         # Agent teams with shared TODO lists + message bus
+    include_liteparse=True,     # Document parsing — PDF, DOCX, XLSX + OCR
     web_search=True,            # Tool-calling: web search
     web_fetch=True,             # Tool-calling: web fetch
     thinking="high",            # Extended thinking / reasoning effort

--- a/apps/cli/agent.py
+++ b/apps/cli/agent.py
@@ -85,6 +85,7 @@ def create_cli_agent(  # noqa: C901
     temperature: float | None = None,
     include_browser: bool | None = None,
     browser_headless: bool | None = None,
+    include_liteparse: bool | None = None,
 ) -> tuple[Any, DeepAgentDeps]:
     """Create a CLI-configured agent with all pydantic-deep capabilities.
 
@@ -256,6 +257,9 @@ def create_cli_agent(  # noqa: C901
     _browser = include_browser if include_browser is not None else config.include_browser
     effective_browser = _browser if not lean else False
 
+    _liteparse = include_liteparse if include_liteparse is not None else config.include_liteparse
+    effective_liteparse = _liteparse if not lean else False
+
     # Model settings — explicit param > model_settings dict > non-interactive > config
     effective_model_settings: dict[str, Any] = {}
     if non_interactive:
@@ -328,6 +332,8 @@ def create_cli_agent(  # noqa: C901
         context_discovery=_context_disc if not lean else False,
         # Teams
         include_teams=(include_teams if include_teams is not None else config.include_teams),
+        # Document parsing
+        include_liteparse=effective_liteparse,
         # Self-improvement
         include_improve=True,
         # Web tools — explicit params override config

--- a/apps/cli/config.py
+++ b/apps/cli/config.py
@@ -113,7 +113,9 @@ class CliConfig:
     browser_headless: bool = True
     """Run browser without a visible window. Default ``True`` — browser window is hidden."""
     include_liteparse: bool = True
-    """Enable document parsing via LiteParse (requires ``pydantic-deep[liteparse]`` and Node.js >= 18)."""
+    """Enable document parsing via LiteParse.
+
+    Requires ``pydantic-deep[liteparse]`` and Node.js >= 18."""
 
 
 def load_config(path: Path | None = None) -> CliConfig:

--- a/apps/cli/config.py
+++ b/apps/cli/config.py
@@ -63,6 +63,7 @@ _BOOL_FIELDS = frozenset(
         "logfire",
         "include_browser",
         "browser_headless",
+        "include_liteparse",
     }
 )
 
@@ -111,6 +112,8 @@ class CliConfig:
     """Enable browser automation via Playwright (requires ``pydantic-deep[browser]``)."""
     browser_headless: bool = True
     """Run browser without a visible window. Default ``True`` — browser window is hidden."""
+    include_liteparse: bool = True
+    """Enable document parsing via LiteParse (requires ``pydantic-deep[liteparse]`` and Node.js >= 18)."""
 
 
 def load_config(path: Path | None = None) -> CliConfig:

--- a/apps/cli/main.py
+++ b/apps/cli/main.py
@@ -269,6 +269,13 @@ def run(
             help="Browser window mode: headless (hidden) or headed (visible, default)",
         ),
     ] = None,
+    include_liteparse: Annotated[
+        bool | None,
+        typer.Option(
+            "--liteparse/--no-liteparse",
+            help="Enable LiteParse document parsing (requires pydantic-deep[liteparse] and Node.js)",
+        ),
+    ] = None,
 ) -> None:
     """Run a task non-interactively (headless mode).
 
@@ -337,6 +344,7 @@ def run(
             verbose=verbose,
             include_browser=include_browser,
             browser_headless=browser_headless,
+            include_liteparse=include_liteparse,
         )
     )
     raise typer.Exit(result)

--- a/apps/cli/main.py
+++ b/apps/cli/main.py
@@ -273,7 +273,7 @@ def run(
         bool | None,
         typer.Option(
             "--liteparse/--no-liteparse",
-            help="Enable LiteParse document parsing (requires pydantic-deep[liteparse] and Node.js)",
+            help="Enable LiteParse document parsing (requires pydantic-deep[liteparse] + Node.js)",
         ),
     ] = None,
 ) -> None:

--- a/apps/cli/run.py
+++ b/apps/cli/run.py
@@ -41,6 +41,7 @@ async def execute_headless(  # noqa: C901
     verbose: bool = False,
     include_browser: bool | None = None,
     browser_headless: bool | None = None,
+    include_liteparse: bool | None = None,
 ) -> int:
     """Execute a task in headless mode and print the result.
 
@@ -113,6 +114,8 @@ async def execute_headless(  # noqa: C901
         agent_kwargs["include_browser"] = include_browser
     if browser_headless is not None:
         agent_kwargs["browser_headless"] = browser_headless
+    if include_liteparse is not None:
+        agent_kwargs["include_liteparse"] = include_liteparse
 
     agent, deps = create_cli_agent(**agent_kwargs)
 

--- a/docs/advanced/liteparse.md
+++ b/docs/advanced/liteparse.md
@@ -1,0 +1,121 @@
+# Document Parsing (LiteParse)
+
+`LiteparseToolset` gives the agent the ability to extract text and generate page screenshots
+from PDFs, Word documents, spreadsheets, and other document formats — locally, with no cloud
+services required.
+
+Parsing is powered by [LiteParse](https://github.com/run-llama/liteparse), a Node.js library
+with optional OCR. The Python package wraps its CLI via subprocess.
+
+## Requirements
+
+- **Node.js >= 18** installed on the system
+- **LiteParse CLI**: `npm install -g @llamaindex/liteparse`
+- **Python extra**: `pip install pydantic-deep[liteparse]`
+
+The CLI is auto-installed via npm on first use if `npm` is in PATH (controlled by
+`install_if_not_available`, default `True`). For production/Docker deployments,
+pre-install the CLI in your `Dockerfile` instead.
+
+### Docker
+
+```dockerfile
+FROM python:3.12-slim
+
+# Install Node.js
+RUN apt-get update && apt-get install -y curl && \
+    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs
+
+# Pre-install LiteParse CLI
+RUN npm install -g @llamaindex/liteparse
+
+COPY . .
+RUN pip install pydantic-deep[liteparse]
+```
+
+## Quick Start
+
+Enable with `include_liteparse=True` in [`create_deep_agent`][pydantic_deep.agent.create_deep_agent]:
+
+```python
+from pydantic_deep import create_deep_agent, create_default_deps
+from pydantic_ai_backends import LocalBackend
+
+agent = create_deep_agent(
+    model="anthropic:claude-sonnet-4-6",
+    include_liteparse=True,
+)
+
+deps = create_default_deps(LocalBackend(root_dir="."))
+result = await agent.run("Parse report.pdf and summarize the key findings", deps=deps)
+```
+
+## Standalone Usage
+
+Use [`LiteparseToolset`][pydantic_deep.LiteparseToolset] directly for fine-grained control:
+
+```python
+from pydantic_ai import Agent
+from pydantic_deep import DeepAgentDeps
+from pydantic_deep.toolsets.liteparse import LiteparseToolset
+
+agent = Agent(
+    "anthropic:claude-sonnet-4-6",
+    deps_type=DeepAgentDeps,
+    toolsets=[
+        LiteparseToolset(
+            ocr_enabled=True,
+            ocr_language="en",
+            dpi=300,
+        )
+    ],
+)
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `parse_document` | Extract full text from a document (PDF, DOCX, XLSX, images, …) |
+| `screenshot_document` | Generate per-page PNG screenshots saved to the backend |
+
+## Configuration Options
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `ocr_enabled` | `True` | Enable OCR for scanned/image-based documents |
+| `ocr_language` | `"en"` | OCR language code (`"en"`, `"fr"`, `"de"`, …) |
+| `ocr_server_url` | `None` | HTTP OCR server URL. Uses built-in Tesseract when not set |
+| `dpi` | `150` | Rendering DPI — higher is better for OCR but slower |
+| `max_pages` | `10000` | Maximum pages to parse per document |
+| `install_if_not_available` | `True` | Auto-install CLI via npm on first use |
+| `descriptions` | `None` | Dict to override tool descriptions (`parse_document`, `screenshot_document`) |
+
+## Supported Formats
+
+- **PDF** — native text extraction + OCR for scanned pages
+- **Microsoft Office** — DOCX, XLSX, PPTX (requires LibreOffice on the system)
+- **OpenDocument** — ODT, ODS, ODP (requires LibreOffice)
+- **Images** — PNG, JPG, TIFF and more (requires ImageMagick)
+
+## Custom OCR Server
+
+Point to a PaddleOCR or EasyOCR server for higher accuracy:
+
+```python
+LiteparseToolset(
+    ocr_server_url="http://localhost:8828/ocr",
+    ocr_language="en",
+    dpi=200,
+)
+```
+
+See the [OCR server examples](https://github.com/run-llama/liteparse/tree/main/ocr)
+in the LiteParse repository for EasyOCR and PaddleOCR server implementations.
+
+## Notes
+
+- `parse_document` passes file contents as bytes to the CLI via stdin — no temp files written for PDFs.
+- `screenshot_document` writes the file to a temp directory, calls the CLI, then copies images to the backend.
+- Large documents may be slow on first call due to Node.js + PDF engine cold start. Subsequent calls within the same process reuse the parser instance.

--- a/install.sh
+++ b/install.sh
@@ -51,13 +51,38 @@ fi
 
 echo ""
 
-# ── Step 2: install pydantic-deep ─────────────────────────────────────────────
-say "Installing pydantic-deep CLI (with browser support)..."
-uv tool install "pydantic-deep[cli,browser]" --upgrade
+# ── Step 2: ask about optional features ──────────────────────────────────────
+echo ""
+printf "  ${BOLD}Optional features${RESET}\n"
+printf "  ─────────────────────────────\n"
+echo ""
+
+# LiteParse document parsing
+INSTALL_LITEPARSE=false
+printf "  Install document parsing support via ${BOLD}LiteParse${RESET}?\n"
+printf "  Parses PDFs, DOCX, XLSX and more — runs locally with optional OCR.\n"
+printf "  Requires ${BOLD}Node.js >= 18${RESET} on your system.\n"
+printf "  [Y/n] "
+read -r _lp_answer </dev/tty
+case "${_lp_answer:-Y}" in
+    [Yy]*) INSTALL_LITEPARSE=true ;;
+    *)     ok "Skipping LiteParse — enable later with: pydantic-deep run --liteparse" ;;
+esac
 
 echo ""
 
-# ── Step 3: install Chromium for browser automation ───────────────────────────
+# ── Step 3: install pydantic-deep ─────────────────────────────────────────────
+if $INSTALL_LITEPARSE; then
+    say "Installing pydantic-deep CLI (with browser and liteparse support)..."
+    uv tool install "pydantic-deep[cli,browser,liteparse]" --upgrade
+else
+    say "Installing pydantic-deep CLI (with browser support)..."
+    uv tool install "pydantic-deep[cli,browser]" --upgrade
+fi
+
+echo ""
+
+# ── Step 4: install Chromium for browser automation ───────────────────────────
 say "Installing Chromium for browser automation..."
 # uv tool executables land in ~/.local/bin — ensure it's in PATH
 export PATH="$HOME/.local/bin:$PATH"
@@ -71,7 +96,46 @@ fi
 
 echo ""
 
-# ── Step 4: verify ────────────────────────────────────────────────────────────
+# ── Step 5: install LiteParse CLI (Node.js) ───────────────────────────────────
+if $INSTALL_LITEPARSE; then
+    say "Setting up LiteParse document parsing..."
+
+    # Check for Node.js
+    if command -v node &>/dev/null; then
+        NODE_VERSION="$(node --version 2>/dev/null | sed 's/v//')"
+        NODE_MAJOR="$(echo "$NODE_VERSION" | cut -d. -f1)"
+        if [ "$NODE_MAJOR" -ge 18 ] 2>/dev/null; then
+            ok "Node.js ${NODE_VERSION} found."
+        else
+            warn "Node.js ${NODE_VERSION} is too old (need >= 18). Installing a newer version..."
+            if command -v nvm &>/dev/null; then
+                nvm install 20 && nvm use 20 || warn "nvm install failed — install Node.js 20 manually from https://nodejs.org/"
+            else
+                warn "Please install Node.js >= 18 from https://nodejs.org/ and re-run:"
+                warn "  npm install -g @llamaindex/liteparse"
+            fi
+        fi
+    else
+        warn "Node.js not found. Install Node.js >= 18 from https://nodejs.org/ and then run:"
+        warn "  npm install -g @llamaindex/liteparse"
+    fi
+
+    # Install the LiteParse CLI if npm is available and Node.js >= 18
+    if command -v npm &>/dev/null && command -v node &>/dev/null; then
+        NODE_MAJOR="$(node --version 2>/dev/null | sed 's/v//' | cut -d. -f1)"
+        if [ "${NODE_MAJOR:-0}" -ge 18 ] 2>/dev/null; then
+            if npm install -g @llamaindex/liteparse 2>/dev/null; then
+                ok "LiteParse CLI installed."
+            else
+                warn "LiteParse CLI install failed — run 'npm install -g @llamaindex/liteparse' manually."
+            fi
+        fi
+    fi
+
+    echo ""
+fi
+
+# ── Step 6: verify ────────────────────────────────────────────────────────────
 if command -v pydantic-deep &>/dev/null; then
     VERSION="$(pydantic-deep --version 2>&1 | head -1)"
     ok "${VERSION} installed successfully!"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,7 @@ plugins:
           - advanced/plan-mode.md: Plan mode subagent
           - advanced/web-tools.md: Web tools (built-in)
           - advanced/browser.md: Browser automation via Playwright
+          - advanced/liteparse.md: Document parsing (LiteParse)
           - advanced/mcp.md: MCP servers
           - advanced/acp.md: ACP editor integration (Zed)
           - advanced/multi-user.md: Multi-user isolation patterns
@@ -230,6 +231,7 @@ nav:
     - advanced/plan-mode.md
     - advanced/web-tools.md
     - advanced/browser.md
+    - advanced/liteparse.md
     - advanced/mcp.md
     - advanced/acp.md
     - advanced/multi-user.md

--- a/pydantic_deep/__init__.py
+++ b/pydantic_deep/__init__.py
@@ -136,6 +136,11 @@ from pydantic_deep.styles import (
 )
 from pydantic_deep.toolsets import SkillsToolset, SubAgentToolset, TodoToolset, create_plan_toolset
 from pydantic_deep.toolsets.browser import BrowserToolset
+from pydantic_deep.toolsets.liteparse import (
+    PARSE_DOCUMENT_DESCRIPTION,
+    SCREENSHOT_DOCUMENT_DESCRIPTION,
+    LiteparseToolset,
+)
 from pydantic_deep.toolsets.checkpointing import (
     Checkpoint,
     CheckpointMiddleware,
@@ -253,6 +258,9 @@ __all__ = [
     "CostTracking",
     # Toolsets
     "BrowserToolset",
+    "LiteparseToolset",
+    "PARSE_DOCUMENT_DESCRIPTION",
+    "SCREENSHOT_DOCUMENT_DESCRIPTION",
     "TodoToolset",
     "create_console_toolset",
     "get_console_system_prompt",

--- a/pydantic_deep/__init__.py
+++ b/pydantic_deep/__init__.py
@@ -136,11 +136,6 @@ from pydantic_deep.styles import (
 )
 from pydantic_deep.toolsets import SkillsToolset, SubAgentToolset, TodoToolset, create_plan_toolset
 from pydantic_deep.toolsets.browser import BrowserToolset
-from pydantic_deep.toolsets.liteparse import (
-    PARSE_DOCUMENT_DESCRIPTION,
-    SCREENSHOT_DOCUMENT_DESCRIPTION,
-    LiteparseToolset,
-)
 from pydantic_deep.toolsets.checkpointing import (
     Checkpoint,
     CheckpointMiddleware,
@@ -160,6 +155,11 @@ from pydantic_deep.toolsets.context import (
     discover_context_files,
     format_context_prompt,
     load_context_files,
+)
+from pydantic_deep.toolsets.liteparse import (
+    PARSE_DOCUMENT_DESCRIPTION,
+    SCREENSHOT_DOCUMENT_DESCRIPTION,
+    LiteparseToolset,
 )
 from pydantic_deep.toolsets.memory import (
     DEFAULT_MAX_MEMORY_LINES,

--- a/pydantic_deep/agent.py
+++ b/pydantic_deep/agent.py
@@ -117,6 +117,7 @@ def create_deep_agent(
     checkpoint_store: Any | None = None,
     include_teams: bool = False,
     include_improve: bool = False,
+    include_liteparse: bool = False,
     stuck_loop_detection: bool = True,
     web_search: bool = True,
     web_fetch: bool = True,
@@ -186,6 +187,7 @@ def create_deep_agent(
     checkpoint_store: Any | None = None,
     include_teams: bool = False,
     include_improve: bool = False,
+    include_liteparse: bool = False,
     stuck_loop_detection: bool = True,
     web_search: bool = True,
     web_fetch: bool = True,
@@ -253,6 +255,7 @@ def create_deep_agent(  # noqa: C901
     checkpoint_store: Any | None = None,
     include_teams: bool = False,
     include_improve: bool = False,
+    include_liteparse: bool = False,
     stuck_loop_detection: bool = True,
     web_search: bool = True,
     web_fetch: bool = True,
@@ -408,6 +411,12 @@ def create_deep_agent(  # noqa: C901
             When True, adds tools for spawning agent teams, assigning
             tasks via shared todo lists, messaging teammates, and
             dissolving teams. Defaults to False.
+        include_liteparse: Whether to include the LiteParse document parsing
+            toolset (``parse_document``, ``screenshot_document`` tools).
+            Requires Node.js >= 18 and the ``liteparse`` optional extra:
+            ``pip install pydantic-deep[liteparse]``.
+            The Node.js CLI is auto-installed via npm on first use if
+            ``npm`` is in PATH. Defaults to False.
         web_search: Whether to include the ``WebSearch`` capability.
             Defaults to True.
         web_fetch: Whether to include the ``WebFetch`` capability.
@@ -789,6 +798,13 @@ def create_deep_agent(  # noqa: C901
             model=model if isinstance(model, str) else "openrouter:anthropic/claude-sonnet-4",
         )
         all_toolsets.append(improve_toolset)
+
+    # LiteParse document parsing toolset
+    if include_liteparse:
+        from pydantic_deep.toolsets.liteparse import LiteparseToolset
+
+        liteparse_toolset = LiteparseToolset()
+        all_toolsets.append(liteparse_toolset)
 
     # Inject output style into instructions
     if output_style is not None:

--- a/pydantic_deep/toolsets/__init__.py
+++ b/pydantic_deep/toolsets/__init__.py
@@ -8,6 +8,7 @@ from pydantic_ai_backends import (
 from pydantic_ai_todo import create_todo_toolset as TodoToolset
 from subagents_pydantic_ai import SubAgentToolset
 
+from pydantic_deep.toolsets.liteparse import LiteparseToolset
 from pydantic_deep.toolsets.plan import create_plan_toolset
 from pydantic_deep.toolsets.skills import SkillsToolset
 from pydantic_deep.toolsets.teams import create_team_toolset
@@ -19,6 +20,7 @@ __all__ = [
     "ConsoleDeps",
     "SubAgentToolset",
     "SkillsToolset",
+    "LiteparseToolset",
     "create_plan_toolset",
     "create_team_toolset",
 ]

--- a/pydantic_deep/toolsets/liteparse.py
+++ b/pydantic_deep/toolsets/liteparse.py
@@ -1,0 +1,204 @@
+"""LiteParse document parsing toolset.
+
+Provides tools for parsing PDFs, DOCX, images and other documents using the
+LiteParse Node.js CLI via the ``liteparse`` Python package.
+
+Requirements:
+    - Node.js >= 18 installed on the system
+    - LiteParse CLI: ``npm install -g @llamaindex/liteparse``
+    - Python package: ``pip install pydantic-deep[liteparse]``
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from pydantic_ai import RunContext
+from pydantic_ai.toolsets import FunctionToolset
+
+_HAS_LITEPARSE = False
+
+try:
+    from liteparse import LiteParse as _LiteParse
+    from liteparse.types import CLINotFoundError as _CLINotFoundError
+
+    _HAS_LITEPARSE = True
+except ImportError:  # pragma: no cover
+
+    class _LiteParse:  # type: ignore[no-redef]
+        def __init__(self, **kwargs: Any) -> None: ...  # pragma: no cover
+
+    class _CLINotFoundError(Exception):  # type: ignore[no-redef]
+        pass  # pragma: no cover
+
+
+_NOT_INSTALLED_MSG = (
+    "LiteParse is not installed. "
+    "Run: pip install pydantic-deep[liteparse] "
+    "and npm install -g @llamaindex/liteparse"
+)
+
+PARSE_DOCUMENT_DESCRIPTION = """\
+Parse a document (PDF, DOCX, XLSX, PPTX, images, etc.) and extract its text content.
+
+Returns the full text of the document with spatial layout preserved. Supports OCR for
+scanned documents. Pass the path to the file in the backend filesystem.
+
+Supported formats: PDF, DOCX, XLSX, PPTX, PNG, JPG, TIFF, and more."""
+
+SCREENSHOT_DOCUMENT_DESCRIPTION = """\
+Generate page screenshots from a document (PDF or images).
+
+Saves screenshot images to the backend and returns a list of their paths. Useful for
+visual inspection or passing pages to a multimodal model.
+
+Args:
+    path: Path to the document in the backend filesystem.
+    output_dir: Backend directory to save screenshots (default: /screenshots).
+    target_pages: Pages to screenshot, e.g. "1-5" or "1,3,5". None means all pages."""
+
+
+class LiteparseToolset(FunctionToolset[Any]):
+    """Toolset for parsing documents with LiteParse.
+
+    Provides tools to extract text and generate screenshots from PDFs, DOCX, and other
+    document formats using the LiteParse Node.js CLI.
+
+    Requirements:
+        - Node.js >= 18 on the system
+        - LiteParse CLI (auto-installed via npm on first use if ``install_if_not_available=True``)
+        - ``pip install pydantic-deep[liteparse]``
+
+    Tools:
+        - ``parse_document``: Extract text content from a document
+        - ``screenshot_document``: Generate page screenshots saved to the backend
+    """
+
+    def __init__(
+        self,
+        *,
+        ocr_enabled: bool = True,
+        ocr_language: str = "en",
+        ocr_server_url: str | None = None,
+        dpi: int = 150,
+        max_pages: int = 10_000,
+        install_if_not_available: bool = True,
+        descriptions: dict[str, str] | None = None,
+    ) -> None:
+        """Initialize LiteparseToolset.
+
+        Args:
+            ocr_enabled: Enable OCR for scanned documents. Defaults to True.
+            ocr_language: OCR language code (e.g. "en", "fr", "de"). Defaults to "en".
+            ocr_server_url: URL of HTTP OCR server. Uses built-in Tesseract if not set.
+            dpi: Rendering DPI — higher gives better OCR quality but is slower. Defaults to 150.
+            max_pages: Maximum pages to parse per document. Defaults to 10,000.
+            install_if_not_available: Auto-install CLI via npm on first use. Defaults to True.
+            descriptions: Optional dict to override tool descriptions.
+                Keys: ``parse_document``, ``screenshot_document``.
+        """
+        super().__init__(id="deep-liteparse")
+        self._ocr_enabled = ocr_enabled
+        self._ocr_language = ocr_language
+        self._ocr_server_url = ocr_server_url
+        self._dpi = dpi
+        self._max_pages = max_pages
+        self._install_if_not_available = install_if_not_available
+        self._parser: Any = None
+
+        descs = descriptions or {}
+
+        @self.tool(description=descs.get("parse_document", PARSE_DOCUMENT_DESCRIPTION))
+        async def parse_document(ctx: RunContext[Any], path: str) -> str:
+            """Extract text content from a document.
+
+            Args:
+                path: Path to the document in the backend filesystem.
+            """
+            if not _HAS_LITEPARSE:
+                return _NOT_INSTALLED_MSG
+            backend = ctx.deps.backend
+            file_bytes: bytes | None = backend._read_bytes(path)
+            if not file_bytes:
+                return f"File not found: {path}"
+            try:
+                parser = self._get_parser()
+                result = await parser.parse_async(
+                    file_bytes,
+                    ocr_enabled=self._ocr_enabled,
+                    ocr_language=self._ocr_language,
+                    ocr_server_url=self._ocr_server_url,
+                    dpi=self._dpi,
+                    max_pages=self._max_pages,
+                )
+                return f"[{result.num_pages} page(s)]\n\n{result.text}"
+            except _CLINotFoundError as exc:
+                return f"LiteParse CLI not found: {exc}"
+            except Exception as exc:
+                return f"Parse error: {exc}"
+
+        @self.tool(description=descs.get("screenshot_document", SCREENSHOT_DOCUMENT_DESCRIPTION))
+        async def screenshot_document(
+            ctx: RunContext[Any],
+            path: str,
+            output_dir: str = "/screenshots",
+            target_pages: str | None = None,
+        ) -> str:
+            """Generate page screenshots from a document.
+
+            Args:
+                path: Path to the document in the backend filesystem.
+                output_dir: Backend directory where screenshots are saved.
+                target_pages: Pages to screenshot, e.g. "1-5" or "1,3,5". None for all.
+            """
+            if not _HAS_LITEPARSE:
+                return _NOT_INSTALLED_MSG
+            backend = ctx.deps.backend
+            file_bytes = backend._read_bytes(path)
+            if not file_bytes:
+                return f"File not found: {path}"
+            try:
+                parser = self._get_parser()
+                with tempfile.TemporaryDirectory(prefix="liteparse_ss_") as tmpdir:
+                    filename = Path(path).name
+                    tmp_input = Path(tmpdir) / filename
+                    tmp_input.write_bytes(file_bytes)
+
+                    ss_result = await parser.screenshot_async(
+                        tmp_input,
+                        output_dir=tmpdir,
+                        target_pages=target_pages,
+                        dpi=self._dpi,
+                        load_bytes=True,
+                    )
+
+                    if not ss_result.screenshots:
+                        return "No screenshots generated."
+
+                    saved: list[str] = []
+                    for screenshot in ss_result:
+                        if screenshot.image_bytes:
+                            out_path = (
+                                f"{output_dir.rstrip('/')}/page_{screenshot.page_num}.png"
+                            )
+                            backend.write(out_path, screenshot.image_bytes)
+                            saved.append(out_path)
+
+                    if not saved:
+                        return "No screenshots saved."
+
+                    return f"Generated {len(saved)} screenshot(s):\n" + "\n".join(saved)
+            except _CLINotFoundError as exc:
+                return f"LiteParse CLI not found: {exc}"
+            except Exception as exc:
+                return f"Screenshot error: {exc}"
+
+    def _get_parser(self) -> Any:
+        """Lazy-initialize the LiteParse parser instance."""
+        if self._parser is None:
+            self._parser = _LiteParse(
+                install_if_not_available=self._install_if_not_available
+            )
+        return self._parser

--- a/pydantic_deep/toolsets/liteparse.py
+++ b/pydantic_deep/toolsets/liteparse.py
@@ -198,3 +198,6 @@ class LiteparseToolset(FunctionToolset[Any]):
         if self._parser is None:
             self._parser = _LiteParse(install_if_not_available=self._install_if_not_available)
         return self._parser
+
+
+LiteparseCliNotFoundError = _CLINotFoundError

--- a/pydantic_deep/toolsets/liteparse.py
+++ b/pydantic_deep/toolsets/liteparse.py
@@ -180,9 +180,7 @@ class LiteparseToolset(FunctionToolset[Any]):
                     saved: list[str] = []
                     for screenshot in ss_result:
                         if screenshot.image_bytes:
-                            out_path = (
-                                f"{output_dir.rstrip('/')}/page_{screenshot.page_num}.png"
-                            )
+                            out_path = f"{output_dir.rstrip('/')}/page_{screenshot.page_num}.png"
                             backend.write(out_path, screenshot.image_bytes)
                             saved.append(out_path)
 
@@ -198,7 +196,5 @@ class LiteparseToolset(FunctionToolset[Any]):
     def _get_parser(self) -> Any:
         """Lazy-initialize the LiteParse parser instance."""
         if self._parser is None:
-            self._parser = _LiteParse(
-                install_if_not_available=self._install_if_not_available
-            )
+            self._parser = _LiteParse(install_if_not_available=self._install_if_not_available)
         return self._parser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-deep"
-version = "0.3.16"
+version = "0.3.17"
 description = "Batteries-included agent harness for Python — tool-calling, sandboxed execution, multi-agent teams, and unlimited context on Pydantic AI"
 readme = "README.md"
 keywords = [
@@ -85,13 +85,15 @@ browser = [
     "playwright>=1.40.0",
     "html2text>=2020.1",
 ]
+# Document parsing via LiteParse (requires Node.js >= 18)
+liteparse = ["liteparse>=0.1.0"]
 # ACP (Agent Client Protocol) support for editor integration
 acp = ["agent-client-protocol>=0.8.0"]
 # Logfire tracing support
 logfire = ["logfire>=4.0"]
 # All optional dependencies
 all = [
-    "pydantic-deep[sandbox,cli,web,yaml,acp,logfire,browser]",
+    "pydantic-deep[sandbox,cli,web,yaml,acp,logfire,browser,liteparse]",
 ]
 
 [project.urls]

--- a/tests/test_liteparse.py
+++ b/tests/test_liteparse.py
@@ -10,10 +10,11 @@ from pydantic_ai.models.test import TestModel
 from pydantic_ai.usage import RunUsage
 
 from pydantic_deep.toolsets.liteparse import (
+    _NOT_INSTALLED_MSG,
     PARSE_DOCUMENT_DESCRIPTION,
     SCREENSHOT_DOCUMENT_DESCRIPTION,
+    LiteparseCliNotFoundError,
     LiteparseToolset,
-    _NOT_INSTALLED_MSG,
 )
 
 TEST_MODEL = TestModel()
@@ -156,10 +157,8 @@ class TestParseDocument:
         backend._read_bytes.return_value = b"data"
         ctx = _ctx(backend)
 
-        from pydantic_deep.toolsets.liteparse import _CLINotFoundError
-
         mock_parser = MagicMock()
-        mock_parser.parse_async = AsyncMock(side_effect=_CLINotFoundError("CLI missing"))
+        mock_parser.parse_async = AsyncMock(side_effect=LiteparseCliNotFoundError("CLI missing"))
         ts._parser = mock_parser
 
         with patch("pydantic_deep.toolsets.liteparse._HAS_LITEPARSE", True):
@@ -316,10 +315,8 @@ class TestScreenshotDocument:
         backend._read_bytes.return_value = b"data"
         ctx = _ctx(backend)
 
-        from pydantic_deep.toolsets.liteparse import _CLINotFoundError
-
         mock_parser = MagicMock()
-        mock_parser.screenshot_async = AsyncMock(side_effect=_CLINotFoundError("no CLI"))
+        mock_parser.screenshot_async = AsyncMock(side_effect=LiteparseCliNotFoundError("no CLI"))
         ts._parser = mock_parser
 
         with patch("pydantic_deep.toolsets.liteparse._HAS_LITEPARSE", True):

--- a/tests/test_liteparse.py
+++ b/tests/test_liteparse.py
@@ -304,9 +304,7 @@ class TestScreenshotDocument:
         ts._parser = mock_parser
 
         with patch("pydantic_deep.toolsets.liteparse._HAS_LITEPARSE", True):
-            await ts.tools["screenshot_document"].function(
-                ctx, path="/doc.pdf", target_pages="1-3"
-            )
+            await ts.tools["screenshot_document"].function(ctx, path="/doc.pdf", target_pages="1-3")
 
         call_kwargs = mock_parser.screenshot_async.call_args.kwargs
         assert call_kwargs["target_pages"] == "1-3"

--- a/tests/test_liteparse.py
+++ b/tests/test_liteparse.py
@@ -1,0 +1,370 @@
+"""Tests for LiteparseToolset."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.usage import RunUsage
+
+from pydantic_deep.toolsets.liteparse import (
+    PARSE_DOCUMENT_DESCRIPTION,
+    SCREENSHOT_DOCUMENT_DESCRIPTION,
+    LiteparseToolset,
+    _NOT_INSTALLED_MSG,
+)
+
+TEST_MODEL = TestModel()
+
+
+def _ctx(backend: Any = None) -> Any:
+    from pydantic_ai import RunContext
+
+    deps = MagicMock()
+    deps.backend = backend or MagicMock()
+    return RunContext(deps=deps, model=TEST_MODEL, usage=RunUsage())
+
+
+# ── LiteparseToolset construction ─────────────────────────────────────────────
+
+
+class TestLiteparseToolsetInit:
+    def test_default_id(self) -> None:
+        ts = LiteparseToolset()
+        assert ts.id == "deep-liteparse"
+
+    def test_default_params(self) -> None:
+        ts = LiteparseToolset()
+        assert ts._ocr_enabled is True
+        assert ts._ocr_language == "en"
+        assert ts._ocr_server_url is None
+        assert ts._dpi == 150
+        assert ts._max_pages == 10_000
+        assert ts._install_if_not_available is True
+        assert ts._parser is None
+
+    def test_custom_params(self) -> None:
+        ts = LiteparseToolset(
+            ocr_enabled=False,
+            ocr_language="fr",
+            ocr_server_url="http://localhost:8828/ocr",
+            dpi=300,
+            max_pages=50,
+            install_if_not_available=False,
+        )
+        assert ts._ocr_enabled is False
+        assert ts._ocr_language == "fr"
+        assert ts._ocr_server_url == "http://localhost:8828/ocr"
+        assert ts._dpi == 300
+        assert ts._max_pages == 50
+        assert ts._install_if_not_available is False
+
+    def test_custom_descriptions(self) -> None:
+        custom = {"parse_document": "Custom parse desc", "screenshot_document": "Custom ss desc"}
+        ts = LiteparseToolset(descriptions=custom)
+        assert ts.tools["parse_document"].description == "Custom parse desc"
+        assert ts.tools["screenshot_document"].description == "Custom ss desc"
+
+    def test_default_descriptions(self) -> None:
+        ts = LiteparseToolset()
+        assert ts.tools["parse_document"].description == PARSE_DOCUMENT_DESCRIPTION
+        assert ts.tools["screenshot_document"].description == SCREENSHOT_DOCUMENT_DESCRIPTION
+
+    def test_tools_registered(self) -> None:
+        ts = LiteparseToolset()
+        assert "parse_document" in ts.tools
+        assert "screenshot_document" in ts.tools
+
+
+# ── _get_parser ───────────────────────────────────────────────────────────────
+
+
+class TestGetParser:
+    def test_lazy_init(self) -> None:
+        ts = LiteparseToolset()
+        mock_parser = MagicMock()
+        with patch("pydantic_deep.toolsets.liteparse._LiteParse", return_value=mock_parser):
+            parser = ts._get_parser()
+            assert parser is mock_parser
+            assert ts._parser is mock_parser
+
+    def test_reuses_existing(self) -> None:
+        ts = LiteparseToolset()
+        existing = MagicMock()
+        ts._parser = existing
+        assert ts._get_parser() is existing
+
+
+# ── parse_document ────────────────────────────────────────────────────────────
+
+
+class TestParseDocument:
+    @pytest.mark.asyncio
+    async def test_not_installed(self) -> None:
+        ts = LiteparseToolset()
+        ctx = _ctx()
+        with patch("pydantic_deep.toolsets.liteparse._HAS_LITEPARSE", False):
+            result = await ts.tools["parse_document"].function(ctx, path="/doc.pdf")
+        assert result == _NOT_INSTALLED_MSG
+
+    @pytest.mark.asyncio
+    async def test_file_not_found(self) -> None:
+        ts = LiteparseToolset()
+        backend = MagicMock()
+        backend._read_bytes.return_value = None
+        ctx = _ctx(backend)
+        with patch("pydantic_deep.toolsets.liteparse._HAS_LITEPARSE", True):
+            result = await ts.tools["parse_document"].function(ctx, path="/missing.pdf")
+        assert "File not found" in result
+        assert "/missing.pdf" in result
+
+    @pytest.mark.asyncio
+    async def test_success(self) -> None:
+        ts = LiteparseToolset()
+        backend = MagicMock()
+        backend._read_bytes.return_value = b"%PDF-1.4 fake content"
+        ctx = _ctx(backend)
+
+        mock_result = MagicMock()
+        mock_result.num_pages = 3
+        mock_result.text = "Hello world"
+
+        mock_parser = MagicMock()
+        mock_parser.parse_async = AsyncMock(return_value=mock_result)
+        ts._parser = mock_parser
+
+        with patch("pydantic_deep.toolsets.liteparse._HAS_LITEPARSE", True):
+            result = await ts.tools["parse_document"].function(ctx, path="/doc.pdf")
+
+        assert "[3 page(s)]" in result
+        assert "Hello world" in result
+        mock_parser.parse_async.assert_called_once_with(
+            b"%PDF-1.4 fake content",
+            ocr_enabled=True,
+            ocr_language="en",
+            ocr_server_url=None,
+            dpi=150,
+            max_pages=10_000,
+        )
+
+    @pytest.mark.asyncio
+    async def test_cli_not_found_error(self) -> None:
+        ts = LiteparseToolset()
+        backend = MagicMock()
+        backend._read_bytes.return_value = b"data"
+        ctx = _ctx(backend)
+
+        from pydantic_deep.toolsets.liteparse import _CLINotFoundError
+
+        mock_parser = MagicMock()
+        mock_parser.parse_async = AsyncMock(side_effect=_CLINotFoundError("CLI missing"))
+        ts._parser = mock_parser
+
+        with patch("pydantic_deep.toolsets.liteparse._HAS_LITEPARSE", True):
+            result = await ts.tools["parse_document"].function(ctx, path="/doc.pdf")
+
+        assert "LiteParse CLI not found" in result
+        assert "CLI missing" in result
+
+    @pytest.mark.asyncio
+    async def test_generic_exception(self) -> None:
+        ts = LiteparseToolset()
+        backend = MagicMock()
+        backend._read_bytes.return_value = b"data"
+        ctx = _ctx(backend)
+
+        mock_parser = MagicMock()
+        mock_parser.parse_async = AsyncMock(side_effect=RuntimeError("boom"))
+        ts._parser = mock_parser
+
+        with patch("pydantic_deep.toolsets.liteparse._HAS_LITEPARSE", True):
+            result = await ts.tools["parse_document"].function(ctx, path="/doc.pdf")
+
+        assert "Parse error" in result
+        assert "boom" in result
+
+
+# ── screenshot_document ───────────────────────────────────────────────────────
+
+
+class TestScreenshotDocument:
+    @pytest.mark.asyncio
+    async def test_not_installed(self) -> None:
+        ts = LiteparseToolset()
+        ctx = _ctx()
+        with patch("pydantic_deep.toolsets.liteparse._HAS_LITEPARSE", False):
+            result = await ts.tools["screenshot_document"].function(ctx, path="/doc.pdf")
+        assert result == _NOT_INSTALLED_MSG
+
+    @pytest.mark.asyncio
+    async def test_file_not_found(self) -> None:
+        ts = LiteparseToolset()
+        backend = MagicMock()
+        backend._read_bytes.return_value = None
+        ctx = _ctx(backend)
+        with patch("pydantic_deep.toolsets.liteparse._HAS_LITEPARSE", True):
+            result = await ts.tools["screenshot_document"].function(ctx, path="/missing.pdf")
+        assert "File not found" in result
+
+    @pytest.mark.asyncio
+    async def test_success(self) -> None:
+        ts = LiteparseToolset()
+        backend = MagicMock()
+        backend._read_bytes.return_value = b"pdfdata"
+        ctx = _ctx(backend)
+
+        shot1 = MagicMock()
+        shot1.page_num = 1
+        shot1.image_bytes = b"png1"
+        shot2 = MagicMock()
+        shot2.page_num = 2
+        shot2.image_bytes = b"png2"
+
+        ss_result = MagicMock()
+        ss_result.screenshots = [shot1, shot2]
+        ss_result.__iter__ = MagicMock(return_value=iter([shot1, shot2]))
+
+        mock_parser = MagicMock()
+        mock_parser.screenshot_async = AsyncMock(return_value=ss_result)
+        ts._parser = mock_parser
+
+        with patch("pydantic_deep.toolsets.liteparse._HAS_LITEPARSE", True):
+            result = await ts.tools["screenshot_document"].function(
+                ctx, path="/doc.pdf", output_dir="/screenshots"
+            )
+
+        assert "Generated 2 screenshot(s)" in result
+        assert "/screenshots/page_1.png" in result
+        assert "/screenshots/page_2.png" in result
+        backend.write.assert_any_call("/screenshots/page_1.png", b"png1")
+        backend.write.assert_any_call("/screenshots/page_2.png", b"png2")
+
+    @pytest.mark.asyncio
+    async def test_no_screenshots_generated(self) -> None:
+        ts = LiteparseToolset()
+        backend = MagicMock()
+        backend._read_bytes.return_value = b"pdfdata"
+        ctx = _ctx(backend)
+
+        ss_result = MagicMock()
+        ss_result.screenshots = []
+
+        mock_parser = MagicMock()
+        mock_parser.screenshot_async = AsyncMock(return_value=ss_result)
+        ts._parser = mock_parser
+
+        with patch("pydantic_deep.toolsets.liteparse._HAS_LITEPARSE", True):
+            result = await ts.tools["screenshot_document"].function(ctx, path="/doc.pdf")
+
+        assert result == "No screenshots generated."
+
+    @pytest.mark.asyncio
+    async def test_screenshots_without_bytes(self) -> None:
+        """Screenshots with no image_bytes are skipped."""
+        ts = LiteparseToolset()
+        backend = MagicMock()
+        backend._read_bytes.return_value = b"pdfdata"
+        ctx = _ctx(backend)
+
+        shot = MagicMock()
+        shot.page_num = 1
+        shot.image_bytes = None  # no bytes
+
+        ss_result = MagicMock()
+        ss_result.screenshots = [shot]
+        ss_result.__iter__ = MagicMock(return_value=iter([shot]))
+
+        mock_parser = MagicMock()
+        mock_parser.screenshot_async = AsyncMock(return_value=ss_result)
+        ts._parser = mock_parser
+
+        with patch("pydantic_deep.toolsets.liteparse._HAS_LITEPARSE", True):
+            result = await ts.tools["screenshot_document"].function(ctx, path="/doc.pdf")
+
+        assert result == "No screenshots saved."
+
+    @pytest.mark.asyncio
+    async def test_target_pages_forwarded(self) -> None:
+        ts = LiteparseToolset()
+        backend = MagicMock()
+        backend._read_bytes.return_value = b"pdfdata"
+        ctx = _ctx(backend)
+
+        shot = MagicMock()
+        shot.page_num = 1
+        shot.image_bytes = b"png"
+        ss_result = MagicMock()
+        ss_result.screenshots = [shot]
+        ss_result.__iter__ = MagicMock(return_value=iter([shot]))
+
+        mock_parser = MagicMock()
+        mock_parser.screenshot_async = AsyncMock(return_value=ss_result)
+        ts._parser = mock_parser
+
+        with patch("pydantic_deep.toolsets.liteparse._HAS_LITEPARSE", True):
+            await ts.tools["screenshot_document"].function(
+                ctx, path="/doc.pdf", target_pages="1-3"
+            )
+
+        call_kwargs = mock_parser.screenshot_async.call_args.kwargs
+        assert call_kwargs["target_pages"] == "1-3"
+
+    @pytest.mark.asyncio
+    async def test_cli_not_found_error(self) -> None:
+        ts = LiteparseToolset()
+        backend = MagicMock()
+        backend._read_bytes.return_value = b"data"
+        ctx = _ctx(backend)
+
+        from pydantic_deep.toolsets.liteparse import _CLINotFoundError
+
+        mock_parser = MagicMock()
+        mock_parser.screenshot_async = AsyncMock(side_effect=_CLINotFoundError("no CLI"))
+        ts._parser = mock_parser
+
+        with patch("pydantic_deep.toolsets.liteparse._HAS_LITEPARSE", True):
+            result = await ts.tools["screenshot_document"].function(ctx, path="/doc.pdf")
+
+        assert "LiteParse CLI not found" in result
+
+    @pytest.mark.asyncio
+    async def test_generic_exception(self) -> None:
+        ts = LiteparseToolset()
+        backend = MagicMock()
+        backend._read_bytes.return_value = b"data"
+        ctx = _ctx(backend)
+
+        mock_parser = MagicMock()
+        mock_parser.screenshot_async = AsyncMock(side_effect=OSError("disk full"))
+        ts._parser = mock_parser
+
+        with patch("pydantic_deep.toolsets.liteparse._HAS_LITEPARSE", True):
+            result = await ts.tools["screenshot_document"].function(ctx, path="/doc.pdf")
+
+        assert "Screenshot error" in result
+        assert "disk full" in result
+
+
+# ── create_deep_agent integration ─────────────────────────────────────────────
+
+
+class TestCreateDeepAgentLiteparse:
+    def test_include_liteparse_adds_toolset(self) -> None:
+        from pydantic_ai.models.test import TestModel as _TestModel
+
+        from pydantic_deep import create_deep_agent
+
+        agent = create_deep_agent(model=_TestModel(), include_liteparse=True)
+        toolset_ids = [ts.id for ts in agent._user_toolsets if hasattr(ts, "id")]
+        assert "deep-liteparse" in toolset_ids
+
+    def test_exclude_liteparse_default(self) -> None:
+        from pydantic_ai.models.test import TestModel as _TestModel
+
+        from pydantic_deep import create_deep_agent
+
+        agent = create_deep_agent(model=_TestModel())
+        toolset_ids = [ts.id for ts in agent._user_toolsets if hasattr(ts, "id")]
+        assert "deep-liteparse" not in toolset_ids


### PR DESCRIPTION
## [0.3.17] - 2026-04-22

### Added

- **`LiteparseToolset` — document parsing via [LiteParse](https://github.com/run-llama/liteparse)**
  - New toolset at `pydantic_deep.toolsets.liteparse`
  - Tools: `parse_document` (text extraction) and `screenshot_document` (per-page images)
  - Reads files from any backend as bytes — works with `StateBackend`, `LocalBackend`, `DockerSandbox`
  - Optional OCR via built-in Tesseract or pluggable HTTP server (PaddleOCR, EasyOCR)
  - Lazy parser initialization — the Node.js CLI is found/installed on first tool call
  - Configurable: `ocr_enabled`, `ocr_language`, `ocr_server_url`, `dpi`, `max_pages`
  - Graceful error messages when the `liteparse` package or Node.js CLI is not installed
  - Enabled via `include_liteparse=True` in `create_deep_agent()`

- **`liteparse` optional extra in `pyproject.toml`**
  - `pip install pydantic-deep[liteparse]` installs the Python wrapper
  - Node.js >= 18 and `npm install -g @llamaindex/liteparse` are required separately
