### PR TITLE
feat(agent): forward subagent usage limits via create_deep_agent (subagents#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.26] - 2026-06-07
+## [0.3.27] - 2026-06-07
+
+### Added
+
+- **`subagent_usage_limits` on `create_deep_agent()`** ([subagents-pydantic-ai#43](https://github.com/vstorm-co/subagents-pydantic-ai/issues/43)) (`pydantic_deep/agent.py`). Deep-agent construction now forwards delegated-subagent usage limits straight into `create_subagent_toolset(usage_limits=...)`, so downstream callers no longer have to disable `include_subagents`, build the subagent toolset by hand, and re-wire the delegation prompt + task manager just to raise a specialist's `request_limit`. Accepts either a static `UsageLimits` (same budget for every delegated `agent.run(...)`, including retries) or a `UsageLimitsFactory` (`(ctx, config) -> UsageLimits | None`) that resolves per-specialist limits from the selected `SubAgentConfig` — e.g. a small budget for lightweight specialists and a larger one for heavy research/execution agents. Defaults to `None` (pydantic-ai's own default limit stays in place); only applies when `include_subagents=True`. The underlying capability already existed in `subagents-pydantic-ai`; this exposes it through the normal public deep-agent API.
 
 ### Fixed
 

--- a/pydantic_deep/agent.py
+++ b/pydantic_deep/agent.py
@@ -8,7 +8,7 @@ from collections.abc import AsyncIterator, Callable, Sequence
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, TypeVar, overload
 
-from pydantic_ai import Agent
+from pydantic_ai import Agent, UsageLimits
 from pydantic_ai._agent_graph import HistoryProcessor
 from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.exceptions import ModelAPIError
@@ -25,7 +25,11 @@ from pydantic_ai_backends import (
     get_console_system_prompt,
 )
 from pydantic_ai_todo import create_todo_toolset, get_todo_system_prompt
-from subagents_pydantic_ai import create_subagent_toolset, get_subagent_system_prompt
+from subagents_pydantic_ai import (
+    UsageLimitsFactory,
+    create_subagent_toolset,
+    get_subagent_system_prompt,
+)
 
 from pydantic_deep.capabilities.hooks import HookEvent
 from pydantic_deep.deps import DeepAgentDeps
@@ -311,6 +315,7 @@ def create_deep_agent(
     max_nesting_depth: int = 1,
     subagent_registry: Any | None = None,
     subagent_extra_toolsets: Sequence[AbstractToolset[Any]] | None = None,
+    subagent_usage_limits: UsageLimits | UsageLimitsFactory | None = None,
     include_execute: bool | None = None,
     interrupt_on: dict[str, bool] | None = None,
     output_type: None = None,
@@ -387,6 +392,7 @@ def create_deep_agent(
     max_nesting_depth: int = 1,
     subagent_registry: Any | None = None,
     subagent_extra_toolsets: Sequence[AbstractToolset[Any]] | None = None,
+    subagent_usage_limits: UsageLimits | UsageLimitsFactory | None = None,
     include_execute: bool | None = None,
     interrupt_on: dict[str, bool] | None = None,
     *,
@@ -463,6 +469,7 @@ def create_deep_agent(  # noqa: C901
     max_nesting_depth: int = 1,
     subagent_registry: Any | None = None,
     subagent_extra_toolsets: Sequence[AbstractToolset[Any]] | None = None,
+    subagent_usage_limits: UsageLimits | UsageLimitsFactory | None = None,
     include_execute: bool | None = None,
     interrupt_on: dict[str, bool] | None = None,
     output_type: OutputSpec[OutputDataT] | None = None,
@@ -564,6 +571,16 @@ def create_deep_agent(  # noqa: C901
         subagent_registry: Optional DynamicAgentRegistry instance. When provided,
             the task tool will also look up dynamically created agents from
             the registry (created via create_agent_factory_toolset).
+        subagent_usage_limits: `UsageLimits` applied to delegated subagent
+            `agent.run(...)` calls (including retries), forwarded to
+            `create_subagent_toolset(usage_limits=...)`. Pass a single
+            `UsageLimits` to use the same budget for every delegated run, or a
+            `UsageLimitsFactory` (`(ctx, config) -> UsageLimits | None`) to
+            resolve per-specialist limits by reading the selected
+            `SubAgentConfig` — e.g. a small budget for lightweight specialists
+            and a larger `request_limit` for heavy research/execution ones.
+            `None` (default) leaves pydantic-ai's own default in place. Only
+            takes effect when `include_subagents=True`.
         include_execute: Whether to include the execute tool. If None (default),
             automatically determined based on whether backend is a SandboxProtocol.
             Set to True to force include even when backend is None (useful when
@@ -897,6 +914,7 @@ def create_deep_agent(  # noqa: C901
             include_general_purpose=False,  # We use our own built-in subagents
             max_nesting_depth=max_nesting_depth,
             registry=subagent_registry,
+            usage_limits=subagent_usage_limits,
         )
         all_toolsets.append(subagent_toolset)
         _subagent_task_manager = getattr(subagent_toolset, "task_manager", None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-deep"
-version = "0.3.26"
+version = "0.3.27"
 description = "Batteries-included agent harness for Python — tool-calling, sandboxed execution, multi-agent teams, and unlimited context on Pydantic AI"
 readme = "README.md"
 keywords = [

--- a/tests/test_agent_extended.py
+++ b/tests/test_agent_extended.py
@@ -1,7 +1,7 @@
 """Extended tests for agent factory to reach 100% coverage."""
 
 from collections.abc import Awaitable
-from typing import cast
+from typing import Any, cast
 
 from pydantic_ai.exceptions import ModelAPIError
 from pydantic_ai.models.fallback import FallbackModel
@@ -715,3 +715,55 @@ class TestFallbackModel:
             async for _ in stream:
                 pass
         assert _fallback_hop_cv.get() == 0
+
+
+class TestSubagentUsageLimits:
+    """subagents#43 — create_deep_agent forwards delegated usage limits."""
+
+    def _spy_toolset(self, monkeypatch: Any) -> dict[str, Any]:
+        """Patch create_subagent_toolset to capture its kwargs, still building it."""
+        from subagents_pydantic_ai import create_subagent_toolset as real
+
+        captured: dict[str, Any] = {}
+
+        def _spy(*args: Any, **kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr("pydantic_deep.agent.create_subagent_toolset", _spy)
+        return captured
+
+    def test_static_usage_limits_forwarded(self, monkeypatch: Any) -> None:
+        """A static UsageLimits reaches create_subagent_toolset unchanged."""
+        from pydantic_ai import UsageLimits
+
+        captured = self._spy_toolset(monkeypatch)
+        limits = UsageLimits(request_limit=123)
+        create_deep_agent(
+            model=TEST_MODEL,
+            include_subagents=True,
+            subagent_usage_limits=limits,
+        )
+        assert captured["usage_limits"] is limits
+
+    def test_factory_usage_limits_forwarded(self, monkeypatch: Any) -> None:
+        """A UsageLimitsFactory is forwarded as-is for per-config resolution."""
+        from pydantic_ai import UsageLimits
+
+        captured = self._spy_toolset(monkeypatch)
+
+        def _factory(ctx: Any, config: Any) -> UsageLimits:  # pragma: no cover
+            return UsageLimits(request_limit=config.get("extra", {}).get("limit", 50))
+
+        create_deep_agent(
+            model=TEST_MODEL,
+            include_subagents=True,
+            subagent_usage_limits=_factory,
+        )
+        assert captured["usage_limits"] is _factory
+
+    def test_usage_limits_default_none(self, monkeypatch: Any) -> None:
+        """Omitting the param forwards None (pydantic-ai default stays in place)."""
+        captured = self._spy_toolset(monkeypatch)
+        create_deep_agent(model=TEST_MODEL, include_subagents=True)
+        assert captured["usage_limits"] is None

--- a/tests/test_tui_forking.py
+++ b/tests/test_tui_forking.py
@@ -120,6 +120,26 @@ async def _drain_tasks(session: CLIForkSession) -> None:
                 await asyncio.wait_for(asyncio.shield(runtime.task), timeout=1.0)
 
 
+def _quiesce_fork_poll(app: DeepApp) -> None:
+    """Stop the screen's fork poll loop so it can't replay into a panel that a
+    unit test drives by hand.
+
+    The live ``_poll_fork_state`` timer calls ``mark_status`` / ``replay_messages``
+    on the branch panels every tick. Tests in :class:`TestIncrementalReplay`
+    reset ``_last_replayed_len`` and assert exact watermark/child counts, so a
+    poll tick landing mid-test bumps the watermark nondeterministically (flaky
+    under full-suite ordering). Stopping the timer isolates the panel.
+    """
+    import contextlib
+
+    screen: Any = app.screen
+    timer = getattr(screen, "_poll_timer", None)
+    if timer is not None:
+        with contextlib.suppress(Exception):
+            timer.stop()
+        screen._poll_timer = None
+
+
 def _capture_notifications(app: DeepApp) -> list[str]:
     """Monkey-patch `app.notify` to capture messages into a returned list."""
     captured: list[str] = []
@@ -1598,6 +1618,7 @@ class TestIncrementalReplay:
             await pilot.pause()
 
             panel = list(fork_app.screen.query(BranchPanelWidget))[0]
+            _quiesce_fork_poll(fork_app)
             panel._last_replayed_len = 0
 
             msg1 = [ModelResponse(parts=[TextPart(content="hello")])]
@@ -1622,6 +1643,7 @@ class TestIncrementalReplay:
             await pilot.pause()
 
             panel = list(fork_app.screen.query(BranchPanelWidget))[0]
+            _quiesce_fork_poll(fork_app)
             panel._last_replayed_len = 0
 
             streamed = [
@@ -1656,6 +1678,7 @@ class TestIncrementalReplay:
             await pilot.pause()
 
             panel = list(fork_app.screen.query(BranchPanelWidget))[0]
+            _quiesce_fork_poll(fork_app)
             panel._last_replayed_len = 0
             panel._rendered_call_ids = set()
 
@@ -1697,6 +1720,7 @@ class TestIncrementalReplay:
             await pilot.pause()
 
             panel = list(fork_app.screen.query(BranchPanelWidget))[0]
+            _quiesce_fork_poll(fork_app)
             panel._last_replayed_len = 0
             panel._rendered_call_ids = set()
 
@@ -1748,6 +1772,7 @@ class TestIncrementalReplay:
             await pilot.pause()
 
             panel = list(fork_app.screen.query(BranchPanelWidget))[0]
+            _quiesce_fork_poll(fork_app)
             msg_list = panel.query_one(MessageList)
             # Start from a clean panel (the fork setup pre-populates it).
             msg_list.clear_messages()
@@ -1788,6 +1813,7 @@ class TestIncrementalReplay:
             await pilot.pause()
 
             panel = list(fork_app.screen.query(BranchPanelWidget))[0]
+            _quiesce_fork_poll(fork_app)
             panel._last_replayed_len = 0
 
             msgs = [
@@ -1824,6 +1850,7 @@ class TestIncrementalReplay:
             await pilot.pause()
 
             panel = list(fork_app.screen.query(BranchPanelWidget))[0]
+            _quiesce_fork_poll(fork_app)
 
             messages = [
                 ModelResponse(
@@ -1862,6 +1889,7 @@ class TestIncrementalReplay:
             await pilot.pause()
 
             panel = list(fork_app.screen.query(BranchPanelWidget))[0]
+            _quiesce_fork_poll(fork_app)
             panel._last_replayed_len = 0
 
             msgs = [


### PR DESCRIPTION
Downstream deep-agent users needed a public way to pass per-subagent UsageLimits into delegated agent.run(...) calls without rebuilding the subagent toolset by hand. subagents-pydantic-ai already supports create_subagent_toolset(usage_limits=...) (static or UsageLimitsFactory); the gap was that create_deep_agent built the toolset internally and never exposed the argument.

Add subagent_usage_limits: UsageLimits | UsageLimitsFactory | None = None to create_deep_agent (both overloads + impl) and forward it to create_subagent_toolset. A factory resolves per-specialist limits from the selected SubAgentConfig; None keeps pydantic-ai's default. Only applies when include_subagents=True.

Adds forwarding tests (static, factory, default-None); pydantic_deep stays at 100% coverage. Bump version to 0.3.27.

## Summary

<!-- What does this PR do? What problem does it solve? -->

## Changes

<!-- List the key changes made in this PR -->
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] New tests added for any new functionality (required — `make test` enforces 100% coverage)
- [ ] All tests pass locally: `make test`
- [ ] Linting passes: `make lint`
- [ ] Type checking passes: `make typecheck`
- [ ] Security scan passes: `make security`
- [ ] Full check suite passes: `make all`

## Related Issues

<!-- Link to any related issues: "Fixes #123" or "Closes #456" -->

## Notes for Reviewers

<!-- Anything the reviewer should pay special attention to? -->
