### PR TITLE
fix(cli): handle multi-round tool approval so retried commands don't hang (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.25] - 2026-06-07
+
+### Fixed
+
+- **Approved shell commands could hang forever after the first attempt failed** ([#136](https://github.com/vstorm-co/pydantic-deepagents/issues/136)) (`apps/cli/screens/chat.py`). When `execute` requires approval, the TUI handled exactly **one** round of `DeferredToolRequests`. But the model frequently issues a follow-up command in the same turn when the first one fails — most visibly on Windows, where `rm -rf` errors (`'rm' is not recognized`) and the agent immediately retries with `rd`/`rmdir`. That retry is a *second* approval round, which the single-pass resume code silently dropped: the follow-up tool call stayed deferred-but-unsurfaced and its spinner spun indefinitely (reporters saw 460–693s). The deferred-approval resume is now a `while` loop that surfaces every subsequent approval round until the run no longer ends on a `DeferredToolRequests`, so each retried command is approved and actually executes. Not Windows-specific in cause (the subprocess path and Textual's event loop are fine); Windows just reliably triggers the multi-round retry that exposed it.
+- **Project-local `.env` was shadowed by the global `~/.pydantic-deep/.env`** (`apps/cli/main.py`). The startup dotenv loads ran global-first with the project `./.env` last at `override=False`, so a key already set by the global file (e.g. a stale `OPENROUTER_API_KEY`) could never be corrected by the project's own working value — surfacing as a `401 "User not found"` from OpenRouter despite a valid project key. Loads are now ordered most-specific-first (all `override=False`): project files win over the global fallback, while real shell env vars still take precedence over every dotenv file.
+
 ## [0.3.24] - 2026-06-01
 
 ### Fixed

--- a/apps/cli/main.py
+++ b/apps/cli/main.py
@@ -81,9 +81,15 @@ def _main_callback(
     try:
         from dotenv import load_dotenv
 
+        # Most-specific first, all override=False: the first load to set a var
+        # wins, so project-local files take precedence over the global fallback,
+        # while real shell env vars (already in os.environ) still beat them all.
+        # Ordering the global ~/.pydantic-deep/.env LAST stops a stale global
+        # OPENROUTER_API_KEY from shadowing the project's working key in ./.env —
+        # which otherwise surfaces as a 401 "User not found".
+        load_dotenv(Path.cwd() / ".pydantic-deep" / ".env", override=False)
+        load_dotenv(Path.cwd() / ".env", override=False)
         load_dotenv(Path.home() / ".pydantic-deep" / ".env", override=False)
-        load_dotenv(Path.cwd() / ".pydantic-deep" / ".env", override=True)
-        load_dotenv()
     except ImportError:  # pragma: no cover
         pass
 

--- a/apps/cli/screens/chat.py
+++ b/apps/cli/screens/chat.py
@@ -1074,10 +1074,7 @@ class ChatScreen(Screen):
                 # also needs approval (`rd`, then `rmdir`). Handling only the
                 # first round left every later call deferred-but-unsurfaced, so
                 # its tool-call spinner ran forever (issue #136).
-                while (
-                    isinstance(result.output, DeferredToolRequests)
-                    and result.output.approvals
-                ):
+                while isinstance(result.output, DeferredToolRequests) and result.output.approvals:
                     from pydantic_ai.tools import (
                         DeferredToolResults,
                         ToolApproved,

--- a/apps/cli/screens/chat.py
+++ b/apps/cli/screens/chat.py
@@ -1068,7 +1068,16 @@ class ChatScreen(Screen):
 
                 self._sync_status_from_history()
 
-                if _deferred and isinstance(result.output, DeferredToolRequests):
+                # Loop, not a single pass: a resumed run can itself end on
+                # another DeferredToolRequests — e.g. the model's first command
+                # fails (`rm` on Windows) and it immediately tries another that
+                # also needs approval (`rd`, then `rmdir`). Handling only the
+                # first round left every later call deferred-but-unsurfaced, so
+                # its tool-call spinner ran forever (issue #136).
+                while (
+                    isinstance(result.output, DeferredToolRequests)
+                    and result.output.approvals
+                ):
                     from pydantic_ai.tools import (
                         DeferredToolResults,
                         ToolApproved,
@@ -1201,6 +1210,13 @@ class ChatScreen(Screen):
                         "Agent run completed (after approval)",
                         total_messages=len(app.message_history),  # type: ignore[arg-type]
                     )
+
+                    # Advance the loop: if this resumed run ended on yet another
+                    # DeferredToolRequests, the `while` re-enters and surfaces the
+                    # next approval round instead of leaving its call hanging.
+                    if cont_result is None:
+                        break
+                    result = cont_result
 
                 from apps.cli.forking import reconcile_active_fork
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-deep"
-version = "0.3.24"
+version = "0.3.25"
 description = "Batteries-included agent harness for Python — tool-calling, sandboxed execution, multi-agent teams, and unlimited context on Pydantic AI"
 readme = "README.md"
 keywords = [


### PR DESCRIPTION

The deferred-approval resume in the TUI handled only one round of DeferredToolRequests. When the model's first command fails and it retries another in the same turn (e.g. Windows: rm -rf errors, agent retries rd/rmdir), that retry is a second approval round the single-pass resume silently dropped — the follow-up tool call stayed deferred and its spinner spun forever (460-693s). Resume is now a while loop that surfaces every subsequent approval round until the run no longer ends deferred.

Also fix dotenv precedence in main.py: project-local ./.env was shadowed by the global ~/.pydantic-deep/.env (global loaded first, project last at override=False), surfacing as a 401 "User not found" from OpenRouter despite a valid project key. Loads are now most-specific-first so project files win over the global fallback while real shell env still wins overall.

Bump version to 0.3.25.

## Summary

<!-- What does this PR do? What problem does it solve? -->

## Changes

<!-- List the key changes made in this PR -->
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] New tests added for any new functionality (required — `make test` enforces 100% coverage)
- [ ] All tests pass locally: `make test`
- [ ] Linting passes: `make lint`
- [ ] Type checking passes: `make typecheck`
- [ ] Security scan passes: `make security`
- [ ] Full check suite passes: `make all`

## Related Issues

<!-- Link to any related issues: "Fixes #123" or "Closes #456" -->

## Notes for Reviewers

<!-- Anything the reviewer should pay special attention to? -->
