### PR TITLE
fix: Esc interrupt, tool spinner lifecycle, and empty message cleanup

### DIFF
--- a/apps/cli/app.py
+++ b/apps/cli/app.py
@@ -45,6 +45,7 @@ class DeepApp(App):
 
     BINDINGS = [
         Binding("ctrl+c", "interrupt", "Interrupt", show=False),
+        Binding("escape", "escape_key", "Interrupt/Focus", show=False),
         Binding("ctrl+d", "quit", "Quit", show=False),
         Binding("f1", "show_help", "Help"),
         Binding("f2", "show_settings", "Settings"),
@@ -366,6 +367,18 @@ class DeepApp(App):
             self.notify("Agent interrupted", severity="warning")
         else:
             self.exit()
+
+    def action_escape_key(self) -> None:
+        """Handle Esc — interrupt running agent, or focus input if idle."""
+        if self._agent_task and not self._agent_task.done():
+            self._agent_task.cancel()
+            self.is_streaming = False
+            self.notify("Agent interrupted", severity="warning")
+        else:
+            from apps.cli.widgets.input_area import InputArea
+
+            with contextlib.suppress(NoMatches, Exception):
+                self.screen.query_one(InputArea).focus_input()
 
     def action_show_help(self) -> None:
         self.handle_command("/help")

--- a/apps/cli/app.py
+++ b/apps/cli/app.py
@@ -63,6 +63,8 @@ class DeepApp(App):
     total_cost: reactive[float] = reactive(0.0)
     current_cost: reactive[float] = reactive(0.0)
 
+    _agent_task: asyncio.Task[None] | None = None
+
     def __init__(
         self,
         agent: Agent[Any, str] | None = None,
@@ -83,7 +85,6 @@ class DeepApp(App):
         self._branch = _detect_git_branch(str(working_dir))
         self.message_history: list[ModelMessage] = message_history or []
         self.last_response: str = ""
-        self._agent_task: asyncio.Task[Any] | None = None
         self._startup_error = startup_error
 
         # Register custom themes
@@ -363,7 +364,6 @@ class DeepApp(App):
         """Handle Ctrl+C — cancel running agent or exit."""
         if self._agent_task and not self._agent_task.done():
             self._agent_task.cancel()
-            self.is_streaming = False
             self.notify("Agent interrupted", severity="warning")
         else:
             self.exit()
@@ -372,12 +372,11 @@ class DeepApp(App):
         """Handle Esc — interrupt running agent, or focus input if idle."""
         if self._agent_task and not self._agent_task.done():
             self._agent_task.cancel()
-            self.is_streaming = False
             self.notify("Agent interrupted", severity="warning")
         else:
             from apps.cli.widgets.input_area import InputArea
 
-            with contextlib.suppress(NoMatches, Exception):
+            with contextlib.suppress(NoMatches):
                 self.screen.query_one(InputArea).focus_input()
 
     def action_show_help(self) -> None:

--- a/apps/cli/commands.py
+++ b/apps/cli/commands.py
@@ -306,6 +306,14 @@ async def dispatch_command(app: DeepApp, command: str) -> None:  # noqa: C901
                 msg_list = app.screen.query_one(MessageList)
                 msg_list.clear_messages()
 
+                completed_call_ids: set[str] = set()
+                for msg in history:
+                    for part in msg.parts:
+                        if getattr(part, "part_kind", "") == "tool-return":
+                            call_id = getattr(part, "tool_call_id", "")
+                            if call_id:
+                                completed_call_ids.add(call_id)
+
                 # Replay messages into the message list
                 for msg in history:
                     for part in msg.parts:
@@ -324,7 +332,11 @@ async def dispatch_command(app: DeepApp, command: str) -> None:  # noqa: C901
                         elif kind == "tool-call":
                             # Show tool calls in the most recent assistant message
                             tool_name = getattr(part, "tool_name", "unknown")
-                            args = getattr(part, "args", {})
+                            args = (
+                                part.args_as_dict()
+                                if hasattr(part, "args_as_dict")
+                                else getattr(part, "args", {})
+                            )
                             if not isinstance(args, dict):
                                 args = {}
                             call_id = getattr(part, "tool_call_id", tool_name)
@@ -332,6 +344,8 @@ async def dispatch_command(app: DeepApp, command: str) -> None:  # noqa: C901
                             if assistant_msg is None:
                                 assistant_msg = msg_list.begin_assistant_message()
                             assistant_msg.add_tool_call(tool_name, args, call_id)
+                            if call_id not in completed_call_ids:
+                                assistant_msg.complete_tool_call(call_id, "Interrupted", 0.0, True)
                         elif kind == "tool-return":
                             tool_name = getattr(part, "tool_name", "unknown")
                             call_id = getattr(part, "tool_call_id", tool_name)

--- a/apps/cli/commands.py
+++ b/apps/cli/commands.py
@@ -306,57 +306,53 @@ async def dispatch_command(app: DeepApp, command: str) -> None:  # noqa: C901
                 msg_list = app.screen.query_one(MessageList)
                 msg_list.clear_messages()
 
-                completed_call_ids: set[str] = set()
-                for msg in history:
-                    for part in msg.parts:
-                        if getattr(part, "part_kind", "") == "tool-return":
-                            call_id = getattr(part, "tool_call_id", "")
-                            if call_id:
-                                completed_call_ids.add(call_id)
+                from pydantic_ai.messages import (
+                    TextPart,
+                    ToolCallPart,
+                    ToolReturnPart,
+                    UserPromptPart,
+                )
+
+                completed_call_ids: set[str] = {
+                    part.tool_call_id
+                    for msg in history
+                    for part in msg.parts
+                    if isinstance(part, ToolReturnPart)
+                }
 
                 # Replay messages into the message list
                 for msg in history:
                     for part in msg.parts:
-                        kind = getattr(part, "part_kind", "")
-                        if kind == "user-prompt":
-                            content = getattr(part, "content", "")
+                        if isinstance(part, UserPromptPart):
+                            content = part.content
                             if isinstance(content, str) and content:
                                 msg_list.append_user_message(content)
-                        elif kind == "text":
-                            content = getattr(part, "content", "")
-                            if isinstance(content, str) and content:
+                        elif isinstance(part, TextPart):
+                            if part.content:
                                 assistant_msg = msg_list.begin_assistant_message()
-                                assistant_msg.append_text(content)
+                                assistant_msg.append_text(part.content)
                                 assistant_msg.finalize_text()
                                 msg_list.end_assistant_message()
-                        elif kind == "tool-call":
-                            # Show tool calls in the most recent assistant message
-                            tool_name = getattr(part, "tool_name", "unknown")
-                            args = (
-                                part.args_as_dict()
-                                if hasattr(part, "args_as_dict")
-                                else getattr(part, "args", {})
-                            )
-                            if not isinstance(args, dict):
-                                args = {}
-                            call_id = getattr(part, "tool_call_id", tool_name)
+                        elif isinstance(part, ToolCallPart):
+                            args = part.args_as_dict()
+                            call_id = part.tool_call_id
                             assistant_msg = msg_list.current_assistant
                             if assistant_msg is None:
                                 assistant_msg = msg_list.begin_assistant_message()
-                            assistant_msg.add_tool_call(tool_name, args, call_id)
+                            assistant_msg.add_tool_call(part.tool_name, args, call_id)
                             if call_id not in completed_call_ids:
                                 assistant_msg.complete_tool_call(call_id, "Interrupted", 0.0, True)
-                        elif kind == "tool-return":
-                            tool_name = getattr(part, "tool_name", "unknown")
-                            call_id = getattr(part, "tool_call_id", tool_name)
-                            content = str(getattr(part, "content", ""))
+                        elif isinstance(part, ToolReturnPart):
+                            content = str(part.content)
                             assistant_msg = msg_list.current_assistant
                             if assistant_msg is not None:
                                 is_error = (
                                     "error" in content.lower()[:100]
                                     or "traceback" in content.lower()[:200]
                                 )
-                                assistant_msg.complete_tool_call(call_id, content, 0.0, is_error)
+                                assistant_msg.complete_tool_call(
+                                    part.tool_call_id, content, 0.0, is_error
+                                )
 
                 # Finalize any open assistant message
                 if msg_list.current_assistant is not None:

--- a/apps/cli/screens/chat.py
+++ b/apps/cli/screens/chat.py
@@ -41,7 +41,6 @@ class ChatScreen(Screen):
     """The main chat interface with header, messages, status bar, and input."""
 
     BINDINGS = [
-        Binding("escape", "focus_input", "Focus input", show=False),
         Binding("ctrl+j", "toggle_multiline", "Multiline", show=False),
         Binding("ctrl+k", "show_todos", "TODOs"),
         Binding("ctrl+l", "clear_screen", "Clear"),
@@ -428,6 +427,8 @@ class ChatScreen(Screen):
         """Run the agent and stream results directly to widgets."""
         import asyncio
 
+        from apps.cli.widgets.input_area import HintsBar
+
         app = self.app
         if getattr(app, "agent", None) is None:
             app.notify("No agent configured — use /provider to set up", severity="error")  # type: ignore
@@ -440,9 +441,14 @@ class ChatScreen(Screen):
         app.last_response = ""  # type: ignore
         assistant = msg_list.begin_assistant_message()
 
+        with contextlib.suppress(Exception):
+            self.query_one(HintsBar).update("[dim]Esc[/dim] to interrupt")
+
         task = asyncio.create_task(self._agent_stream_worker(text, assistant, msg_list, header))
+        app._agent_task = task  # type: ignore[attr-defined]
 
         def _on_done(t: asyncio.Task[None]) -> None:
+            app._agent_task = None  # type: ignore[attr-defined]
             exc = t.exception()
             if exc:
                 app.notify(f"Agent error: {exc}", severity="error", timeout=10)  # type: ignore
@@ -479,6 +485,7 @@ class ChatScreen(Screen):
         log.info("Agent run started", prompt_length=len(text), history_messages=len(history))
 
         pending: dict[str, tuple[dict[str, Any], float]] = {}
+        _run_cancelled = False
         _TODO_TOOLS: frozenset[str] = frozenset()  # Show all tool calls in UI
         _TEAM_TOOLS = frozenset(
             {
@@ -505,6 +512,10 @@ class ChatScreen(Screen):
             return {}
 
         try:
+            from pydantic_deep.processors.patch import patch_tool_calls_processor
+
+            history = patch_tool_calls_processor(list(history))
+
             async with agent.iter(
                 text, deps=deps, message_history=history, usage_limits=DEFAULT_USAGE_LIMITS
             ) as run:
@@ -770,6 +781,7 @@ class ChatScreen(Screen):
                 self._save_session()
 
         except asyncio.CancelledError:
+            _run_cancelled = True
             log.info("Agent run cancelled")
         except Exception as exc:
             log.error("Agent run failed", exc_info=True)
@@ -778,6 +790,26 @@ class ChatScreen(Screen):
             with contextlib.suppress(Exception):
                 app.notify(f"Agent error: {exc}", severity="error", timeout=10)  # type: ignore
         finally:
+            from apps.cli.widgets.input_area import HintsBar
+
+            for call_id, (_, start) in list(pending.items()):
+                elapsed = _time.monotonic() - start
+                if _run_cancelled:
+                    assistant.complete_tool_call(call_id, "Interrupted", elapsed, True)
+                else:
+                    assistant.complete_tool_call(call_id, "", elapsed, False)
+            pending.clear()
+
+            is_empty = (
+                not assistant._text.strip()
+                and not assistant._thinking.strip()
+                and not assistant._tool_widgets
+            )
+            if is_empty:
+                msg_list._current_assistant = None
+                with contextlib.suppress(Exception):
+                    assistant.remove()
+
             # Always save session — even after errors or cancellation
             self._save_session()
             header.is_streaming = False
@@ -785,6 +817,8 @@ class ChatScreen(Screen):
             msg_list.end_assistant_message()
             with contextlib.suppress(Exception):
                 self.query_one(InputArea).focus_input()
+            with contextlib.suppress(Exception):
+                self.query_one(HintsBar).update(HintsBar._default_hints())
             with contextlib.suppress(Exception):
                 msg_list.scroll_end(animate=False)
 

--- a/apps/cli/screens/chat.py
+++ b/apps/cli/screens/chat.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import contextlib
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from apps.cli.app import DeepApp
 
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -39,6 +42,10 @@ from pydantic_deep.deps import DEFAULT_USAGE_LIMITS
 
 class ChatScreen(Screen):
     """The main chat interface with header, messages, status bar, and input."""
+
+    @property
+    def app(self) -> DeepApp:
+        return super().app
 
     BINDINGS = [
         Binding("ctrl+j", "toggle_multiline", "Multiline", show=False),
@@ -445,10 +452,10 @@ class ChatScreen(Screen):
             self.query_one(HintsBar).update("[dim]Esc[/dim] to interrupt")
 
         task = asyncio.create_task(self._agent_stream_worker(text, assistant, msg_list, header))
-        app._agent_task = task  # type: ignore[attr-defined]
+        app._agent_task = task
 
         def _on_done(t: asyncio.Task[None]) -> None:
-            app._agent_task = None  # type: ignore[attr-defined]
+            app._agent_task = None
             exc = t.exception()
             if exc:
                 app.notify(f"Agent error: {exc}", severity="error", timeout=10)  # type: ignore
@@ -800,25 +807,18 @@ class ChatScreen(Screen):
                     assistant.complete_tool_call(call_id, "", elapsed, False)
             pending.clear()
 
-            is_empty = (
-                not assistant._text.strip()
-                and not assistant._thinking.strip()
-                and not assistant._tool_widgets
-            )
-            if is_empty:
-                msg_list._current_assistant = None
-                with contextlib.suppress(Exception):
-                    assistant.remove()
+            msg_list.remove_last_if_empty()
 
             # Always save session — even after errors or cancellation
             self._save_session()
+            app.is_streaming = False
             header.is_streaming = False
             header.is_thinking = False
             msg_list.end_assistant_message()
             with contextlib.suppress(Exception):
                 self.query_one(InputArea).focus_input()
             with contextlib.suppress(Exception):
-                self.query_one(HintsBar).update(HintsBar._default_hints())
+                self.query_one(HintsBar).reset()
             with contextlib.suppress(Exception):
                 msg_list.scroll_end(animate=False)
 

--- a/apps/cli/widgets/assistant_message.py
+++ b/apps/cli/widgets/assistant_message.py
@@ -147,6 +147,11 @@ class AssistantMessage(Widget):
         """Final render — called when streaming is done."""
         self._render_text()
 
+    @property
+    def is_empty(self) -> bool:
+        """True when the message has no visible content."""
+        return not self._text.strip() and not self._thinking.strip() and not self._tool_widgets
+
     def set_usage(
         self,
         input_tokens: int,

--- a/apps/cli/widgets/assistant_message.py
+++ b/apps/cli/widgets/assistant_message.py
@@ -116,7 +116,7 @@ class AssistantMessage(Widget):
     ) -> None:
         """Mark a tool call as completed."""
         widget = self._tool_widgets.get(call_id)
-        if widget:
+        if widget and widget.status == "pending":
             widget.complete(result, elapsed, error)
 
     def append_thinking(self, delta: str) -> None:

--- a/apps/cli/widgets/input_area.py
+++ b/apps/cli/widgets/input_area.py
@@ -25,11 +25,11 @@ class HintsBar(Static):
     """
 
     def __init__(self) -> None:
-        super().__init__(self._default_hints())
+        super().__init__()
 
-    @staticmethod
-    def _default_hints() -> str:
-        return (
+    def reset(self) -> None:
+        """Restore the default keyboard hint text."""
+        self.update(
             "[dim]↑[/dim] history   "
             "[dim]/[/dim] commands   "
             "[dim]@[/dim] files   "
@@ -235,7 +235,7 @@ class InputArea(Vertical):
             row.mount(PromptPrefix())
             p = PromptInput()
             row.mount(p)
-            hints.update(HintsBar._default_hints())
+            hints.reset()
             p.focus()
 
     def on_input_area_exit_multiline(self, _event: ExitMultiline) -> None:

--- a/apps/cli/widgets/message_list.py
+++ b/apps/cli/widgets/message_list.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import contextlib
+
 from textual.containers import VerticalScroll
 
 from apps.cli.widgets.assistant_message import AssistantMessage
@@ -46,6 +48,14 @@ class MessageList(VerticalScroll):
             self._current_assistant.finalize_text()
             self._current_assistant = None
         self.scroll_end(animate=False)
+
+    def remove_last_if_empty(self) -> None:
+        """Remove the current assistant message if it has no visible content."""
+        msg = self._current_assistant
+        if msg is not None and msg.is_empty:
+            self._current_assistant = None
+            with contextlib.suppress(Exception):
+                msg.remove()
 
     def clear_messages(self) -> None:
         """Remove all messages."""

--- a/apps/cli/widgets/tool_call.py
+++ b/apps/cli/widgets/tool_call.py
@@ -155,6 +155,10 @@ class ToolCallWidget(Widget):
         if self.is_hidden_tool:
             self.display = False
             return
+        if self.status != "pending":
+            self._refresh_header()
+            self._refresh_output()
+            return
         self._timer_handle = self.set_interval(1 / 12, self._tick_spinner)
 
     def _tick_spinner(self) -> None:

--- a/pydantic_deep/spec.py
+++ b/pydantic_deep/spec.py
@@ -151,7 +151,7 @@ def _dump_yaml(data: dict[str, Any]) -> str:
             "PyYAML is required for YAML spec files. "
             "Install with: pip install 'pydantic-deep[yaml]'"
         ) from e
-    return yaml.dump(data, default_flow_style=False, sort_keys=False)  # type: ignore[no-any-return]
+    return yaml.dump(data, default_flow_style=False, sort_keys=False)
 
 
 class DeepAgent:

--- a/pydantic_deep/toolsets/skills/backend.py
+++ b/pydantic_deep/toolsets/skills/backend.py
@@ -30,7 +30,7 @@ from .exceptions import (
 from .types import Skill, SkillResource, SkillScript
 
 try:
-    import yaml  # type: ignore[import-untyped]
+    import yaml
 
     _HAS_YAML = True
 except ImportError:

--- a/pydantic_deep/toolsets/skills/directory.py
+++ b/pydantic_deep/toolsets/skills/directory.py
@@ -28,7 +28,7 @@ from .local import (
 from .types import Skill, SkillResource, SkillScript
 
 try:
-    import yaml  # type: ignore[import-untyped]
+    import yaml
 
     _HAS_YAML = True
 except ImportError:

--- a/pydantic_deep/toolsets/skills/local.py
+++ b/pydantic_deep/toolsets/skills/local.py
@@ -25,7 +25,7 @@ from .exceptions import SkillResourceLoadError, SkillScriptExecutionError
 from .types import SkillResource, SkillScript
 
 try:
-    import yaml  # type: ignore[import-untyped]
+    import yaml
 
     _HAS_YAML = True
 except ImportError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ lint = [
     "pyright>=1.1.0",
     "mypy>=1.0.0",
     "bandit>=1.8.0",
+    "types-PyYAML>=6.0",
 ]
 docs = [
     "mkdocs>=1.6.0",


### PR DESCRIPTION
## Summary
Four UX and reliability fixes for the TUI: Esc now interrupts a running agent, tool-call spinners always stop correctly, `/load` session replay no longer shows infinite spinners for previously interrupted calls, and the hints bar shows context-aware shortcuts while the agent is running.

## Added
- **Esc to interrupt**: `DeepApp.action_escape_key()` cancels the running agent task on Esc; focuses input when idle. Hint bar updates to `Esc  interrupt` while the agent runs and restores defaults on completion
- **Empty message cleanup**: if the agent is cancelled before producing any output, thinking, or tool calls, the empty assistant message bubble is removed from the UI

## Changed
- Agent task stored on `app._agent_task` so `action_escape_key` can cancel it
- `finally` drain in `_agent_stream_worker` distinguishes cancellation (`_run_cancelled` flag): only marks pending tool widgets "Interrupted" on actual `CancelledError`; on normal completion stops spinners without error state
- `complete_tool_call` is now idempotent — skips widgets already marked success/error, preventing the drain from overwriting a correctly completed tool call

## Fixed
- Tool-call spinner timer race condition in `ToolCallWidget.on_mount`: if `complete()` was called before mount (fast tools), the spinner interval is never started and the final state is rendered immediately
- `/load` session replay: orphaned tool calls (from previously interrupted sessions) are replayed as "Interrupted" instead of spinning forever; `part.args_as_dict()` used for correct label display
- Successful `execute` calls no longer shown as "Interrupted" after agent completes normally

## Removed
- `Binding("escape", "focus_input", ...)` from `ChatScreen.BINDINGS` — superseded by app-level `action_escape_key`

## Testing
Manually tested: `execute(sleep 5)` completes with green ✓; Esc mid-execution shows red ✗ "Interrupted"; `/load` of an interrupted session replays correctly; Esc when idle focuses the input.
- [x] All tests pass locally: `make test`
- [x] Linting passes: `make lint`
- [x] Type checking passes: `make typecheck`
- [x] Full check suite passes: `make all`

## Related Issues
Closes #93