### PR TITLE
fix: migrate from _read_bytes to read_bytes for pydantic-ai-backend 0.2.8

### DIFF
--- a/pydantic_deep/toolsets/context.py
+++ b/pydantic_deep/toolsets/context.py
@@ -87,7 +87,7 @@ def load_context_files(
     """
     result: list[ContextFile] = []
     for path in paths:
-        raw = backend._read_bytes(path)
+        raw = backend.read_bytes(path)
         if not raw:
             continue
         content = raw.decode("utf-8", errors="replace")
@@ -115,7 +115,7 @@ def discover_context_files(
     found: list[str] = []
     for name in filenames:
         path = f"{search_path.rstrip('/')}/{name}"
-        raw = backend._read_bytes(path)
+        raw = backend.read_bytes(path)
         if raw:
             found.append(path)
     return found

--- a/pydantic_deep/toolsets/liteparse.py
+++ b/pydantic_deep/toolsets/liteparse.py
@@ -120,7 +120,7 @@ class LiteparseToolset(FunctionToolset[Any]):
             if not _HAS_LITEPARSE:
                 return _NOT_INSTALLED_MSG
             backend = ctx.deps.backend
-            file_bytes: bytes | None = backend._read_bytes(path)
+            file_bytes: bytes | None = backend.read_bytes(path)
             if not file_bytes:
                 return f"File not found: {path}"
             try:
@@ -156,7 +156,7 @@ class LiteparseToolset(FunctionToolset[Any]):
             if not _HAS_LITEPARSE:
                 return _NOT_INSTALLED_MSG
             backend = ctx.deps.backend
-            file_bytes = backend._read_bytes(path)
+            file_bytes = backend.read_bytes(path)
             if not file_bytes:
                 return f"File not found: {path}"
             try:

--- a/pydantic_deep/toolsets/memory.py
+++ b/pydantic_deep/toolsets/memory.py
@@ -97,7 +97,7 @@ def load_memory(
     Returns:
         MemoryFile if found, None otherwise.
     """
-    raw = backend._read_bytes(path)
+    raw = backend.read_bytes(path)
     if not raw:
         return None
     content = raw.decode("utf-8", errors="replace")

--- a/pydantic_deep/toolsets/skills/backend.py
+++ b/pydantic_deep/toolsets/skills/backend.py
@@ -3,7 +3,7 @@
 This module provides backend-integrated implementations that parallel
 the local filesystem implementations in ``local.py``:
 
-- `BackendSkillResource`: Load resources via ``BackendProtocol._read_bytes()``
+- `BackendSkillResource`: Load resources via ``BackendProtocol.read_bytes()``
 - `BackendSkillScriptExecutor`: Execute scripts via ``SandboxProtocol.execute()``
 - `BackendSkillScript`: File-based script delegating to backend executor
 - `BackendSkillsDirectory`: Discover skills from a backend filesystem
@@ -79,7 +79,7 @@ class BackendSkillResource(SkillResource):
             raise SkillResourceLoadError(f"Resource '{self.name}' has no backend configured")
 
         try:
-            content_bytes = self.backend._read_bytes(self.uri)
+            content_bytes = self.backend.read_bytes(self.uri)
             content = content_bytes.decode("utf-8")
         except Exception as e:
             raise SkillResourceLoadError(
@@ -397,7 +397,7 @@ def _discover_backend_scripts(
 class BackendSkillsDirectory:
     """Discover and load skills from a backend filesystem.
 
-    Uses ``BackendProtocol`` methods (``glob_info``, ``_read_bytes``) for
+    Uses ``BackendProtocol`` methods (``glob_info``, ``read_bytes``) for
     skill discovery and resource loading. Script execution requires
     ``SandboxProtocol`` (with ``execute()``).
 
@@ -501,7 +501,7 @@ class BackendSkillsDirectory:
         Returns:
             Loaded Skill object, or None if skill should be skipped.
         """
-        content_bytes = self._backend._read_bytes(skill_file_path)
+        content_bytes = self._backend.read_bytes(skill_file_path)
         content = content_bytes.decode("utf-8")
 
         frontmatter, instructions = _parse_skill_md(content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 dependencies = [
     "pydantic-ai-slim[web-fetch]>=1.97.0",
     "pydantic-ai-todo>=0.2.2",
-    "pydantic-ai-backend[console]>=0.2.7",
+    "pydantic-ai-backend[console]>=0.2.8",
     "summarization-pydantic-ai>=0.1.4",
     "subagents-pydantic-ai>=0.2.4",
     "pydantic-ai-shields>=0.3.2",
@@ -52,7 +52,7 @@ dependencies = [
 
 [project.optional-dependencies]
 # Docker sandbox support
-sandbox = ["pydantic-ai-backend[docker]>=0.2.7"]
+sandbox = ["pydantic-ai-backend[docker]>=0.2.8"]
 # YAML support for skills (pyyaml-based frontmatter parsing)
 yaml = ["pyyaml>=6.0"]
 # CLI tools + TUI (terminal assistant)

--- a/tests/test_eviction.py
+++ b/tests/test_eviction.py
@@ -252,7 +252,7 @@ class TestEvictionProcessor:
         assert "read_file" in str(tool_part.content)
 
         # File should be written to backend
-        evicted_content = backend._read_bytes("/large_tool_results/call_123")
+        evicted_content = backend.read_bytes("/large_tool_results/call_123")
         assert evicted_content == large_content.encode()
 
     @pytest.mark.anyio
@@ -460,7 +460,7 @@ class TestEvictionProcessor:
         assert "/custom/evicted/" in str(tool_part.content)
 
         # Check file was written to custom path
-        evicted = backend._read_bytes("/custom/evicted/call_custom")
+        evicted = backend.read_bytes("/custom/evicted/call_custom")
         assert evicted == large_content.encode()
 
     @pytest.mark.anyio
@@ -602,11 +602,11 @@ class TestResolveBackend:
         await processor(ctx, messages)
 
         # File should be in RUNTIME backend, not creation backend
-        evicted = runtime_backend._read_bytes("/large_tool_results/call_rt")
+        evicted = runtime_backend.read_bytes("/large_tool_results/call_rt")
         assert evicted == large_content.encode()
 
         # Creation backend should NOT have the file
-        assert creation_backend._read_bytes("/large_tool_results/call_rt") == b""
+        assert creation_backend.read_bytes("/large_tool_results/call_rt") == b""
 
     @pytest.mark.anyio
     async def test_falls_back_to_self_backend(self):
@@ -623,7 +623,7 @@ class TestResolveBackend:
         await processor(ctx, messages)
 
         # File should be in creation (fallback) backend
-        evicted = creation_backend._read_bytes("/large_tool_results/call_fb")
+        evicted = creation_backend.read_bytes("/large_tool_results/call_fb")
         assert evicted == large_content.encode()
 
 
@@ -849,7 +849,7 @@ class TestEvictionPreviewFormat:
         await processor(ctx, messages)
 
         # Read back from backend
-        stored = backend._read_bytes("/large_tool_results/call_read")
+        stored = backend.read_bytes("/large_tool_results/call_read")
         assert stored.decode() == original_content
 
 
@@ -997,7 +997,7 @@ class TestEvictionCapability:
         assert "Tool result too large" in result
         assert "/large_tool_results/call_big" in result
         # File was written
-        evicted = backend._read_bytes("/large_tool_results/call_big")
+        evicted = backend.read_bytes("/large_tool_results/call_big")
         assert evicted == large.encode()
 
     @pytest.mark.anyio
@@ -1018,8 +1018,8 @@ class TestEvictionCapability:
         )
 
         # Written to deps_backend, not fallback
-        assert deps_backend._read_bytes("/large_tool_results/call_deps") not in (None, b"")
-        assert fallback._read_bytes("/large_tool_results/call_deps") in (None, b"")
+        assert deps_backend.read_bytes("/large_tool_results/call_deps") not in (None, b"")
+        assert fallback.read_bytes("/large_tool_results/call_deps") in (None, b"")
 
     @pytest.mark.anyio
     async def test_no_backend_passes_through(self):
@@ -1167,7 +1167,7 @@ class TestEvictionCapabilityToolReturn:
         # content (with the BinaryContent) is preserved as-is
         assert result.content == original.content
         # Backend was not asked to store anything (no eviction)
-        assert backend._read_bytes("/large_tool_results/call_screenshot") in (None, b"")
+        assert backend.read_bytes("/large_tool_results/call_screenshot") in (None, b"")
 
     @pytest.mark.anyio
     async def test_toolreturn_evicts_only_return_value(self):
@@ -1203,7 +1203,7 @@ class TestEvictionCapabilityToolReturn:
         # metadata is preserved
         assert result.metadata == {"trace_id": "abc"}
         # The text value was actually written to the backend
-        assert backend._read_bytes("/large_tool_results/call_big_tr") == large_text.encode()
+        assert backend.read_bytes("/large_tool_results/call_big_tr") == large_text.encode()
 
     @pytest.mark.anyio
     async def test_toolreturn_small_passes_through(self):
@@ -1324,7 +1324,7 @@ class TestBinaryContentRetention:
         # Pruned binaries were stored to backend with deterministic paths
         first_bin = BinaryContent(data=b"image-0-bytes" * 8, media_type="image/jpeg")
         path = f"/large_tool_results/binary_{first_bin.identifier}.jpg"
-        assert backend._read_bytes(path) == b"image-0-bytes" * 8
+        assert backend.read_bytes(path) == b"image-0-bytes" * 8
 
         # Older messages now contain the text reference
         first_part = new_messages[0].parts[0]
@@ -1415,7 +1415,7 @@ class TestBinaryContentRetention:
         # Stored bytes match the original BinaryContent.data
         old_bin = BinaryContent(data=old_bytes, media_type="image/jpeg")
         path = f"/large_tool_results/binary_{old_bin.identifier}.jpg"
-        assert backend._read_bytes(path) == old_bytes
+        assert backend.read_bytes(path) == old_bytes
 
         # ToolReturnPart metadata is preserved
         assert old_part.tool_name == "browser_screenshot"
@@ -1610,7 +1610,7 @@ class TestBinaryRetentionEdgeCases:
         # Stored bytes match the original
         old_bin = BinaryContent(data=old_bytes, media_type="image/png")
         path = f"/large_tool_results/binary_{old_bin.identifier}.png"
-        assert backend._read_bytes(path) == old_bytes
+        assert backend.read_bytes(path) == old_bytes
 
     @pytest.mark.anyio
     async def test_bare_binary_under_limit_unchanged(self):

--- a/tests/test_liteparse.py
+++ b/tests/test_liteparse.py
@@ -114,7 +114,7 @@ class TestParseDocument:
     async def test_file_not_found(self) -> None:
         ts = LiteparseToolset()
         backend = MagicMock()
-        backend._read_bytes.return_value = None
+        backend.read_bytes.return_value = None
         ctx = _ctx(backend)
         with patch("pydantic_deep.toolsets.liteparse._HAS_LITEPARSE", True):
             result = await ts.tools["parse_document"].function(ctx, path="/missing.pdf")
@@ -125,7 +125,7 @@ class TestParseDocument:
     async def test_success(self) -> None:
         ts = LiteparseToolset()
         backend = MagicMock()
-        backend._read_bytes.return_value = b"%PDF-1.4 fake content"
+        backend.read_bytes.return_value = b"%PDF-1.4 fake content"
         ctx = _ctx(backend)
 
         mock_result = MagicMock()
@@ -154,7 +154,7 @@ class TestParseDocument:
     async def test_cli_not_found_error(self) -> None:
         ts = LiteparseToolset()
         backend = MagicMock()
-        backend._read_bytes.return_value = b"data"
+        backend.read_bytes.return_value = b"data"
         ctx = _ctx(backend)
 
         mock_parser = MagicMock()
@@ -171,7 +171,7 @@ class TestParseDocument:
     async def test_generic_exception(self) -> None:
         ts = LiteparseToolset()
         backend = MagicMock()
-        backend._read_bytes.return_value = b"data"
+        backend.read_bytes.return_value = b"data"
         ctx = _ctx(backend)
 
         mock_parser = MagicMock()
@@ -201,7 +201,7 @@ class TestScreenshotDocument:
     async def test_file_not_found(self) -> None:
         ts = LiteparseToolset()
         backend = MagicMock()
-        backend._read_bytes.return_value = None
+        backend.read_bytes.return_value = None
         ctx = _ctx(backend)
         with patch("pydantic_deep.toolsets.liteparse._HAS_LITEPARSE", True):
             result = await ts.tools["screenshot_document"].function(ctx, path="/missing.pdf")
@@ -211,7 +211,7 @@ class TestScreenshotDocument:
     async def test_success(self) -> None:
         ts = LiteparseToolset()
         backend = MagicMock()
-        backend._read_bytes.return_value = b"pdfdata"
+        backend.read_bytes.return_value = b"pdfdata"
         ctx = _ctx(backend)
 
         shot1 = MagicMock()
@@ -244,7 +244,7 @@ class TestScreenshotDocument:
     async def test_no_screenshots_generated(self) -> None:
         ts = LiteparseToolset()
         backend = MagicMock()
-        backend._read_bytes.return_value = b"pdfdata"
+        backend.read_bytes.return_value = b"pdfdata"
         ctx = _ctx(backend)
 
         ss_result = MagicMock()
@@ -264,7 +264,7 @@ class TestScreenshotDocument:
         """Screenshots with no image_bytes are skipped."""
         ts = LiteparseToolset()
         backend = MagicMock()
-        backend._read_bytes.return_value = b"pdfdata"
+        backend.read_bytes.return_value = b"pdfdata"
         ctx = _ctx(backend)
 
         shot = MagicMock()
@@ -288,7 +288,7 @@ class TestScreenshotDocument:
     async def test_target_pages_forwarded(self) -> None:
         ts = LiteparseToolset()
         backend = MagicMock()
-        backend._read_bytes.return_value = b"pdfdata"
+        backend.read_bytes.return_value = b"pdfdata"
         ctx = _ctx(backend)
 
         shot = MagicMock()
@@ -312,7 +312,7 @@ class TestScreenshotDocument:
     async def test_cli_not_found_error(self) -> None:
         ts = LiteparseToolset()
         backend = MagicMock()
-        backend._read_bytes.return_value = b"data"
+        backend.read_bytes.return_value = b"data"
         ctx = _ctx(backend)
 
         mock_parser = MagicMock()
@@ -328,7 +328,7 @@ class TestScreenshotDocument:
     async def test_generic_exception(self) -> None:
         ts = LiteparseToolset()
         backend = MagicMock()
-        backend._read_bytes.return_value = b"data"
+        backend.read_bytes.return_value = b"data"
         ctx = _ctx(backend)
 
         mock_parser = MagicMock()

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -270,7 +270,7 @@ class TestMemoryTools:
 
         assert "Memory updated" in result
         # Verify file was created
-        raw = backend._read_bytes("/.deep/memory/main/MEMORY.md")
+        raw = backend.read_bytes("/.deep/memory/main/MEMORY.md")
         assert raw is not None
         assert b"First entry" in raw
 
@@ -284,7 +284,7 @@ class TestMemoryTools:
         result = await toolset.tools["write_memory"].function(ctx, "New entry")
 
         assert "Memory updated" in result
-        raw = backend._read_bytes("/.deep/memory/main/MEMORY.md")
+        raw = backend.read_bytes("/.deep/memory/main/MEMORY.md")
         assert raw is not None
         content = raw.decode("utf-8")
         assert "Existing" in content
@@ -302,7 +302,7 @@ class TestMemoryTools:
         result = await toolset.tools["update_memory"].function(ctx, "Python 3.11", "Python 3.12")
 
         assert "Memory updated" in result
-        raw = backend._read_bytes("/.deep/memory/main/MEMORY.md")
+        raw = backend.read_bytes("/.deep/memory/main/MEMORY.md")
         assert raw is not None
         assert b"Python 3.12" in raw
         assert b"Python 3.11" not in raw
@@ -336,7 +336,7 @@ class TestMemoryTools:
         )
         await toolset.tools["write_memory"].function(ctx, "Review notes")
 
-        raw = backend._read_bytes("/custom/reviewer/MEMORY.md")
+        raw = backend.read_bytes("/custom/reviewer/MEMORY.md")
         assert raw is not None
         assert b"Review notes" in raw
 

--- a/tests/test_skills_backend.py
+++ b/tests/test_skills_backend.py
@@ -179,9 +179,9 @@ class TestBackendSkillResource:
             await resource.load(ctx=None)
 
     async def test_load_backend_error_raises(self):
-        """If _read_bytes raises, SkillResourceLoadError is raised."""
+        """If read_bytes raises, SkillResourceLoadError is raised."""
         failing_backend = MagicMock()
-        failing_backend._read_bytes.side_effect = OSError("disk error")
+        failing_backend.read_bytes.side_effect = OSError("disk error")
 
         resource = BackendSkillResource(
             name="missing.txt",
@@ -623,18 +623,18 @@ class TestBackendSkillsDirectory:
 
     def test_unexpected_error_wraps_in_validation_error(self):
         backend = StateBackend()
-        # Write a valid-looking SKILL.md but make _read_bytes fail
+        # Write a valid-looking SKILL.md but make read_bytes fail
         backend.write("/skills/test/SKILL.md", "---\nname: test\n---\nContent")
 
-        # Patch _read_bytes to fail after glob succeeds
-        original_read = backend._read_bytes
+        # Patch read_bytes to fail after glob succeeds
+        original_read = backend.read_bytes
 
         def failing_read(path: str) -> bytes:
             if "SKILL.md" in path:
                 raise OSError("disk error")
             return original_read(path)  # type: ignore[no-any-return]
 
-        backend._read_bytes = failing_read
+        backend.read_bytes = failing_read
 
         with pytest.raises(SkillValidationError, match="Failed to load skill"):
             BackendSkillsDirectory(backend=backend, path="/skills")


### PR DESCRIPTION
## Summary
Version:  0.3.21

`pydantic-ai-backend 0.2.8` renamed `BackendProtocol._read_bytes(path)` → `read_bytes(path)` ([changelog](https://github.com/vstorm-co/pydantic-ai-backend/blob/HEAD/CHANGELOG.md#028---2026-05-24)), promoting the bytes-read entry point from private to public. 

Importantly, the CHANGELOG marks this as breaking, and no transitional alias was kept.

`pydantic-deep` still called the underscored name at five sites and declared its dependency as `pydantic-ai-backend>=0.2.7` (unbounded), so fresh resolutions pulled 0.2.8 transitively. Every toolset that touches the backend then failed at `get_instructions()` time with: 
`AttributeError: 'LocalBackend' object has no attribute '_read_bytes'`

This probably affects any non-trivial deepagent setup. 

## Changes
1. **Rename call sites** in the four toolsets that read bytes through the backend protocol:
   - `pydantic_deep/toolsets/memory.py` (`load_memory`)
   - `pydantic_deep/toolsets/liteparse.py` (PDF / file ingestion)
   - `pydantic_deep/toolsets/context.py` (`ContextToolset` preload)
   - `pydantic_deep/toolsets/skills/backend.py` (`BackendSkillResource` + `BackendSkillScript` load)
   Also updates two module-level docstrings in `skills/backend.py` that reference the protocol method by name.
2. **Update tests** that mocked or asserted on the same name:
   - `tests/test_memory.py`
   - `tests/test_liteparse.py`
   - `tests/test_skills_backend.py`
   - `tests/test_eviction.py`
3. **Bump dependency constraint** from `pydantic-ai-backend>=0.2.7` to `>=0.2.8` (both the main dep and the `sandbox` extra) so the declared minimum matches the protocol the code now targets.
## Relationship to PR #118
This supersedes #118 (Renovate auto-bump), which raises the constraint to `>=0.2.8` but doesn't update the code. 

I'm concered that merging #118 alone would force the broken combination on every installer; this PR makes the code and the constraint consistent.

## Test plan
- [x] Full suite passes: **1553 passed, 0 failed**
- [x] Directly affected modules pass: **227 passed** across `test_memory`, `test_liteparse`, `test_skills_backend`, `test_eviction`
- [x] No `_read_bytes` references remain in `pydantic_deep/` or `tests/`