### PR TITLE
chore: release 0.3.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.22] - 2026-05-24
+
+### Fixed
+
+- **`AttributeError: 'LocalBackend' object has no attribute '_read_bytes'` at toolset `get_instructions()` time** ([#118](https://github.com/vstorm-co/pydantic-deepagents/pull/118), independently authored by [@mcauthorn](https://github.com/mcauthorn) in [#119](https://github.com/vstorm-co/pydantic-deepagents/pull/119)). `pydantic-ai-backend 0.2.8` promoted the bytes-read entry point on `BackendProtocol` from private `_read_bytes` to public `read_bytes` and (deliberately) kept no transitional alias. With `pydantic-ai-backend>=0.2.7` unbounded, fresh resolutions pulled `0.2.8` transitively, so every toolset that reaches for bytes (`context`, `memory`, `liteparse`, `skills/backend`) blew up at instructions-load time. Word-boundary rename across all call sites and test mocks.
+
+### Changed
+
+- **Bumped `pydantic-ai-backend>=0.2.7 → >=0.2.8`** ([#118](https://github.com/vstorm-co/pydantic-deepagents/pull/118), Renovate) — pulls in the `exists()` predicate, the `read_bytes` rename (see Fixed above), `hashline_edit` per-`(backend, path)` serialization, and the `async_execute` wire-up in the console toolset's `execute` tool.
+- **Bumped `summarization-pydantic-ai>=0.1.4 → >=0.1.5`** ([#118](https://github.com/vstorm-co/pydantic-deepagents/pull/118), Renovate) — batched with the backend bump; pure CI-housekeeping release on the summarization side, no behaviour change.
+
 ## [0.3.21] - 2026-05-24
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-deep"
-version = "0.3.21"
+version = "0.3.22"
 description = "Batteries-included agent harness for Python — tool-calling, sandboxed execution, multi-agent teams, and unlimited context on Pydantic AI"
 readme = "README.md"
 keywords = [


### PR DESCRIPTION
Cuts the 0.3.22 release so the #118 fix reaches PyPI.

## What's in 0.3.22

- **Fixed** — `AttributeError: '...' object has no attribute '_read_bytes'` after `pydantic-ai-backend 0.2.8` (#118; independently authored by [@mcauthorn](https://github.com/mcauthorn) in [#119](https://github.com/vstorm-co/pydantic-deepagents/pull/119); co-author trailer on the rename commit preserves their credit in `git log`).
- **Changed** — bumped `pydantic-ai-backend>=0.2.8`, `summarization-pydantic-ai>=0.1.5` (via #118).

No source-code changes here — pure version + CHANGELOG.

## Gate

- `make typecheck` (pyright) — 0 errors
- `uv run mypy pydantic_deep tests` (CI-equivalent) — 0 errors
- `make test` — 1553 passed, 100% coverage
- `make lint` + `make format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)