### PR TITLE
chore(release): 0.3.28 — bump pydantic-ai-backend to >=0.2.11; restore lost 0.3.26 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.28] - 2026-06-07
+
+### Changed
+
+- **Bumped `pydantic-ai-backend` to `>=0.2.11`** (`pyproject.toml`, `console` + `docker` extras). 0.2.11 adds `document_support` / `max_document_bytes` to `create_console_toolset`, so `read_file` can return PDFs as `BinaryContent(application/pdf)` for document-capable models ([pydantic-ai-backend#48](https://github.com/vstorm-co/pydantic-ai-backend/pull/48)) instead of the empty string the binary-unaware text path produced.
+
 ## [0.3.27] - 2026-06-07
 
 ### Added
 
 - **`subagent_usage_limits` on `create_deep_agent()`** ([subagents-pydantic-ai#43](https://github.com/vstorm-co/subagents-pydantic-ai/issues/43)) (`pydantic_deep/agent.py`). Deep-agent construction now forwards delegated-subagent usage limits straight into `create_subagent_toolset(usage_limits=...)`, so downstream callers no longer have to disable `include_subagents`, build the subagent toolset by hand, and re-wire the delegation prompt + task manager just to raise a specialist's `request_limit`. Accepts either a static `UsageLimits` (same budget for every delegated `agent.run(...)`, including retries) or a `UsageLimitsFactory` (`(ctx, config) -> UsageLimits | None`) that resolves per-specialist limits from the selected `SubAgentConfig` — e.g. a small budget for lightweight specialists and a larger one for heavy research/execution agents. Defaults to `None` (pydantic-ai's own default limit stays in place); only applies when `include_subagents=True`. The underlying capability already existed in `subagents-pydantic-ai`; this exposes it through the normal public deep-agent API.
+
+## [0.3.26] - 2026-06-07
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-deep"
-version = "0.3.27"
+version = "0.3.28"
 description = "Batteries-included agent harness for Python — tool-calling, sandboxed execution, multi-agent teams, and unlimited context on Pydantic AI"
 readme = "README.md"
 keywords = [
@@ -42,7 +42,7 @@ classifiers = [
 dependencies = [
     "pydantic-ai-slim[web-fetch]>=1.97.0",
     "pydantic-ai-todo>=0.2.4",
-    "pydantic-ai-backend[console]>=0.2.10",
+    "pydantic-ai-backend[console]>=0.2.11",
     "summarization-pydantic-ai>=0.1.7",
     "subagents-pydantic-ai>=0.2.7",
     "pydantic-ai-shields>=0.3.4",
@@ -52,7 +52,7 @@ dependencies = [
 
 [project.optional-dependencies]
 # Docker sandbox support
-sandbox = ["pydantic-ai-backend[docker]>=0.2.10"]
+sandbox = ["pydantic-ai-backend[docker]>=0.2.11"]
 # YAML support for skills (pyyaml-based frontmatter parsing)
 yaml = ["pyyaml>=6.0"]
 # CLI tools + TUI (terminal assistant)


### PR DESCRIPTION
- Bump pydantic-ai-backend (console + docker extras) 0.2.10 -> 0.2.11, which adds document_support so read_file returns PDFs as BinaryContent (pydantic-ai-backend#48). Full suite green against 0.2.11.
- Fix CHANGELOG: the 0.3.27 commit accidentally replaced the "## [0.3.26]" header instead of inserting 0.3.27 above it, so the 0.3.26 section vanished and its memory-tools fix was listed under 0.3.27. Restore the 0.3.26 header so each fix sits under its own version.
- Bump version 0.3.27 -> 0.3.28.

## Summary

<!-- What does this PR do? What problem does it solve? -->

## Changes

<!-- List the key changes made in this PR -->
-
-

## Testing

<!-- Describe how you tested your changes -->

- [ ] New tests added for any new functionality (required — `make test` enforces 100% coverage)
- [ ] All tests pass locally: `make test`
- [ ] Linting passes: `make lint`
- [ ] Type checking passes: `make typecheck`
- [ ] Security scan passes: `make security`
- [ ] Full check suite passes: `make all`

## Related Issues

<!-- Link to any related issues: "Fixes #123" or "Closes #456" -->

## Notes for Reviewers

<!-- Anything the reviewer should pay special attention to? -->
