### PR TITLE
chore: bump version to 0.3.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.21] - 2026-05-24
+
+### Changed
+
+- **Bumped `pydantic-ai-todo` floor from `>=0.2.1` to `>=0.2.2`** ([#114](https://github.com/vstorm-co/pydantic-deepagents/pull/114), auto-opened by the new Renovate config). Brings in [`pydantic-ai-todo 0.2.2`](https://github.com/vstorm-co/pydantic-ai-todo/releases/tag/0.2.2): the new `AsyncRedisStorage` backend (Redis Hash + companion List, session-scoped, multi-tenant, event-emitter integration) plus a follow-up batch of correctness fixes (`remove_todo` atomicity via single pipeline, Redis Cluster–safe hash-tagged keys, idempotent `initialize()`).
+
 ## [0.3.20] - 2026-05-18
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-deep"
-version = "0.3.20"
+version = "0.3.21"
 description = "Batteries-included agent harness for Python — tool-calling, sandboxed execution, multi-agent teams, and unlimited context on Pydantic AI"
 readme = "README.md"
 keywords = [


### PR DESCRIPTION
Cuts a release for #114 (Renovate auto-bump of `pydantic-ai-todo>=0.2.1 → >=0.2.2`).

## What's in 0.3.21

`pydantic-ai-todo 0.2.2` brings:
- `AsyncRedisStorage` — third storage backend (Redis Hash + companion List, session-scoped, multi-tenant, full event-emitter integration).
- Follow-up correctness fixes: `remove_todo` atomicity via single pipeline, Redis Cluster–safe `{session_id}` hash-tagged keys, idempotent `initialize()`.

Renovate config from #109 picked this up automatically and opened #114 — first confirmation the dep-bot wiring works end-to-end. 🚀

## Notes

- `0.3.20` has not been published to PyPI yet (PyPI latest is still `0.3.19`). Per the user's preference for explicit version bumps per merged batch, `0.3.21` is cut separately rather than folding into `0.3.20`.
- No source-code changes; pure version + CHANGELOG.

## Gate

- `make typecheck` (pyright) — 0 errors
- `uv run mypy pydantic_deep tests` (CI-equivalent) — 0 errors
- `make test` — 1553 passed, coverage unchanged
- `make lint` + `make format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)