### PR TITLE
fix: binary content eviction

### DIFF
--- a/pydantic_deep/__init__.py
+++ b/pydantic_deep/__init__.py
@@ -110,7 +110,9 @@ from pydantic_deep.capabilities.hooks import (
 from pydantic_deep.deps import DEFAULT_USAGE_LIMITS as DEFAULT_USAGE_LIMITS
 from pydantic_deep.deps import DeepAgentDeps
 from pydantic_deep.processors.eviction import (
+    BINARY_PRUNED_TEMPLATE,
     DEFAULT_EVICTION_PATH,
+    DEFAULT_MAX_BINARY_CONTENT,
     DEFAULT_TOKEN_LIMIT,
     EVICTION_MESSAGE_TEMPLATE,
     NUM_CHARS_PER_TOKEN,
@@ -317,7 +319,9 @@ __all__ = [
     "NUM_CHARS_PER_TOKEN",
     "DEFAULT_TOKEN_LIMIT",
     "DEFAULT_EVICTION_PATH",
+    "DEFAULT_MAX_BINARY_CONTENT",
     "EVICTION_MESSAGE_TEMPLATE",
+    "BINARY_PRUNED_TEMPLATE",
     # Processors (from summarization-pydantic-ai)
     "SummarizationProcessor",
     "SlidingWindowProcessor",

--- a/pydantic_deep/agent.py
+++ b/pydantic_deep/agent.py
@@ -97,6 +97,7 @@ def create_deep_agent(
     output_type: None = None,
     history_processors: Sequence[HistoryProcessor[DeepAgentDeps]] | None = None,
     eviction_token_limit: int | None = 20_000,
+    max_binary_content: int | None = 3,
     edit_format: str = "hashline",
     context_manager: bool = True,
     context_manager_max_tokens: int | None = None,
@@ -167,6 +168,7 @@ def create_deep_agent(
     output_type: OutputSpec[OutputDataT],
     history_processors: Sequence[HistoryProcessor[DeepAgentDeps]] | None = None,
     eviction_token_limit: int | None = 20_000,
+    max_binary_content: int | None = 3,
     edit_format: str = "hashline",
     context_manager: bool = True,
     context_manager_max_tokens: int | None = None,
@@ -235,6 +237,7 @@ def create_deep_agent(  # noqa: C901
     output_type: OutputSpec[OutputDataT] | None = None,
     history_processors: Sequence[HistoryProcessor[DeepAgentDeps]] | None = None,
     eviction_token_limit: int | None = 20_000,
+    max_binary_content: int | None = 3,
     edit_format: str = "hashline",
     context_manager: bool = True,
     context_manager_max_tokens: int | None = None,
@@ -332,6 +335,13 @@ def create_deep_agent(  # noqa: C901
             Tool outputs exceeding this limit are saved to files and
             replaced with a preview + file reference. Defaults to 20,000.
             Set to None to disable eviction.
+        max_binary_content: Maximum number of multimodal binary parts
+            (e.g. ``BinaryContent`` screenshots) to keep in model-visible
+            history. Older binaries are written to the backend and replaced
+            with a compact ``read_file``-able text reference so the agent can
+            still retrieve them on demand. Defaults to 3. Set to ``None`` to
+            keep every binary in history. Only applies when
+            ``eviction_token_limit`` is set.
         context_manager: Whether to enable the ContextManagerMiddleware for
             automatic token tracking and auto-compression. When True (default),
             the middleware monitors token usage and triggers LLM-based
@@ -844,6 +854,7 @@ def create_deep_agent(  # noqa: C901
     # Previously this was a history processor; now it uses after_tool_execute
     # to intercept large outputs before they enter message history.
     _eviction_token_limit = eviction_token_limit
+    _max_binary_content = max_binary_content
     _on_eviction = on_eviction
 
     # Resolve history_messages_path to absolute for the middleware
@@ -937,6 +948,7 @@ def create_deep_agent(  # noqa: C901
             EvictionCapability(
                 backend=backend,
                 token_limit=_eviction_token_limit,
+                max_binary_content=_max_binary_content,
                 on_eviction=_on_eviction,
             )
         )

--- a/pydantic_deep/processors/eviction.py
+++ b/pydantic_deep/processors/eviction.py
@@ -16,11 +16,18 @@ from __future__ import annotations
 import inspect
 import json
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
-from pydantic_ai.messages import ModelMessage, ModelRequest, ToolReturnPart
+from pydantic_ai.messages import (
+    BinaryContent,
+    ModelMessage,
+    ModelRequest,
+    ToolReturn,
+    ToolReturnPart,
+    UserPromptPart,
+)
 from pydantic_ai.tools import RunContext
 from pydantic_ai_backends import BackendProtocol
 
@@ -42,6 +49,9 @@ DEFAULT_HEAD_LINES = 5
 DEFAULT_TAIL_LINES = 5
 """Default number of lines to show from the end of content in preview."""
 
+DEFAULT_MAX_BINARY_CONTENT = 3
+"""Default maximum number of multimodal binary parts to keep in history."""
+
 EVICTION_MESSAGE_TEMPLATE = """Tool result too large, saved to: {file_path}
 
 Read the result using read_file with offset and limit parameters.
@@ -52,6 +62,68 @@ Preview (head/tail):
 {content_sample}
 """
 """Template for the replacement message after eviction."""
+
+BINARY_PRUNED_TEMPLATE = (
+    "[Binary content omitted: {media_type}, {size} bytes, "
+    'saved to {file_path}. Use read_file(path="{file_path}") to retrieve.]'
+)
+"""Template for the text replacement of a pruned ``BinaryContent`` part."""
+
+_MEDIA_TYPE_EXTENSIONS: dict[str, str] = {
+    "image/jpeg": "jpg",
+    "image/jpg": "jpg",
+    "image/png": "png",
+    "image/gif": "gif",
+    "image/webp": "webp",
+    "image/svg+xml": "svg",
+    "image/bmp": "bmp",
+    "image/tiff": "tiff",
+    "audio/mpeg": "mp3",
+    "audio/wav": "wav",
+    "audio/flac": "flac",
+    "audio/ogg": "ogg",
+    "audio/aac": "aac",
+    "video/mp4": "mp4",
+    "video/webm": "webm",
+    "video/quicktime": "mov",
+    "application/pdf": "pdf",
+    "application/json": "json",
+    "text/plain": "txt",
+    "text/csv": "csv",
+    "text/markdown": "md",
+    "text/html": "html",
+}
+"""Mapping of common media types to file extensions used when storing pruned binaries."""
+
+
+def _extension_for_media_type(media_type: str) -> str:
+    """Return a filename extension for ``media_type``.
+
+    Falls back to the media subtype (e.g. ``"image/x-foo"`` -> ``"x-foo"``)
+    or ``"bin"`` when the media type cannot be split.
+    """
+    if media_type in _MEDIA_TYPE_EXTENSIONS:
+        return _MEDIA_TYPE_EXTENSIONS[media_type]
+    if "/" in media_type:
+        subtype = media_type.split("/", 1)[1].split(";", 1)[0].strip()
+        if subtype:
+            return re.sub(r"[^a-zA-Z0-9_-]", "_", subtype) or "bin"
+    return "bin"
+
+
+def _binary_storage_path(eviction_path: str, binary: BinaryContent) -> str:
+    """Build a deterministic storage path for a ``BinaryContent`` value."""
+    extension = _extension_for_media_type(binary.media_type)
+    return f"{eviction_path.rstrip('/')}/binary_{binary.identifier}.{extension}"
+
+
+def _binary_replacement_text(binary: BinaryContent, file_path: str) -> str:
+    """Return the text placeholder used to replace a pruned binary part."""
+    return BINARY_PRUNED_TEMPLATE.format(
+        media_type=binary.media_type,
+        size=len(binary.data),
+        file_path=file_path,
+    )
 
 
 def create_content_preview(content: str, *, head_lines: int = 5, tail_lines: int = 5) -> str:
@@ -355,12 +427,24 @@ class EvictionCapability(AbstractCapability[Any]):
     The evicted content is saved to a file via the backend, and the tool result
     is replaced with a compact preview + file reference.
 
+    For tool results that are :class:`pydantic_ai.messages.ToolReturn` values,
+    only the ``return_value`` is considered for size-based eviction; multimodal
+    ``content`` (such as :class:`BinaryContent` screenshots) is preserved.
+
+    Multimodal binary parts that accumulate across messages are bounded by
+    ``max_binary_content`` via :meth:`before_model_request`. Older binaries are
+    written to the backend and replaced with a compact retrievable text
+    reference, so the agent can still re-read them via ``read_file``.
+
     Args:
         backend: Fallback backend for writing evicted files.
         token_limit: Maximum estimated tokens before eviction (default: 20K).
         eviction_path: Directory in the backend for evicted files.
         head_lines: Lines from start in preview.
         tail_lines: Lines from end in preview.
+        max_binary_content: Maximum multimodal binary parts to keep in
+            history. Older binaries are persisted to the backend and replaced
+            with a text reference. ``None`` disables binary pruning.
         on_eviction: Optional callback ``(tool_name, file_path, original_chars, preview_chars)``.
     """
 
@@ -369,6 +453,7 @@ class EvictionCapability(AbstractCapability[Any]):
     eviction_path: str = DEFAULT_EVICTION_PATH
     head_lines: int = DEFAULT_HEAD_LINES
     tail_lines: int = DEFAULT_TAIL_LINES
+    max_binary_content: int | None = DEFAULT_MAX_BINARY_CONTENT
     on_eviction: Callable[[str, str, int, int], Any] | None = None
 
     def _resolve_backend(self, ctx: RunContext[Any]) -> BackendProtocol | None:
@@ -387,23 +472,55 @@ class EvictionCapability(AbstractCapability[Any]):
         args: dict[str, Any],
         result: Any,
     ) -> Any:
-        """Intercept large tool results before they enter message history."""
-        content_str = _content_to_str(result)
+        """Intercept large tool results before they enter message history.
+
+        ``ToolReturn`` results are handled specially: only ``return_value`` is
+        considered for size-based text eviction so multimodal ``content`` (e.g.
+        :class:`BinaryContent` screenshots) is never collapsed into a string.
+        """
+        if isinstance(result, ToolReturn):
+            evicted_value = await self._maybe_evict_text(ctx, call=call, value=result.return_value)
+            if evicted_value is None:
+                return result
+            return ToolReturn(
+                return_value=evicted_value,
+                content=result.content,
+                metadata=result.metadata,
+            )
+
+        evicted = await self._maybe_evict_text(ctx, call=call, value=result)
+        if evicted is None:
+            return result
+        return evicted
+
+    async def _maybe_evict_text(
+        self,
+        ctx: RunContext[Any],
+        *,
+        call: ToolCallPart,
+        value: Any,
+    ) -> str | None:
+        """Apply text eviction to ``value``.
+
+        Returns the replacement text when eviction occurred or ``None`` when
+        the value is below the threshold or eviction could not be performed.
+        """
+        content_str = _content_to_str(value)
         char_limit = self.token_limit * NUM_CHARS_PER_TOKEN
 
         if len(content_str) <= char_limit:
-            return result
+            return None
 
         backend = self._resolve_backend(ctx)
         if backend is None:
-            return result
+            return None
 
         sanitized_id = _sanitize_id(call.tool_call_id)
         file_path = f"{self.eviction_path}/{sanitized_id}"
         write_result = backend.write(file_path, content_str)
 
         if write_result.error:
-            return result  # Keep original on write failure
+            return None
 
         preview = create_content_preview(
             content_str,
@@ -423,3 +540,205 @@ class EvictionCapability(AbstractCapability[Any]):
                 await _cb_result
 
         return replacement
+
+    async def before_model_request(
+        self,
+        ctx: RunContext[Any],
+        request_context: Any,
+    ) -> Any:
+        """Bound the number of multimodal binary parts in message history.
+
+        Walks ``request_context.messages`` newest-to-oldest and keeps the most
+        recent ``max_binary_content`` :class:`BinaryContent` parts. Older
+        binaries are written to the runtime backend and replaced with a
+        compact text reference so the agent can still retrieve them via
+        ``read_file``. Binaries are left untouched when no backend is
+        available or when a write fails, to avoid losing data.
+        """
+        limit = self.max_binary_content
+        if limit is None or limit < 0:
+            return request_context
+
+        backend = self._resolve_backend(ctx)
+        if backend is None:
+            return request_context
+
+        request_context.messages = _prune_binaries_in_messages(
+            request_context.messages,
+            max_binary_content=limit,
+            backend=backend,
+            eviction_path=self.eviction_path,
+        )
+        return request_context
+
+
+def _prune_binaries_in_messages(
+    messages: list[ModelMessage],
+    *,
+    max_binary_content: int,
+    backend: BackendProtocol,
+    eviction_path: str,
+) -> list[ModelMessage]:
+    """Return ``messages`` with older binary parts pruned and stored in ``backend``."""
+    kept = 0
+    new_messages: list[ModelMessage] = list(messages)
+
+    for msg_idx in range(len(new_messages) - 1, -1, -1):
+        message = new_messages[msg_idx]
+        if not isinstance(message, ModelRequest):
+            continue
+
+        new_parts = list(message.parts)
+        modified = False
+
+        for part_idx in range(len(new_parts) - 1, -1, -1):
+            part = new_parts[part_idx]
+
+            if isinstance(part, UserPromptPart):
+                new_content, kept, part_modified = _prune_user_content(
+                    part.content,
+                    kept=kept,
+                    max_binary_content=max_binary_content,
+                    backend=backend,
+                    eviction_path=eviction_path,
+                )
+                if part_modified:
+                    new_parts[part_idx] = UserPromptPart(
+                        content=new_content,
+                        timestamp=part.timestamp,
+                    )
+                    modified = True
+
+            elif isinstance(part, ToolReturnPart):
+                new_content, kept, part_modified = _prune_tool_return_content(
+                    part.content,
+                    kept=kept,
+                    max_binary_content=max_binary_content,
+                    backend=backend,
+                    eviction_path=eviction_path,
+                )
+                if part_modified:
+                    new_parts[part_idx] = ToolReturnPart(
+                        tool_name=part.tool_name,
+                        content=new_content,
+                        tool_call_id=part.tool_call_id,
+                        metadata=part.metadata,
+                        timestamp=part.timestamp,
+                    )
+                    modified = True
+
+        if modified:
+            new_messages[msg_idx] = ModelRequest(
+                parts=new_parts,
+                timestamp=message.timestamp,
+                instructions=message.instructions,
+            )
+
+    return new_messages
+
+
+def _prune_user_content(
+    content: str | Sequence[Any],
+    *,
+    kept: int,
+    max_binary_content: int,
+    backend: BackendProtocol,
+    eviction_path: str,
+) -> tuple[str | list[Any], int, bool]:
+    """Prune binaries from a ``UserPromptPart.content`` value.
+
+    Walks the list right-to-left so the most recent binaries (later in the
+    list) are kept. Returns the rebuilt content, updated ``kept`` count, and a
+    flag indicating whether any pruning occurred.
+    """
+    if isinstance(content, str):
+        return content, kept, False
+
+    items = list(content)
+    modified = False
+
+    for i in range(len(items) - 1, -1, -1):
+        item = items[i]
+        if not isinstance(item, BinaryContent):
+            continue
+        if kept < max_binary_content:
+            kept += 1
+            continue
+        replacement = _store_and_replace_binary(item, backend=backend, eviction_path=eviction_path)
+        if replacement is None:
+            kept += 1
+            continue
+        items[i] = replacement
+        modified = True
+
+    return items, kept, modified
+
+
+def _prune_tool_return_content(
+    content: Any,
+    *,
+    kept: int,
+    max_binary_content: int,
+    backend: BackendProtocol,
+    eviction_path: str,
+) -> tuple[Any, int, bool]:
+    """Prune binaries from a ``ToolReturnPart.content`` value.
+
+    Handles three shapes:
+
+    - A bare :class:`BinaryContent` value (replaced with text when pruned).
+    - A list/tuple containing :class:`BinaryContent` items (walked
+      right-to-left so the most recent binaries are kept).
+    - Any other value (returned unchanged).
+    """
+    if isinstance(content, BinaryContent):
+        if kept < max_binary_content:
+            return content, kept + 1, False
+        replacement = _store_and_replace_binary(
+            content, backend=backend, eviction_path=eviction_path
+        )
+        if replacement is None:
+            return content, kept + 1, False
+        return replacement, kept, True
+
+    if isinstance(content, (list, tuple)):
+        items = list(content)
+        modified = False
+
+        for i in range(len(items) - 1, -1, -1):
+            item = items[i]
+            if not isinstance(item, BinaryContent):
+                continue
+            if kept < max_binary_content:
+                kept += 1
+                continue
+            replacement = _store_and_replace_binary(
+                item, backend=backend, eviction_path=eviction_path
+            )
+            if replacement is None:
+                kept += 1
+                continue
+            items[i] = replacement
+            modified = True
+
+        return items, kept, modified
+
+    return content, kept, False
+
+
+def _store_and_replace_binary(
+    binary: BinaryContent,
+    *,
+    backend: BackendProtocol,
+    eviction_path: str,
+) -> str | None:
+    """Persist ``binary`` to the backend and return a text replacement.
+
+    Returns ``None`` when the write fails, signalling that the caller should
+    keep the original binary in place.
+    """
+    file_path = _binary_storage_path(eviction_path, binary)
+    write_result = backend.write(file_path, binary.data)
+    if write_result.error:
+        return None
+    return _binary_replacement_text(binary, file_path)

--- a/tests/test_eviction.py
+++ b/tests/test_eviction.py
@@ -1311,9 +1311,7 @@ class TestBinaryContentRetention:
             count = 0
             for part in msg.parts:
                 if isinstance(part, UserPromptPart):
-                    items = (
-                        part.content if isinstance(part.content, list) else [part.content]
-                    )
+                    items = part.content if isinstance(part.content, list) else [part.content]
                     count += sum(1 for x in items if isinstance(x, BinaryContent))
             return count
 
@@ -1409,9 +1407,7 @@ class TestBinaryContentRetention:
 
         assert isinstance(old_part.content, list)
         assert not any(isinstance(x, BinaryContent) for x in old_part.content)
-        assert any(
-            isinstance(x, str) and "Binary content omitted" in x for x in old_part.content
-        )
+        assert any(isinstance(x, str) and "Binary content omitted" in x for x in old_part.content)
 
         assert isinstance(new_part.content, list)
         assert any(isinstance(x, BinaryContent) for x in new_part.content)

--- a/tests/test_eviction.py
+++ b/tests/test_eviction.py
@@ -1128,3 +1128,682 @@ class TestEvictionCapability:
         from pydantic_deep import EvictionCapability as Imported
 
         assert Imported is EvictionCapability
+
+
+# ---------------------------------------------------------------------------
+# ToolReturn preservation (after_tool_execute)
+# ---------------------------------------------------------------------------
+
+
+class TestEvictionCapabilityToolReturn:
+    """Tests for ``EvictionCapability`` handling of ``ToolReturn`` results."""
+
+    @pytest.mark.anyio
+    async def test_toolreturn_preserves_binary_content(self):
+        """ToolReturn with BinaryContent in `content` is not collapsed by text eviction."""
+        from pydantic_ai.messages import BinaryContent, ToolReturn
+
+        backend = StateBackend()
+        cap = EvictionCapability(backend=backend, token_limit=10)
+        ctx = _make_ctx(backend)
+
+        screenshot = BinaryContent(data=b"\xff\xd8" + b"x" * 1024, media_type="image/jpeg")
+        original = ToolReturn(
+            return_value="Page screenshot at https://example.com",
+            content=["Page screenshot at https://example.com", screenshot],
+        )
+
+        result = await cap.after_tool_execute(
+            ctx,
+            call=_cap_call(call_id="call_screenshot"),
+            tool_def=_cap_td(),
+            args={},
+            result=original,
+        )
+
+        assert isinstance(result, ToolReturn)
+        # return_value is small so it stays unchanged
+        assert result.return_value == original.return_value
+        # content (with the BinaryContent) is preserved as-is
+        assert result.content == original.content
+        # Backend was not asked to store anything (no eviction)
+        assert backend._read_bytes("/large_tool_results/call_screenshot") in (None, b"")
+
+    @pytest.mark.anyio
+    async def test_toolreturn_evicts_only_return_value(self):
+        """Large ToolReturn.return_value is evicted but content is preserved."""
+        from pydantic_ai.messages import BinaryContent, ToolReturn
+
+        backend = StateBackend()
+        cap = EvictionCapability(backend=backend, token_limit=10)  # 40 chars
+        ctx = _make_ctx(backend)
+
+        large_text = _make_large_content(20)
+        screenshot = BinaryContent(data=b"image-bytes", media_type="image/png")
+        original = ToolReturn(
+            return_value=large_text,
+            content=["caption", screenshot],
+            metadata={"trace_id": "abc"},
+        )
+
+        result = await cap.after_tool_execute(
+            ctx,
+            call=_cap_call(call_id="call_big_tr"),
+            tool_def=_cap_td(),
+            args={},
+            result=original,
+        )
+
+        assert isinstance(result, ToolReturn)
+        assert isinstance(result.return_value, str)
+        assert "Tool result too large" in result.return_value
+        assert "/large_tool_results/call_big_tr" in result.return_value
+        # content (with the BinaryContent) is preserved as-is
+        assert result.content == original.content
+        # metadata is preserved
+        assert result.metadata == {"trace_id": "abc"}
+        # The text value was actually written to the backend
+        assert backend._read_bytes("/large_tool_results/call_big_tr") == large_text.encode()
+
+    @pytest.mark.anyio
+    async def test_toolreturn_small_passes_through(self):
+        """Small ToolReturn passes through unchanged (same instance)."""
+        from pydantic_ai.messages import BinaryContent, ToolReturn
+
+        backend = StateBackend()
+        cap = EvictionCapability(backend=backend, token_limit=1000)
+        ctx = _make_ctx(backend)
+
+        screenshot = BinaryContent(data=b"x" * 32, media_type="image/jpeg")
+        original = ToolReturn(return_value="ok", content=["caption", screenshot])
+
+        result = await cap.after_tool_execute(
+            ctx,
+            call=_cap_call(call_id="call_small_tr"),
+            tool_def=_cap_td(),
+            args={},
+            result=original,
+        )
+
+        assert result is original
+
+
+# ---------------------------------------------------------------------------
+# Binary content retention (before_model_request)
+# ---------------------------------------------------------------------------
+
+
+class _FakeRequestContext:
+    """Minimal stand-in for ``ModelRequestContext`` used in tests."""
+
+    def __init__(self, messages: list[ModelMessage]) -> None:
+        self.messages = messages
+
+
+def _user_with_image(
+    image_bytes: bytes,
+    media_type: str = "image/jpeg",
+    text: str = "image",
+    timestamp: datetime | None = None,
+) -> ModelRequest:
+    from pydantic_ai.messages import BinaryContent
+
+    return ModelRequest(
+        parts=[
+            UserPromptPart(
+                content=[text, BinaryContent(data=image_bytes, media_type=media_type)],
+                timestamp=timestamp or datetime(2024, 1, 1, tzinfo=timezone.utc),
+            )
+        ],
+        timestamp=timestamp or datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def _toolreturn_with_image(
+    image_bytes: bytes,
+    *,
+    media_type: str = "image/jpeg",
+    text: str = "Page screenshot",
+    tool_call_id: str = "call_img",
+) -> ModelRequest:
+    from pydantic_ai.messages import BinaryContent
+
+    return ModelRequest(
+        parts=[
+            ToolReturnPart(
+                tool_name="browser_screenshot",
+                content=[text, BinaryContent(data=image_bytes, media_type=media_type)],
+                tool_call_id=tool_call_id,
+                timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            )
+        ],
+        timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+class TestBinaryContentRetention:
+    """Tests for ``EvictionCapability.before_model_request`` binary pruning."""
+
+    @pytest.mark.anyio
+    async def test_keeps_most_recent_binaries(self):
+        """The N most recent binaries are kept; older ones are pruned and stored."""
+        from pydantic_ai.messages import BinaryContent
+
+        backend = StateBackend()
+        cap = EvictionCapability(backend=backend, max_binary_content=2)
+        ctx = _make_ctx(backend)
+
+        # 4 messages, each with one image — newest last
+        messages: list[ModelMessage] = [
+            _user_with_image(b"image-0-bytes" * 8, text="img0"),
+            _user_with_image(b"image-1-bytes" * 8, text="img1"),
+            _user_with_image(b"image-2-bytes" * 8, text="img2"),
+            _user_with_image(b"image-3-bytes" * 8, text="img3"),
+        ]
+        rc = _FakeRequestContext(messages)
+
+        result_rc = await cap.before_model_request(ctx, rc)
+
+        new_messages = result_rc.messages
+        assert len(new_messages) == 4
+
+        def _binary_count(msg: ModelMessage) -> int:
+            count = 0
+            for part in msg.parts:
+                if isinstance(part, UserPromptPart):
+                    items = (
+                        part.content if isinstance(part.content, list) else [part.content]
+                    )
+                    count += sum(1 for x in items if isinstance(x, BinaryContent))
+            return count
+
+        # Two oldest messages have their binary replaced with a text reference
+        assert _binary_count(new_messages[0]) == 0
+        assert _binary_count(new_messages[1]) == 0
+        assert _binary_count(new_messages[2]) == 1
+        assert _binary_count(new_messages[3]) == 1
+
+        # Pruned binaries were stored to backend with deterministic paths
+        first_bin = BinaryContent(data=b"image-0-bytes" * 8, media_type="image/jpeg")
+        path = f"/large_tool_results/binary_{first_bin.identifier}.jpg"
+        assert backend._read_bytes(path) == b"image-0-bytes" * 8
+
+        # Older messages now contain the text reference
+        first_part = new_messages[0].parts[0]
+        assert isinstance(first_part, UserPromptPart)
+        assert isinstance(first_part.content, list)
+        text_replacements = [x for x in first_part.content if isinstance(x, str)]
+        assert any("Binary content omitted" in t for t in text_replacements)
+        assert any("read_file" in t for t in text_replacements)
+
+    @pytest.mark.anyio
+    async def test_under_limit_unchanged(self):
+        """When binaries are at or under the limit, messages pass through unchanged."""
+        backend = StateBackend()
+        cap = EvictionCapability(backend=backend, max_binary_content=3)
+        ctx = _make_ctx(backend)
+
+        messages: list[ModelMessage] = [
+            _user_with_image(b"a" * 32, text="img0"),
+            _user_with_image(b"b" * 32, text="img1"),
+        ]
+        rc = _FakeRequestContext(messages)
+
+        result_rc = await cap.before_model_request(ctx, rc)
+
+        # Same list, same message instances
+        assert result_rc.messages is rc.messages
+        assert result_rc.messages[0] is messages[0]
+        assert result_rc.messages[1] is messages[1]
+
+    @pytest.mark.anyio
+    async def test_none_disables_pruning(self):
+        """``max_binary_content=None`` keeps every binary in history."""
+        from pydantic_ai.messages import BinaryContent
+
+        backend = StateBackend()
+        cap = EvictionCapability(backend=backend, max_binary_content=None)
+        ctx = _make_ctx(backend)
+
+        messages: list[ModelMessage] = [
+            _user_with_image(b"img-%d" % i, text=f"i{i}") for i in range(5)
+        ]
+        rc = _FakeRequestContext(messages)
+
+        result_rc = await cap.before_model_request(ctx, rc)
+
+        for msg in result_rc.messages:
+            part = msg.parts[0]
+            assert isinstance(part, UserPromptPart)
+            items = part.content if isinstance(part.content, list) else [part.content]
+            assert any(isinstance(x, BinaryContent) for x in items)
+
+    @pytest.mark.anyio
+    async def test_prunes_binary_in_toolreturn_part(self):
+        """Binary parts inside ``ToolReturnPart.content`` are also pruned and stored."""
+        from pydantic_ai.messages import BinaryContent
+
+        backend = StateBackend()
+        cap = EvictionCapability(backend=backend, max_binary_content=1)
+        ctx = _make_ctx(backend)
+
+        old_bytes = b"old-image-bytes" * 4
+        new_bytes = b"new-image-bytes" * 4
+
+        messages: list[ModelMessage] = [
+            _toolreturn_with_image(old_bytes, tool_call_id="call_old"),
+            _toolreturn_with_image(new_bytes, tool_call_id="call_new"),
+        ]
+        rc = _FakeRequestContext(messages)
+
+        result_rc = await cap.before_model_request(ctx, rc)
+
+        # Newest preserved, oldest pruned
+        old_msg = result_rc.messages[0]
+        new_msg = result_rc.messages[1]
+
+        old_part = old_msg.parts[0]
+        new_part = new_msg.parts[0]
+        assert isinstance(old_part, ToolReturnPart)
+        assert isinstance(new_part, ToolReturnPart)
+
+        assert isinstance(old_part.content, list)
+        assert not any(isinstance(x, BinaryContent) for x in old_part.content)
+        assert any(
+            isinstance(x, str) and "Binary content omitted" in x for x in old_part.content
+        )
+
+        assert isinstance(new_part.content, list)
+        assert any(isinstance(x, BinaryContent) for x in new_part.content)
+
+        # Stored bytes match the original BinaryContent.data
+        old_bin = BinaryContent(data=old_bytes, media_type="image/jpeg")
+        path = f"/large_tool_results/binary_{old_bin.identifier}.jpg"
+        assert backend._read_bytes(path) == old_bytes
+
+        # ToolReturnPart metadata is preserved
+        assert old_part.tool_name == "browser_screenshot"
+        assert old_part.tool_call_id == "call_old"
+
+    @pytest.mark.anyio
+    async def test_no_backend_skips_pruning(self):
+        """With no backend available, binaries are left in place."""
+        from pydantic_ai.messages import BinaryContent
+
+        cap = EvictionCapability(backend=None, max_binary_content=1)
+        ctx = _make_ctx_no_backend()
+
+        messages: list[ModelMessage] = [
+            _user_with_image(b"a" * 16, text="img0"),
+            _user_with_image(b"b" * 16, text="img1"),
+        ]
+        rc = _FakeRequestContext(messages)
+
+        result_rc = await cap.before_model_request(ctx, rc)
+        assert result_rc.messages is rc.messages
+        for msg in result_rc.messages:
+            part = msg.parts[0]
+            assert isinstance(part, UserPromptPart)
+            items = part.content if isinstance(part.content, list) else [part.content]
+            assert any(isinstance(x, BinaryContent) for x in items)
+
+    @pytest.mark.anyio
+    async def test_write_failure_keeps_binary(self):
+        """A backend write failure keeps the binary in history rather than dropping it."""
+        from pydantic_ai.messages import BinaryContent
+
+        backend = StateBackend()
+
+        def failing_write(path: str, content: str | bytes) -> WriteResult:
+            return WriteResult(path=path, error="disk full")
+
+        backend.write = failing_write
+        cap = EvictionCapability(backend=backend, max_binary_content=1)
+        ctx = _make_ctx(backend)
+
+        messages: list[ModelMessage] = [
+            _user_with_image(b"old" * 8, text="old"),
+            _user_with_image(b"new" * 8, text="new"),
+        ]
+        rc = _FakeRequestContext(messages)
+
+        result_rc = await cap.before_model_request(ctx, rc)
+
+        # Both binaries still present because the write failed
+        for msg in result_rc.messages:
+            part = msg.parts[0]
+            assert isinstance(part, UserPromptPart)
+            items = part.content if isinstance(part.content, list) else [part.content]
+            assert any(isinstance(x, BinaryContent) for x in items)
+
+
+class TestMaxBinaryContentAgentIntegration:
+    """``max_binary_content`` plumbing through ``create_deep_agent``."""
+
+    def _eviction_capabilities(self, agent: object) -> list[EvictionCapability]:
+        root = getattr(agent, "_root_capability", None)
+        if root is None:
+            return []
+        return [c for c in getattr(root, "capabilities", []) if isinstance(c, EvictionCapability)]
+
+    def test_agent_accepts_max_binary_content(self):
+        """``create_deep_agent`` accepts ``max_binary_content`` and forwards it."""
+        agent = create_deep_agent(
+            model=TEST_MODEL,
+            eviction_token_limit=20000,
+            max_binary_content=2,
+            include_subagents=False,
+            include_skills=False,
+        )
+
+        caps = self._eviction_capabilities(agent)
+        assert len(caps) == 1
+        assert caps[0].max_binary_content == 2
+
+    def test_agent_default_max_binary_content(self):
+        """Default ``max_binary_content`` is 3 when not specified."""
+        agent = create_deep_agent(
+            model=TEST_MODEL,
+            eviction_token_limit=20000,
+            include_subagents=False,
+            include_skills=False,
+        )
+
+        caps = self._eviction_capabilities(agent)
+        assert len(caps) == 1
+        assert caps[0].max_binary_content == 3
+
+    def test_agent_max_binary_content_none(self):
+        """``max_binary_content=None`` disables pruning."""
+        agent = create_deep_agent(
+            model=TEST_MODEL,
+            eviction_token_limit=20000,
+            max_binary_content=None,
+            include_subagents=False,
+            include_skills=False,
+        )
+
+        caps = self._eviction_capabilities(agent)
+        assert len(caps) == 1
+        assert caps[0].max_binary_content is None
+
+
+class TestExtensionForMediaType:
+    """Tests for the ``_extension_for_media_type`` helper."""
+
+    def test_known_media_type_uses_mapping(self):
+        from pydantic_deep.processors.eviction import _extension_for_media_type
+
+        assert _extension_for_media_type("image/jpeg") == "jpg"
+        assert _extension_for_media_type("image/png") == "png"
+
+    def test_unknown_media_type_uses_subtype(self):
+        from pydantic_deep.processors.eviction import _extension_for_media_type
+
+        assert _extension_for_media_type("image/x-foo") == "x-foo"
+        assert _extension_for_media_type("application/x-custom; charset=utf-8") == "x-custom"
+
+    def test_subtype_special_chars_sanitized(self):
+        from pydantic_deep.processors.eviction import _extension_for_media_type
+
+        assert _extension_for_media_type("image/foo.bar") == "foo_bar"
+
+    def test_no_slash_falls_back_to_bin(self):
+        from pydantic_deep.processors.eviction import _extension_for_media_type
+
+        assert _extension_for_media_type("weirdmediatype") == "bin"
+
+    def test_empty_subtype_falls_back_to_bin(self):
+        from pydantic_deep.processors.eviction import _extension_for_media_type
+
+        assert _extension_for_media_type("image/") == "bin"
+
+
+class TestBinaryRetentionEdgeCases:
+    """Edge cases for ``before_model_request`` binary pruning."""
+
+    @pytest.mark.anyio
+    async def test_bare_binary_in_toolreturn_content_pruned(self):
+        """Bare ``BinaryContent`` (not in a list) on ``ToolReturnPart.content`` is pruned."""
+        from pydantic_ai.messages import BinaryContent
+
+        backend = StateBackend()
+        cap = EvictionCapability(backend=backend, max_binary_content=1)
+        ctx = _make_ctx(backend)
+
+        old_bytes = b"old-bare-binary"
+        new_bytes = b"new-bare-binary"
+
+        old_msg = ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="screenshot",
+                    content=BinaryContent(data=old_bytes, media_type="image/png"),
+                    tool_call_id="call_old_bare",
+                    timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                )
+            ],
+            timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        )
+        new_msg = ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="screenshot",
+                    content=BinaryContent(data=new_bytes, media_type="image/png"),
+                    tool_call_id="call_new_bare",
+                    timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                )
+            ],
+            timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        )
+
+        rc = _FakeRequestContext([old_msg, new_msg])
+        result_rc = await cap.before_model_request(ctx, rc)
+
+        old_part = result_rc.messages[0].parts[0]
+        new_part = result_rc.messages[1].parts[0]
+        assert isinstance(old_part, ToolReturnPart)
+        assert isinstance(new_part, ToolReturnPart)
+
+        # Newest preserved as a BinaryContent, oldest replaced with a text reference
+        assert isinstance(new_part.content, BinaryContent)
+        assert isinstance(old_part.content, str)
+        assert "Binary content omitted" in old_part.content
+        assert "read_file" in old_part.content
+
+        # Stored bytes match the original
+        old_bin = BinaryContent(data=old_bytes, media_type="image/png")
+        path = f"/large_tool_results/binary_{old_bin.identifier}.png"
+        assert backend._read_bytes(path) == old_bytes
+
+    @pytest.mark.anyio
+    async def test_bare_binary_under_limit_unchanged(self):
+        """Bare ``BinaryContent`` under the limit is left untouched."""
+        from pydantic_ai.messages import BinaryContent
+
+        backend = StateBackend()
+        cap = EvictionCapability(backend=backend, max_binary_content=3)
+        ctx = _make_ctx(backend)
+
+        msg = ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="screenshot",
+                    content=BinaryContent(data=b"only", media_type="image/png"),
+                    tool_call_id="call_only",
+                    timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                )
+            ],
+            timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        )
+        rc = _FakeRequestContext([msg])
+        result_rc = await cap.before_model_request(ctx, rc)
+
+        # Same instance, no rebuild
+        assert result_rc.messages[0] is msg
+
+    @pytest.mark.anyio
+    async def test_bare_binary_write_failure_keeps_binary(self):
+        """A failed backend write leaves a bare ``BinaryContent`` untouched."""
+        from pydantic_ai.messages import BinaryContent
+
+        backend = StateBackend()
+
+        def failing_write(path: str, content: str | bytes) -> WriteResult:
+            return WriteResult(path=path, error="disk full")
+
+        backend.write = failing_write
+        cap = EvictionCapability(backend=backend, max_binary_content=1)
+        ctx = _make_ctx(backend)
+
+        old_bin = BinaryContent(data=b"old-bare", media_type="image/png")
+        new_bin = BinaryContent(data=b"new-bare", media_type="image/png")
+
+        old_msg = ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="screenshot",
+                    content=old_bin,
+                    tool_call_id="call_old_fail_bare",
+                    timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                )
+            ],
+            timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        )
+        new_msg = ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="screenshot",
+                    content=new_bin,
+                    tool_call_id="call_new_fail_bare",
+                    timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                )
+            ],
+            timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        )
+
+        rc = _FakeRequestContext([old_msg, new_msg])
+        result_rc = await cap.before_model_request(ctx, rc)
+
+        old_part = result_rc.messages[0].parts[0]
+        new_part = result_rc.messages[1].parts[0]
+        assert isinstance(old_part, ToolReturnPart)
+        assert isinstance(new_part, ToolReturnPart)
+
+        # Both still BinaryContent because the write failed
+        assert isinstance(old_part.content, BinaryContent)
+        assert isinstance(new_part.content, BinaryContent)
+
+    @pytest.mark.anyio
+    async def test_list_write_failure_keeps_binary(self):
+        """A failed backend write leaves list-form binaries untouched."""
+        from pydantic_ai.messages import BinaryContent
+
+        backend = StateBackend()
+
+        def failing_write(path: str, content: str | bytes) -> WriteResult:
+            return WriteResult(path=path, error="disk full")
+
+        backend.write = failing_write
+        cap = EvictionCapability(backend=backend, max_binary_content=1)
+        ctx = _make_ctx(backend)
+
+        msg_old = ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="screenshot",
+                    content=["caption", BinaryContent(data=b"old-list", media_type="image/png")],
+                    tool_call_id="call_old_list_fail",
+                    timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                )
+            ],
+            timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        )
+        msg_new = ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="screenshot",
+                    content=["caption", BinaryContent(data=b"new-list", media_type="image/png")],
+                    tool_call_id="call_new_list_fail",
+                    timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                )
+            ],
+            timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        )
+
+        rc = _FakeRequestContext([msg_old, msg_new])
+        result_rc = await cap.before_model_request(ctx, rc)
+
+        old_part = result_rc.messages[0].parts[0]
+        new_part = result_rc.messages[1].parts[0]
+        assert isinstance(old_part, ToolReturnPart)
+        assert isinstance(new_part, ToolReturnPart)
+
+        # Both messages still hold their BinaryContent because the write failed
+        assert isinstance(old_part.content, list)
+        assert isinstance(new_part.content, list)
+        assert any(isinstance(x, BinaryContent) for x in old_part.content)
+        assert any(isinstance(x, BinaryContent) for x in new_part.content)
+
+    @pytest.mark.anyio
+    async def test_other_request_parts_skipped(self):
+        """Non user/tool-return parts (e.g. ``RetryPromptPart``) are passed over."""
+        from pydantic_ai.messages import RetryPromptPart
+
+        backend = StateBackend()
+        cap = EvictionCapability(backend=backend, max_binary_content=1)
+        ctx = _make_ctx(backend)
+
+        retry_msg = ModelRequest(
+            parts=[RetryPromptPart(content="please retry")],
+            timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        )
+
+        rc = _FakeRequestContext([retry_msg])
+        result_rc = await cap.before_model_request(ctx, rc)
+
+        # Same instance — nothing to prune
+        assert result_rc.messages[0] is retry_msg
+
+    @pytest.mark.anyio
+    async def test_non_list_non_binary_toolreturn_content_unchanged(self):
+        """Scalar non-binary ``ToolReturnPart.content`` (e.g. a dict) is left as-is."""
+        from pydantic_ai.messages import BinaryContent
+
+        backend = StateBackend()
+        cap = EvictionCapability(backend=backend, max_binary_content=1)
+        ctx = _make_ctx(backend)
+
+        # A dict-form content that should not be touched, alongside a binary
+        msg_dict = ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="some_tool",
+                    content={"data": "value"},
+                    tool_call_id="call_dict_form",
+                    timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                )
+            ],
+            timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        )
+        msg_bin = ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="screenshot",
+                    content=BinaryContent(data=b"new-bin", media_type="image/png"),
+                    tool_call_id="call_bin",
+                    timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                )
+            ],
+            timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        )
+
+        rc = _FakeRequestContext([msg_dict, msg_bin])
+        result_rc = await cap.before_model_request(ctx, rc)
+
+        # The dict-form message is preserved as the same instance (no modifications)
+        assert result_rc.messages[0] is msg_dict
+        # Binary is preserved (under the limit of 1)
+        bin_part = result_rc.messages[1].parts[0]
+        assert isinstance(bin_part, ToolReturnPart)
+        assert isinstance(bin_part.content, BinaryContent)


### PR DESCRIPTION
Fixes https://github.com/vstorm-co/pydantic-deepagents/issues/90

## Summary

Fixes a bug in `EvictionCapability` where `ToolReturn(return_value=..., content=[..., BinaryContent(...)])` results were collapsed into a string and replaced with a text eviction message, dropping the multimodal `BinaryContent` (e.g. screenshots) entirely. Adds a new `max_binary_content` knob (default `3`) that bounds how many `BinaryContent` parts remain model-visible across the message history, while persisting older binaries to the backend with a `read_file`-able reference so the agent can still retrieve them on demand.

## Changes

- `EvictionCapability.after_tool_execute` now special-cases `ToolReturn`: only `return_value` is measured for size-based text eviction, and `content` (including `BinaryContent`) plus `metadata` are preserved by re-wrapping the result.
- New `EvictionCapability.before_model_request` hook prunes older multimodal binary parts in `UserPromptPart.content` and `ToolReturnPart.content` (both list-form and bare `BinaryContent`), keeping the most recent `max_binary_content` items.
- Pruned binary bytes are written to the backend at deterministic paths (`/large_tool_results/binary_{identifier}.{ext}`) using `BinaryContent.identifier` and a media-type-derived extension, then replaced with a compact `[Binary content omitted: ..., saved to ..., use read_file(path="...")]` reference. If no backend is available or a write fails, the binary is left in place to avoid data loss.
- New helpers in `pydantic_deep/processors/eviction.py`: `_extension_for_media_type`, `_binary_storage_path`, `_binary_replacement_text`, `_prune_binaries_in_messages`, `_prune_user_content`, `_prune_tool_return_content`, `_store_and_replace_binary`. New constants `DEFAULT_MAX_BINARY_CONTENT = 3` and `BINARY_PRUNED_TEMPLATE`.
- `create_deep_agent(...)` gains a `max_binary_content: int | None = 3` parameter (across all overloads) and threads it into the registered `EvictionCapability`. Passing `None` disables binary pruning.
- `pydantic_deep` package now exports `DEFAULT_MAX_BINARY_CONTENT` and `BINARY_PRUNED_TEMPLATE`.

## Testing

- [x] New tests added for any new functionality (required — `make test` enforces 100% coverage)
- [x] All tests pass locally: `make test`
- [ ] Linting passes: `make lint`
- [ ] Type checking passes: `make typecheck`
- [ ] Security scan passes: `make security`
- [ ] Full check suite passes: `make all`

Added `TestEvictionCapabilityToolReturn`, `TestBinaryContentRetention`, `TestExtensionForMediaType`, `TestBinaryRetentionEdgeCases`, and `TestMaxBinaryContentAgentIntegration` in `tests/test_eviction.py`. Coverage for `pydantic_deep/processors/eviction.py` is 100% (lines + branches), and the full suite is `1433 passed` via `uv run pytest`.

## Related Issues

<!-- Link to any related issues: "Fixes #123" or "Closes #456" -->

## Notes for Reviewers

- The behavior change is opt-out: existing agents that previously relied on the buggy collapse of `ToolReturn` into a text eviction will now see multimodal `content` retained. If the agent talks to a non-multimodal model, the `before_model_request` pruning still kicks in and gradually replaces older binaries with text references after the limit is exceeded.
- Storage paths use `BinaryContent.identifier` (a stable 6-char SHA1 of the bytes) so re-pruning the same binary is idempotent and never duplicates writes.
- The console toolset is created with `image_support=True`, so the stored `.jpg`/`.png` paths can be re-read as `BinaryContent` via `read_file` when the agent decides to look at an older image again.
- The legacy `EvictionProcessor` (history processor) is intentionally unchanged; the default path is `EvictionCapability`. If we ever need binary handling there too, it can be added separately.