### PR TITLE
fix: add missing `checkpoint_store` field to DeepAgentDeps

### DIFF
--- a/pydantic_deep/deps.py
+++ b/pydantic_deep/deps.py
@@ -30,6 +30,8 @@ class DeepAgentDeps:
         files: In-memory file cache (used with StateBackend)
         todos: Task list for planning
         subagents: Pre-configured subagents available for delegation
+        checkpoint_store: Per-session checkpoint store (e.g. InMemoryCheckpointStore).
+            When set, overrides the global store passed to ``create_deep_agent()``.
     """
 
     backend: BackendProtocol = field(default_factory=StateBackend)
@@ -40,6 +42,7 @@ class DeepAgentDeps:
     ask_user: Any = field(default=None, repr=False)  # Callback for interactive questions
     context_middleware: Any = field(default=None, repr=False)  # ContextManagerCapability | None
     share_todos: bool = False  # When True, subagents share parent's todo list
+    checkpoint_store: Any = field(default=None, repr=False)  # Per-session CheckpointStore
 
     def __post_init__(self) -> None:
         """Initialize backend with files if using StateBackend."""
@@ -232,6 +235,7 @@ class DeepAgentDeps:
             uploads=self.uploads,  # Shared reference
             ask_user=self.ask_user,  # Propagate to subagents
             share_todos=self.share_todos,  # Propagate to subagents
+            checkpoint_store=self.checkpoint_store,  # Shared reference
         )
 
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -305,6 +305,28 @@ class TestDeepAgentDeps:
         assert cloned.todos == []
         assert cloned.subagents == {}
 
+    def test_checkpoint_store_default(self):
+        """checkpoint_store defaults to None."""
+        deps = DeepAgentDeps()
+        assert deps.checkpoint_store is None
+
+    def test_checkpoint_store_set(self):
+        """checkpoint_store can be passed to constructor."""
+        from pydantic_deep.toolsets.checkpointing import InMemoryCheckpointStore
+
+        store = InMemoryCheckpointStore()
+        deps = DeepAgentDeps(checkpoint_store=store)
+        assert deps.checkpoint_store is store
+
+    def test_clone_for_subagent_propagates_checkpoint_store(self):
+        """checkpoint_store is shared with subagent deps."""
+        from pydantic_deep.toolsets.checkpointing import InMemoryCheckpointStore
+
+        store = InMemoryCheckpointStore()
+        original = DeepAgentDeps(checkpoint_store=store)
+        cloned = original.clone_for_subagent()
+        assert cloned.checkpoint_store is store
+
     def test_upload_file(self):
         """Test uploading a file."""
         deps = DeepAgentDeps(backend=StateBackend())

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -596,7 +596,7 @@ class TestCheckpointToolset:
     def _make_ctx(self, store: InMemoryCheckpointStore | None = None) -> Any:
         """Create a mock RunContext."""
         deps = DeepAgentDeps()
-        deps.checkpoint_store = store  # type: ignore[attr-defined]
+        deps.checkpoint_store = store
         ctx = type("MockCtx", (), {"deps": deps})()
         return ctx
 
@@ -708,7 +708,7 @@ class TestResolveToolsetStore:
         """Returns store from ctx.deps."""
         store = InMemoryCheckpointStore()
         deps = DeepAgentDeps()
-        deps.checkpoint_store = store  # type: ignore[attr-defined]
+        deps.checkpoint_store = store
         ctx = type("MockCtx", (), {"deps": deps})()
         assert _resolve_toolset_store(ctx, None) is store
 


### PR DESCRIPTION
## Summary

`DeepAgentDeps` was missing the checkpoint_store field despite the documentation (checkpointing guide, multi-user guide, API reference) instructing users to pass it at construction time. 

The checkpointing middleware already uses `getattr(deps, "checkpoint_store", None)` to resolve per-session stores, but the field could never actually be set. This PR adds the missing field.

## Changes

- Added `checkpoint_store: Any = field(default=None, repr=False)` to `DeepAgentDeps` in `pydantic_deep/deps.py`                                                                                                                                 
- Updated `clone_for_subagent()` to propagate `checkpoint_store` to subagent deps (shared reference)
- Added 3 tests: default is `None`, constructor assignment works, subagent cloning propagates the store

## Testing

- [X] New tests added for any new functionality (required — `make test` enforces 100% coverage)
- [X] All tests pass locally: `make test`
- [X] Linting passes: `make lint`
- [X] Type checking passes: `make typecheck`
- [X] Security scan passes: `make security`
- [X] Full check suite passes: `make all`

## Related Issues

Fixes #87 

## Notes for Reviewers

N/A
