### PR TITLE
fix(memory): surface backend write and permission failures (#135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.26] - 2026-06-07
+
+### Fixed
+
+- **Memory tools now surface backend write and permission failures** ([#135](https://github.com/vstorm-co/pydantic-deepagents/issues/135)) (`pydantic_deep/toolsets/memory.py`). `AgentMemoryToolset` could report a successful persistent-memory write even when the backend rejected it, and could turn a *denied* memory read into the same `No memory saved yet.` result as a genuinely empty file — making a misconfigured memory directory (e.g. one outside the backend's `allowed_directories`) look like normal empty memory, with traces showing only successful tool calls.
+  - **Write path:** `write_memory` and `update_memory` now inspect `WriteResult.error` and return an explicit `Error: failed to save memory ...` instead of a phantom `Memory updated (...)`.
+  - **Read path:** new `MemoryAccessError` (exported from the package root) lets `load_memory` distinguish *denied* from *missing/empty*. Because `backend.read_bytes()` collapses missing, empty, and denied paths to empty bytes, `load_memory` now disambiguates via `backend.read()` (which reports access errors as `Error: ...` but a missing file as `... not found`), raising `MemoryAccessError` only on a real access failure. `read_memory`/`update_memory` surface it as an error string; `get_instructions` swallows it (prompt injection must not abort a run). Genuinely missing memory still returns `No memory saved yet.`.
+
 ## [0.3.24] - 2026-06-01
 
 ### Fixed

--- a/pydantic_deep/__init__.py
+++ b/pydantic_deep/__init__.py
@@ -209,6 +209,7 @@ from pydantic_deep.toolsets.memory import (
     DEFAULT_MEMORY_DIR,
     DEFAULT_MEMORY_FILENAME,
     AgentMemoryToolset,
+    MemoryAccessError,
     MemoryFile,
     format_memory_prompt,
     get_memory_path,
@@ -384,6 +385,7 @@ __all__ = [
     "SUBAGENT_CONTEXT_ALLOWLIST",
     # Memory (persistent agent memory)
     "AgentMemoryToolset",
+    "MemoryAccessError",
     "MemoryFile",
     "load_memory",
     "get_memory_path",

--- a/pydantic_deep/toolsets/memory.py
+++ b/pydantic_deep/toolsets/memory.py
@@ -19,6 +19,17 @@ from pydantic_ai.messages import InstructionPart
 from pydantic_ai.toolsets import FunctionToolset
 from pydantic_ai_backends import BackendProtocol
 
+
+class MemoryAccessError(Exception):
+    """The backend denied access to the memory path.
+
+    Raised by `load_memory` when a read fails for a reason other than the
+    file being missing or empty (e.g. the memory directory is outside the
+    backend's allowed directories). This keeps a genuine permission/backend
+    failure distinguishable from "no memory saved yet" — see issue #135.
+    """
+
+
 DEFAULT_MEMORY_DIR: str = "/.deep/memory"
 """Default base directory for memory files in the backend."""
 
@@ -89,7 +100,10 @@ def load_memory(
 ) -> MemoryFile | None:
     """Load memory file from backend.
 
-    Returns None if the file doesn't exist.
+    Returns None when the file is genuinely missing or empty. Raises
+    `MemoryAccessError` when the backend denies access to the path, so a
+    misconfigured memory directory is not silently reported as empty memory
+    (issue #135).
 
     Args:
         backend: Backend to read from.
@@ -97,13 +111,24 @@ def load_memory(
         agent_name: Name of the agent owning this memory.
 
     Returns:
-        MemoryFile if found, None otherwise.
+        MemoryFile if found, None if missing or empty.
+
+    Raises:
+        MemoryAccessError: If the backend denied access to the path.
     """
     raw = backend.read_bytes(path)
-    if not raw:
-        return None
-    content = raw.decode("utf-8", errors="replace")
-    return MemoryFile(agent_name=agent_name, path=path, content=content)
+    if raw:
+        content = raw.decode("utf-8", errors="replace")
+        return MemoryFile(agent_name=agent_name, path=path, content=content)
+
+    # `read_bytes` returns empty for missing, empty, AND denied paths — they
+    # are indistinguishable there. Probe via `read`, which surfaces access
+    # errors as an "Error: ..." string while reporting a missing file as
+    # "Error: ... not found". Anything else (or empty) is missing/empty memory.
+    probe = backend.read(path)
+    if probe.startswith("Error:") and "not found" not in probe.lower():
+        raise MemoryAccessError(probe.removeprefix("Error:").strip() or "access denied")
+    return None
 
 
 def format_memory_prompt(memory: MemoryFile, max_lines: int) -> str:
@@ -175,7 +200,10 @@ class AgentMemoryToolset(FunctionToolset[Any]):
         async def read_memory(ctx: RunContext[Any]) -> str:
             """Read your persistent memory."""
             backend: BackendProtocol = ctx.deps.backend
-            mem = load_memory(backend, self._path, self._agent_name)
+            try:
+                mem = load_memory(backend, self._path, self._agent_name)
+            except MemoryAccessError as exc:
+                return f"Error: cannot read memory at '{self._path}': {exc}"
             if mem is None:
                 return "No memory saved yet."
             return mem.content
@@ -188,9 +216,14 @@ class AgentMemoryToolset(FunctionToolset[Any]):
                 content: Text to append to memory (markdown recommended).
             """
             backend: BackendProtocol = ctx.deps.backend
-            existing = load_memory(backend, self._path, self._agent_name)
+            try:
+                existing = load_memory(backend, self._path, self._agent_name)
+            except MemoryAccessError as exc:
+                return f"Error: cannot access memory at '{self._path}': {exc}"
             new_content = existing.content.rstrip("\n") + "\n\n" + content if existing else content
-            backend.write(self._path, new_content.encode("utf-8"))
+            result = backend.write(self._path, new_content.encode("utf-8"))
+            if result.error:
+                return f"Error: failed to save memory to '{self._path}': {result.error}"
             line_count = len(new_content.splitlines())
             return f"Memory updated ({line_count} lines total)."
 
@@ -211,7 +244,10 @@ class AgentMemoryToolset(FunctionToolset[Any]):
                 new_text: The text to replace it with.
             """
             backend: BackendProtocol = ctx.deps.backend
-            mem = load_memory(backend, self._path, self._agent_name)
+            try:
+                mem = load_memory(backend, self._path, self._agent_name)
+            except MemoryAccessError as exc:
+                return f"Error: cannot access memory at '{self._path}': {exc}"
             if mem is None:
                 return "No memory exists yet. Use write_memory to create it."
             count = mem.content.count(old_text)
@@ -224,7 +260,9 @@ class AgentMemoryToolset(FunctionToolset[Any]):
                     "so it matches exactly once."
                 )
             updated = mem.content.replace(old_text, new_text, 1)
-            backend.write(self._path, updated.encode("utf-8"))
+            result = backend.write(self._path, updated.encode("utf-8"))
+            if result.error:
+                return f"Error: failed to save memory to '{self._path}': {result.error}"
             line_count = len(updated.splitlines())
             return f"Memory updated ({line_count} lines total)."
 
@@ -238,7 +276,13 @@ class AgentMemoryToolset(FunctionToolset[Any]):
             Formatted memory prompt, or None if no memory exists.
         """
         backend: BackendProtocol = ctx.deps.backend
-        mem = load_memory(backend, self._path, self._agent_name)
+        try:
+            mem = load_memory(backend, self._path, self._agent_name)
+        except MemoryAccessError:
+            # Prompt injection runs on every request; a denied path must not
+            # abort the run. Skip injection here — the failure is surfaced
+            # loudly through the read_memory/write_memory tool results instead.
+            return None
         if mem is None:
             return None
         result = format_memory_prompt(mem, self._max_lines)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-deep"
-version = "0.3.24"
+version = "0.3.26"
 description = "Batteries-included agent harness for Python — tool-calling, sandboxed execution, multi-agent teams, and unlimited context on Pydantic AI"
 readme = "README.md"
 keywords = [

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -556,3 +556,114 @@ class TestMemoryExports:
         assert DEFAULT_MEMORY_DIR is not None
         assert DEFAULT_MEMORY_FILENAME is not None
         assert DEFAULT_MAX_MEMORY_LINES is not None
+
+
+class _WriteDenyBackend(StateBackend):
+    """StateBackend whose writes are always rejected with a WriteResult error.
+
+    Reads behave normally, so this isolates the "memory is readable but the
+    backend refuses to persist the write" path (issue #135) — distinct from a
+    path the backend denies for reading too.
+    """
+
+    def write(self, path, content):  # type: ignore[override]
+        from pydantic_ai_backends import WriteResult
+
+        return WriteResult(error="disk quota exceeded")
+
+
+def _denied_backend_and_dir(tmp_path):
+    """A LocalBackend whose allowed dir excludes the memory directory."""
+    from pydantic_ai_backends import LocalBackend
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    backend = LocalBackend(root_dir=str(workspace), allowed_directories=[str(workspace)])
+    memory_dir = str(tmp_path / "outside-memory")
+    return backend, memory_dir
+
+
+class TestMemoryFailureSurfacing:
+    """Issue #135 — backend write/permission failures must be visible."""
+
+    def test_load_memory_raises_on_denied_path(self, tmp_path):
+        """A denied path raises MemoryAccessError, not a silent None."""
+        from pydantic_deep import MemoryAccessError
+
+        backend, memory_dir = _denied_backend_and_dir(tmp_path)
+        path = get_memory_path(memory_dir, "main")
+        try:
+            load_memory(backend, path, "main")
+            raise AssertionError("expected MemoryAccessError")
+        except MemoryAccessError as exc:
+            assert "denied" in str(exc).lower() or "outside" in str(exc).lower()
+
+    def test_load_memory_empty_existing_file_returns_none(self):
+        """An empty (but accessible) file is missing/empty memory, not an error."""
+        backend = StateBackend()
+        path = get_memory_path(DEFAULT_MEMORY_DIR, "main")
+        backend.write(path, b"")
+        assert load_memory(backend, path, "main") is None
+
+    async def test_read_memory_surfaces_denied_access(self, tmp_path):
+        """read_memory reports an error instead of 'No memory saved yet.'."""
+        backend, memory_dir = _denied_backend_and_dir(tmp_path)
+        toolset = AgentMemoryToolset(agent_name="main", memory_dir=memory_dir)
+        ctx = _make_ctx(backend)  # type: ignore[arg-type]
+        result = await toolset.tools["read_memory"].function(ctx)
+        assert result.startswith("Error:")
+        assert "No memory saved yet" not in result
+
+    async def test_write_memory_surfaces_denied_access(self, tmp_path):
+        """write_memory reports the access failure instead of phantom success."""
+        backend, memory_dir = _denied_backend_and_dir(tmp_path)
+        toolset = AgentMemoryToolset(agent_name="main", memory_dir=memory_dir)
+        ctx = _make_ctx(backend)  # type: ignore[arg-type]
+        result = await toolset.tools["write_memory"].function(ctx, content="note")
+        assert result.startswith("Error:")
+        assert "Memory updated" not in result
+
+    async def test_write_memory_surfaces_write_result_error(self):
+        """A rejected backend write is not reported as a successful update."""
+        backend = _WriteDenyBackend()
+        toolset = AgentMemoryToolset(agent_name="main", memory_dir=DEFAULT_MEMORY_DIR)
+        ctx = _make_ctx(backend)  # type: ignore[arg-type]
+        result = await toolset.tools["write_memory"].function(ctx, content="note")
+        assert result.startswith("Error:")
+        assert "disk quota exceeded" in result
+
+    async def test_update_memory_surfaces_denied_access(self, tmp_path):
+        """update_memory reports the access failure instead of normal-looking output."""
+        backend, memory_dir = _denied_backend_and_dir(tmp_path)
+        toolset = AgentMemoryToolset(agent_name="main", memory_dir=memory_dir)
+        ctx = _make_ctx(backend)  # type: ignore[arg-type]
+        result = await toolset.tools["update_memory"].function(ctx, old_text="a", new_text="b")
+        assert result.startswith("Error:")
+
+    async def test_update_memory_surfaces_write_result_error(self):
+        """update_memory does not report success when the backend rejects the write."""
+        backend = _WriteDenyBackend()
+        path = get_memory_path(DEFAULT_MEMORY_DIR, "main")
+        # Seed readable content via the parent StateBackend write (bypassing the override).
+        StateBackend.write(backend, path, b"hello world")
+        toolset = AgentMemoryToolset(agent_name="main", memory_dir=DEFAULT_MEMORY_DIR)
+        ctx = _make_ctx(backend)  # type: ignore[arg-type]
+        result = await toolset.tools["update_memory"].function(
+            ctx, old_text="hello", new_text="bye"
+        )
+        assert result.startswith("Error:")
+        assert "disk quota exceeded" in result
+
+    async def test_get_instructions_skips_denied_memory(self, tmp_path):
+        """A denied memory path must not abort the run; instructions are skipped."""
+        backend, memory_dir = _denied_backend_and_dir(tmp_path)
+        toolset = AgentMemoryToolset(agent_name="main", memory_dir=memory_dir)
+        ctx = _make_ctx(backend)  # type: ignore[arg-type]
+        assert await toolset.get_instructions(ctx) is None
+
+    def test_memory_access_error_exported(self):
+        """MemoryAccessError is importable from the package root."""
+        from pydantic_deep import MemoryAccessError
+        from pydantic_deep.toolsets.memory import MemoryAccessError as direct
+
+        assert MemoryAccessError is direct

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,9 +1,12 @@
 """Tests for persistent agent memory."""
 
+from pathlib import Path
+from typing import Any
+
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import RunContext
 from pydantic_ai.usage import RunUsage
-from pydantic_ai_backends import StateBackend
+from pydantic_ai_backends import StateBackend, WriteResult
 
 from pydantic_deep import (
     DEFAULT_MAX_MEMORY_LINES,
@@ -558,21 +561,26 @@ class TestMemoryExports:
         assert DEFAULT_MAX_MEMORY_LINES is not None
 
 
-class _WriteDenyBackend(StateBackend):
-    """StateBackend whose writes are always rejected with a WriteResult error.
+def _write_deny_backend(seed_path: str | None = None, seed: bytes = b"") -> Any:
+    """A StateBackend whose reads work but whose writes are always rejected.
 
-    Reads behave normally, so this isolates the "memory is readable but the
-    backend refuses to persist the write" path (issue #135) — distinct from a
-    path the backend denies for reading too.
+    Isolates the "memory is readable but the backend refuses to persist the
+    write" path (issue #135). When `seed_path` is given, content is written
+    (via the real `write`) before write-denial is installed, so the read side
+    still returns it.
     """
+    backend = StateBackend()
+    if seed_path is not None:
+        backend.write(seed_path, seed)
 
-    def write(self, path, content):  # type: ignore[override]
-        from pydantic_ai_backends import WriteResult
-
+    def _deny(path: str, content: bytes | str) -> WriteResult:
         return WriteResult(error="disk quota exceeded")
 
+    backend.write = _deny
+    return backend
 
-def _denied_backend_and_dir(tmp_path):
+
+def _denied_backend_and_dir(tmp_path: Path) -> tuple[Any, str]:
     """A LocalBackend whose allowed dir excludes the memory directory."""
     from pydantic_ai_backends import LocalBackend
 
@@ -609,7 +617,7 @@ class TestMemoryFailureSurfacing:
         """read_memory reports an error instead of 'No memory saved yet.'."""
         backend, memory_dir = _denied_backend_and_dir(tmp_path)
         toolset = AgentMemoryToolset(agent_name="main", memory_dir=memory_dir)
-        ctx = _make_ctx(backend)  # type: ignore[arg-type]
+        ctx = _make_ctx(backend)
         result = await toolset.tools["read_memory"].function(ctx)
         assert result.startswith("Error:")
         assert "No memory saved yet" not in result
@@ -618,16 +626,16 @@ class TestMemoryFailureSurfacing:
         """write_memory reports the access failure instead of phantom success."""
         backend, memory_dir = _denied_backend_and_dir(tmp_path)
         toolset = AgentMemoryToolset(agent_name="main", memory_dir=memory_dir)
-        ctx = _make_ctx(backend)  # type: ignore[arg-type]
+        ctx = _make_ctx(backend)
         result = await toolset.tools["write_memory"].function(ctx, content="note")
         assert result.startswith("Error:")
         assert "Memory updated" not in result
 
     async def test_write_memory_surfaces_write_result_error(self):
         """A rejected backend write is not reported as a successful update."""
-        backend = _WriteDenyBackend()
+        backend = _write_deny_backend()
         toolset = AgentMemoryToolset(agent_name="main", memory_dir=DEFAULT_MEMORY_DIR)
-        ctx = _make_ctx(backend)  # type: ignore[arg-type]
+        ctx = _make_ctx(backend)
         result = await toolset.tools["write_memory"].function(ctx, content="note")
         assert result.startswith("Error:")
         assert "disk quota exceeded" in result
@@ -636,18 +644,17 @@ class TestMemoryFailureSurfacing:
         """update_memory reports the access failure instead of normal-looking output."""
         backend, memory_dir = _denied_backend_and_dir(tmp_path)
         toolset = AgentMemoryToolset(agent_name="main", memory_dir=memory_dir)
-        ctx = _make_ctx(backend)  # type: ignore[arg-type]
+        ctx = _make_ctx(backend)
         result = await toolset.tools["update_memory"].function(ctx, old_text="a", new_text="b")
         assert result.startswith("Error:")
 
     async def test_update_memory_surfaces_write_result_error(self):
         """update_memory does not report success when the backend rejects the write."""
-        backend = _WriteDenyBackend()
         path = get_memory_path(DEFAULT_MEMORY_DIR, "main")
-        # Seed readable content via the parent StateBackend write (bypassing the override).
-        StateBackend.write(backend, path, b"hello world")
+        # Seed readable content first, then make subsequent writes fail.
+        backend = _write_deny_backend(seed_path=path, seed=b"hello world")
         toolset = AgentMemoryToolset(agent_name="main", memory_dir=DEFAULT_MEMORY_DIR)
-        ctx = _make_ctx(backend)  # type: ignore[arg-type]
+        ctx = _make_ctx(backend)
         result = await toolset.tools["update_memory"].function(
             ctx, old_text="hello", new_text="bye"
         )
@@ -658,7 +665,7 @@ class TestMemoryFailureSurfacing:
         """A denied memory path must not abort the run; instructions are skipped."""
         backend, memory_dir = _denied_backend_and_dir(tmp_path)
         toolset = AgentMemoryToolset(agent_name="main", memory_dir=memory_dir)
-        ctx = _make_ctx(backend)  # type: ignore[arg-type]
+        ctx = _make_ctx(backend)
         assert await toolset.get_instructions(ctx) is None
 
     def test_memory_access_error_exported(self):

--- a/tests/test_tui_forking.py
+++ b/tests/test_tui_forking.py
@@ -463,12 +463,21 @@ class TestForkTabsCostRender:
             # watch_statuses mounts chips async while watch_branch_costs is sync.
             tabs.statuses = statuses
             tabs.branch_costs = costs
-            await pilot.pause()
-            await pilot.pause()
 
+            # The chip mounts asynchronously and the cost is re-applied once it
+            # exists, so poll until it lands rather than guessing a fixed pause
+            # count — the fixed-count version flaked under full-suite load.
             sid = statuses[0].id
-            chip = tabs.query_one(f"#fork-tab-{sid}", Static)
-            text = str(getattr(chip, "content", ""))
+            text = ""
+            for _ in range(50):
+                await pilot.pause()
+                try:
+                    chip = tabs.query_one(f"#fork-tab-{sid}", Static)
+                except Exception:
+                    continue
+                text = str(getattr(chip, "content", ""))
+                if "$0.42" in text:
+                    break
             assert "$0.42" in text, f"cost missing from chip text: {text!r}"
 
             await session.abort()


### PR DESCRIPTION
AgentMemoryToolset could report a successful persistent-memory write even when the backend rejected it, and could turn a denied memory read into the same "No memory saved yet." result as a genuinely empty file — making a misconfigured memory directory look like normal empty memory.

- write_memory/update_memory now inspect WriteResult.error and return an explicit error instead of a phantom "Memory updated (...)".
- New MemoryAccessError lets load_memory distinguish denied from missing/empty: since backend.read_bytes() collapses missing/empty/denied to empty bytes, it now disambiguates via backend.read() (access errors vs "... not found") and raises only on a real access failure. read_memory / update_memory surface it; get_instructions swallows it so prompt injection never aborts a run. Genuinely missing memory still returns the normal message.

Adds regression tests (LocalBackend denial + write-deny fake); memory.py stays at 100% line/branch coverage. Bump version to 0.3.26.

## Summary

<!-- What does this PR do? What problem does it solve? -->

## Changes

<!-- List the key changes made in this PR -->
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] New tests added for any new functionality (required — `make test` enforces 100% coverage)
- [ ] All tests pass locally: `make test`
- [ ] Linting passes: `make lint`
- [ ] Type checking passes: `make typecheck`
- [ ] Security scan passes: `make security`
- [ ] Full check suite passes: `make all`

## Related Issues

<!-- Link to any related issues: "Fixes #123" or "Closes #456" -->

## Notes for Reviewers

<!-- Anything the reviewer should pay special attention to? -->
