### PR TITLE
feat: migrate from sync BackendProtocol to async AsyncBackendProtocol

### DIFF
--- a/apps/cli/commands.py
+++ b/apps/cli/commands.py
@@ -736,7 +736,7 @@ async def _dispatch_merge(app: DeepApp) -> None:
     if session is None:
         app.notify("No active fork — type /fork to start one", severity="warning")
         return
-    report = session.build_diff()
+    report = await session.build_diff()
     if report is None:  # pragma: no cover - defensive: session implies a live fork
         app.notify("Cannot build diff report", severity="error")
         return
@@ -776,7 +776,7 @@ async def _dispatch_merge(app: DeepApp) -> None:
             return
         await _commit_pick(picked.branch_id)
 
-    def _on_open_in_editor(branch_id: str) -> None:
+    async def _on_open_in_editor(branch_id: str) -> None:
         """Bridge the merge picker's `o` binding into the diff picker.
 
         The merge picker passes the currently-highlighted branch id; we
@@ -793,7 +793,7 @@ async def _dispatch_merge(app: DeepApp) -> None:
                 severity="warning",
             )
             return
-        _open_diff_picker(app, kind=kind, initial_branch_id=branch_id)
+        await _open_diff_picker(app, kind=kind, initial_branch_id=branch_id)
 
     def _push_picker(
         *,
@@ -1074,7 +1074,7 @@ async def _dispatch_fork_open_diff(app: DeepApp, _path_arg: str | None) -> None:
 
     kind = EditorDetector.detect()
     if kind == "tui":
-        report = session.build_diff()
+        report = await session.build_diff()
         if report is None:  # pragma: no cover - defensive
             app.notify("Cannot build diff report", severity="error")
             return
@@ -1084,7 +1084,7 @@ async def _dispatch_fork_open_diff(app: DeepApp, _path_arg: str | None) -> None:
         app.push_screen(MergePickerModal(report, statuses, session.label_to_id, view_only=True))
         return
 
-    _open_diff_picker(app, kind=kind, initial_branch_id=None)
+    await _open_diff_picker(app, kind=kind, initial_branch_id=None)
 
 
 def _labeled_symlinks(
@@ -1119,7 +1119,7 @@ def _labeled_symlinks(
     return None, sym_branches
 
 
-def _open_diff_picker(
+async def _open_diff_picker(
     app: DeepApp,
     *,
     kind: str,
@@ -1136,7 +1136,7 @@ def _open_diff_picker(
     session = app.active_fork
     if session is None:  # pragma: no cover - defensive: caller already checked
         return
-    report = session.build_diff()
+    report = await session.build_diff()
     if report is None:  # pragma: no cover - defensive
         app.notify("Cannot build diff report", severity="error")
         return

--- a/apps/cli/forking.py
+++ b/apps/cli/forking.py
@@ -171,12 +171,12 @@ class CLIForkSession:
         """Return a snapshot of every branch's current status."""
         return self.coordinator.inspect_branches()
 
-    def build_diff(self) -> BranchDiffReport | None:
+    async def build_diff(self) -> BranchDiffReport | None:
         """Build a :class:`BranchDiffReport` over the active fork, or `None` if not yet forked."""
         fork_id = self.coordinator.fork_id
         if fork_id is None:  # pragma: no cover - defensive: a CLIForkSession only exists post-fork
             return None
-        return build_diff_report(fork_id, list(self.coordinator.branches.values()))
+        return await build_diff_report(fork_id, list(self.coordinator.branches.values()))
 
 
 async def start_fork_from_cli(

--- a/apps/cli/modals/merge_picker.py
+++ b/apps/cli/modals/merge_picker.py
@@ -14,6 +14,7 @@ Returns the chosen branch id or `None` on cancel.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -257,7 +258,9 @@ class MergePickerModal(ModalScreen["MergePickerResult | None"]):
             return
         branch_id = self._ordered_ids[self._selected_index]
         with contextlib.suppress(Exception):  # pragma: no cover - defensive
-            callback(branch_id)
+            result = callback(branch_id)
+            if asyncio.isfuture(result) or asyncio.iscoroutine(result):
+                asyncio.ensure_future(result)
 
     def action_move_prev(self) -> None:
         if not self._ordered_ids:

--- a/apps/deepresearch/src/deepresearch/app.py
+++ b/apps/deepresearch/src/deepresearch/app.py
@@ -824,7 +824,7 @@ async def websocket_chat(websocket: WebSocket):  # noqa: C901
                     data = b64.b64decode(att["data"])
 
                     # Save to container first
-                    upload_path = session.deps.upload_file(name, data)
+                    upload_path = await session.deps.upload_file(name, data)
                     logger.info(f"Attachment saved: {name} ({len(data)} bytes) -> {upload_path}")
 
                     if media_type.startswith("image/"):
@@ -1349,7 +1349,7 @@ async def upload_file(
 
         logger.info(f"Uploading file: {filename} ({len(content)} bytes) to session {session_id}")
 
-        path = session.deps.upload_file(filename, content)
+        path = await session.deps.upload_file(filename, content)
         logger.info(f"File uploaded to: {path}")
 
         return JSONResponse(

--- a/examples/file_uploads.py
+++ b/examples/file_uploads.py
@@ -69,8 +69,8 @@ async def example_direct_upload():
     deps = DeepAgentDeps(backend=StateBackend())
 
     # Upload multiple files
-    deps.upload_file("config.json", b'{"debug": true, "max_workers": 4}')
-    deps.upload_file(
+    await deps.upload_file("config.json", b'{"debug": true, "max_workers": 4}')
+    await deps.upload_file(
         "settings.json",
         b'{"theme": "dark", "language": "en"}',
         upload_dir="/configs",  # Custom upload directory
@@ -114,7 +114,7 @@ async def example_large_file():
 
     log_data = "\n".join(log_lines).encode("utf-8")
 
-    deps.upload_file("app.log", log_data)
+    await deps.upload_file("app.log", log_data)
 
     print("\nUploaded files:")
     for path, info in deps.uploads.items():
@@ -142,7 +142,7 @@ async def example_binary_file():
 
     # Upload a binary file (e.g., image header simulation)
     binary_data = bytes([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])  # PNG header
-    deps.upload_file("image.png", binary_data)
+    await deps.upload_file("image.png", binary_data)
 
     print("\nUploaded files:")
     for path, info in deps.uploads.items():

--- a/examples/full_app/app.py
+++ b/examples/full_app/app.py
@@ -865,7 +865,7 @@ async def websocket_chat(websocket: WebSocket):  # noqa: C901
                     data = b64.b64decode(att["data"])
 
                     # Save to container first
-                    upload_path = session.deps.upload_file(name, data)
+                    upload_path = await session.deps.upload_file(name, data)
                     logger.info(f"Attachment saved: {name} ({len(data)} bytes) -> {upload_path}")
 
                     if media_type.startswith("image/"):
@@ -1334,7 +1334,7 @@ async def upload_file(
         logger.info(f"Uploading file: {filename} ({len(content)} bytes) to session {session_id}")
 
         # Upload to the session's backend (Docker container)
-        path = session.deps.upload_file(filename, content)
+        path = await session.deps.upload_file(filename, content)
         logger.info(f"File uploaded to: {path}")
 
         # Verify the file exists in the container (if backend supports execute)

--- a/pydantic_deep/agent.py
+++ b/pydantic_deep/agent.py
@@ -112,9 +112,12 @@ def _wrap_with_fallback_and_hooks(
     exhausted) without emitting a spurious event.
     """
 
+    from pydantic_ai_backends import ensure_async
+
     from pydantic_deep.capabilities.hooks import HooksCapability
 
     hooks_cap = HooksCapability(hooks=fallback_hooks)
+    async_backend = ensure_async(backend)
     # Build a flat list of model names for accurate from/to reporting.
     model_chain: list[str] = [primary if isinstance(primary, str) else str(primary)] + [
         f if isinstance(f, str) else str(f) for f in fallbacks
@@ -138,7 +141,7 @@ def _wrap_with_fallback_and_hooks(
         # Only fire the hook when there is actually a next model to fall back to.
         if hop < len(fallbacks):
             await hooks_cap.dispatch_model_fallback(
-                model_chain[hop], model_chain[hop + 1], exc, backend
+                model_chain[hop], model_chain[hop + 1], exc, async_backend
             )
         return True
 

--- a/pydantic_deep/agent.py
+++ b/pydantic_deep/agent.py
@@ -873,8 +873,8 @@ def create_deep_agent(  # noqa: C901
             image_support=True,
             edit_format=edit_format,  # type: ignore[arg-type,unused-ignore]
         )
-        _set_toolset_retries(console_toolset, retries)
-        all_toolsets.append(console_toolset)
+        _set_toolset_retries(console_toolset, retries)  # type: ignore[arg-type,unused-ignore]
+        all_toolsets.append(console_toolset)  # type: ignore[arg-type,unused-ignore]
 
     _subagent_task_manager: Any | None = None
     subagent_toolset: Any | None = None
@@ -1425,7 +1425,7 @@ async def run_with_files(
     """
     # Upload files (batch)
     if files:
-        deps.upload_files(files, upload_dir=upload_dir)
+        await deps.upload_files(files, upload_dir=upload_dir)
 
     # Run agent
     result = await agent.run(query, deps=deps)

--- a/pydantic_deep/agent.py
+++ b/pydantic_deep/agent.py
@@ -22,6 +22,7 @@ from pydantic_ai_backends import (
     SandboxProtocol,
     StateBackend,
     create_console_toolset,
+    ensure_async,
     get_console_system_prompt,
 )
 from pydantic_ai_todo import create_todo_toolset, get_todo_system_prompt
@@ -1194,7 +1195,7 @@ def create_deep_agent(  # noqa: C901
 
         all_capabilities.append(
             EvictionCapability(
-                backend=backend,
+                backend=ensure_async(backend),
                 token_limit=_eviction_token_limit,
                 max_binary_content=_max_binary_content,
                 on_eviction=_on_eviction,

--- a/pydantic_deep/capabilities/hooks.py
+++ b/pydantic_deep/capabilities/hooks.py
@@ -217,8 +217,10 @@ async def _run_hook(
     backend: AsyncSandboxProtocol | None,
 ) -> HookResult:
     """Run a single hook (command or handler)."""
+    from pydantic_deep.deps import unwrap_backend
+
     if hook.command is not None:
-        if backend is None or not hasattr(backend, "execute"):
+        if backend is None or not isinstance(unwrap_backend(backend), SandboxProtocol):
             msg = (
                 "Command hooks require a AsyncSandboxProtocol backend "
                 "(LocalBackend or DockerSandbox). "
@@ -245,8 +247,10 @@ def _get_sandbox_backend(deps: DeepAgentDeps | None) -> AsyncSandboxProtocol | N
     """Extract sandbox-capable backend from deps, if available."""
     if deps is None:
         return None
+    from pydantic_deep.deps import unwrap_backend
+
     backend = deps.backend
-    raw = getattr(backend, "unwrap", lambda: backend)()
+    raw = unwrap_backend(backend)
     if isinstance(raw, SandboxProtocol):
         return backend  # type: ignore[return-value,unused-ignore]
     return None

--- a/pydantic_deep/capabilities/hooks.py
+++ b/pydantic_deep/capabilities/hooks.py
@@ -32,7 +32,7 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic_ai_backends import SandboxProtocol
+from pydantic_ai_backends import AsyncSandboxProtocol, SandboxProtocol
 
 if TYPE_CHECKING:
     from pydantic_ai_backends import ExecuteResponse
@@ -191,14 +191,14 @@ def _parse_command_result(response: ExecuteResponse) -> HookResult:
 async def _execute_command_hook(
     hook: Hook,
     hook_input: HookInput,
-    backend: SandboxProtocol,
+    backend: AsyncSandboxProtocol,
 ) -> HookResult:
-    """Execute a command hook via SandboxProtocol.execute()."""
+    """Execute a command hook via AsyncSandboxProtocol.execute()."""
     json_str = json.dumps(asdict(hook_input))
     # Escape single quotes for shell safety
     escaped = json_str.replace("'", "'\\''")
     full_command = f"printf '%s' '{escaped}' | {hook.command}"
-    response: ExecuteResponse = await asyncio.to_thread(backend.execute, full_command, hook.timeout)
+    response: ExecuteResponse = await backend.execute(full_command, hook.timeout)
     return _parse_command_result(response)
 
 
@@ -214,13 +214,13 @@ async def _execute_handler_hook(
 async def _run_hook(
     hook: Hook,
     hook_input: HookInput,
-    backend: SandboxProtocol | None,
+    backend: AsyncSandboxProtocol | None,
 ) -> HookResult:
     """Run a single hook (command or handler)."""
     if hook.command is not None:
-        if backend is None or not isinstance(backend, SandboxProtocol):
+        if backend is None or not hasattr(backend, "execute"):
             msg = (
-                "Command hooks require a SandboxProtocol backend "
+                "Command hooks require a AsyncSandboxProtocol backend "
                 "(LocalBackend or DockerSandbox). "
                 "Current backend does not support execute()."
             )
@@ -232,7 +232,7 @@ async def _run_hook(
 async def _run_background_hook(
     hook: Hook,
     hook_input: HookInput,
-    backend: SandboxProtocol | None,
+    backend: AsyncSandboxProtocol | None,
 ) -> None:
     """Run a background hook, logging errors without propagating."""
     try:
@@ -241,13 +241,14 @@ async def _run_background_hook(
         logger.exception("Background hook failed: %s", hook.command or hook.handler)
 
 
-def _get_sandbox_backend(deps: DeepAgentDeps | None) -> SandboxProtocol | None:
-    """Extract SandboxProtocol backend from deps, if available."""
+def _get_sandbox_backend(deps: DeepAgentDeps | None) -> AsyncSandboxProtocol | None:
+    """Extract sandbox-capable backend from deps, if available."""
     if deps is None:
         return None
     backend = deps.backend
-    if isinstance(backend, SandboxProtocol):
-        return backend
+    raw = getattr(backend, "unwrap", lambda: backend)()
+    if isinstance(raw, SandboxProtocol):
+        return backend  # type: ignore[return-value,unused-ignore]
     return None
 
 
@@ -277,7 +278,7 @@ class HooksCapability(AbstractCapability[Any]):
         self,
         hook: Hook,
         hook_input: HookInput,
-        backend: SandboxProtocol | None,
+        backend: AsyncSandboxProtocol | None,
     ) -> None:
         """Launch a background hook, retaining a strong reference to its task.
 
@@ -494,7 +495,7 @@ class HooksCapability(AbstractCapability[Any]):
         matched = [h for h in self.hooks if h.event == HookEvent.MODEL_FALLBACK_TRIGGERED]
         if not matched:
             return
-        sandbox = backend if isinstance(backend, SandboxProtocol) else None
+        sandbox = backend if isinstance(backend, AsyncSandboxProtocol) else None
         hook_input = _build_hook_input(
             HookEvent.MODEL_FALLBACK_TRIGGERED,
             "",

--- a/pydantic_deep/deps.py
+++ b/pydantic_deep/deps.py
@@ -12,11 +12,17 @@ if TYPE_CHECKING:
 
 import chardet
 from pydantic_ai.usage import UsageLimits
-from pydantic_ai_backends import BackendProtocol, StateBackend, ensure_async
+from pydantic_ai_backends import StateBackend, ensure_async
 from pydantic_ai_backends.adapter import AsyncBackendAdapter
 from pydantic_ai_backends.protocol import AsyncBackendProtocol
 
 from pydantic_deep.types import FileData, Todo, UploadedFile
+
+
+def unwrap_backend(backend: Any) -> Any:
+    """Return the raw sync backend, unwrapping ``AsyncBackendAdapter`` if needed."""
+    return getattr(backend, "unwrap", lambda: backend)()
+
 
 #: pydantic-ai's default `request_limit=50` is too low for autonomous agents
 #: that routinely need 50-200+ requests on complex tasks.
@@ -62,11 +68,13 @@ class DeepAgentDeps:
         # Auto-wrap sync backends so consumer code can always `await backend.X()`
         if not isinstance(self.backend, AsyncBackendAdapter):
             wrapped = ensure_async(self.backend)
-            if wrapped is not self.backend:
+            if (
+                wrapped is not self.backend
+            ):  # pragma: no cover - only when backend is already async-native
                 object.__setattr__(self, "backend", wrapped)
 
         # Cache wiring via unwrap() for StateBackend's shared files dict
-        raw = getattr(self.backend, "unwrap", lambda: self.backend)()
+        raw = unwrap_backend(self.backend)
         if isinstance(raw, StateBackend):
             if self.files:
                 raw._files = self.files

--- a/pydantic_deep/deps.py
+++ b/pydantic_deep/deps.py
@@ -12,7 +12,9 @@ if TYPE_CHECKING:
 
 import chardet
 from pydantic_ai.usage import UsageLimits
-from pydantic_ai_backends import BackendProtocol, StateBackend
+from pydantic_ai_backends import BackendProtocol, StateBackend, ensure_async
+from pydantic_ai_backends.adapter import AsyncBackendAdapter
+from pydantic_ai_backends.protocol import AsyncBackendProtocol
 
 from pydantic_deep.types import FileData, Todo, UploadedFile
 
@@ -37,7 +39,7 @@ class DeepAgentDeps:
             When set, overrides the global store passed to `create_deep_agent()`.
     """
 
-    backend: BackendProtocol = field(default_factory=StateBackend)
+    backend: AsyncBackendProtocol | Any = field(default_factory=StateBackend)
     files: dict[str, FileData] = field(default_factory=dict)
     todos: list[Todo] = field(default_factory=list)
     subagents: dict[str, Any] = field(default_factory=dict)  # Agent instances
@@ -56,14 +58,20 @@ class DeepAgentDeps:
     _parent_fork_coordinator: Any = field(default=None, repr=False)
 
     def __post_init__(self) -> None:
-        """Initialize backend with files if using StateBackend."""
-        if isinstance(self.backend, StateBackend):
+        """Auto-wrap sync backends and wire StateBackend cache."""
+        # Auto-wrap sync backends so consumer code can always `await backend.X()`
+        if not isinstance(self.backend, AsyncBackendAdapter):
+            wrapped = ensure_async(self.backend)
+            if wrapped is not self.backend:
+                object.__setattr__(self, "backend", wrapped)
+
+        # Cache wiring via unwrap() for StateBackend's shared files dict
+        raw = getattr(self.backend, "unwrap", lambda: self.backend)()
+        if isinstance(raw, StateBackend):
             if self.files:
-                # Sync files to state backend
-                self.backend._files = self.files
+                raw._files = self.files
             else:
-                # Use backend's files dict as the shared reference
-                object.__setattr__(self, "files", self.backend._files)
+                object.__setattr__(self, "files", raw._files)
 
     def get_todo_prompt(self) -> str:
         """Generate system prompt section for todos."""
@@ -105,7 +113,7 @@ class DeepAgentDeps:
 
         return "\n".join(lines)
 
-    def upload_file(
+    async def upload_file(
         self,
         name: str,
         content: bytes,
@@ -128,14 +136,14 @@ class DeepAgentDeps:
         Example:
             ```python
             deps = DeepAgentDeps(backend=StateBackend())
-            path = deps.upload_file("data.csv", csv_bytes)
+            path = await deps.upload_file("data.csv", csv_bytes)
             # Agent can now access the file at /uploads/data.csv
             ```
         """
         path = f"{upload_dir}/{name}"
 
         # Write raw bytes to storage
-        res = self.backend.write(path, content)
+        res = await self.backend.write(path, content)
 
         if res.error:  # pragma: no cover
             raise RuntimeError(f"Failed to upload file: {res.error}")
@@ -167,7 +175,7 @@ class DeepAgentDeps:
 
         return path
 
-    def upload_files(
+    async def upload_files(
         self,
         files: list[tuple[str, bytes]],
         *,
@@ -188,7 +196,7 @@ class DeepAgentDeps:
         Example:
             ```python
             deps = DeepAgentDeps(backend=StateBackend())
-            paths = deps.upload_files([
+            paths = await deps.upload_files([
                 ("data.csv", csv_bytes),
                 ("config.json", json_bytes),
             ])
@@ -197,7 +205,7 @@ class DeepAgentDeps:
         paths: list[str] = []
         for name, content in files:
             try:
-                path = self.upload_file(name, content, upload_dir=upload_dir)
+                path = await self.upload_file(name, content, upload_dir=upload_dir)
                 paths.append(path)
             except Exception:
                 # Skip failed uploads so one bad file doesn't abort the batch.

--- a/pydantic_deep/processors/eviction.py
+++ b/pydantic_deep/processors/eviction.py
@@ -30,8 +30,7 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 from pydantic_ai.tools import RunContext
-from pydantic_ai_backends import AsyncBackendProtocol, BackendProtocol
-from pydantic_ai_backends.adapter import AsyncBackendAdapter
+from pydantic_ai_backends import AsyncBackendProtocol, BackendProtocol, ensure_async
 
 NUM_CHARS_PER_TOKEN = 4
 """Approximate number of characters per token.
@@ -283,7 +282,7 @@ class EvictionProcessor:
         ```
     """
 
-    backend: BackendProtocol
+    backend: AsyncBackendProtocol
     """Fallback backend used when RunContext is not available or deps has no backend."""
 
     token_limit: int = DEFAULT_TOKEN_LIMIT
@@ -316,7 +315,7 @@ class EvictionProcessor:
         while len(self._evicted_ids) > self.max_evicted_ids:
             self._evicted_ids.popitem(last=False)
 
-    def _resolve_backend(self, ctx: RunContext[Any]) -> AsyncBackendProtocol | AsyncBackendAdapter:
+    def _resolve_backend(self, ctx: RunContext[Any]) -> AsyncBackendProtocol:
         """Resolve the backend to use for writing evicted content.
 
         Prefers the runtime backend from ``ctx.deps.backend`` to ensure
@@ -330,9 +329,9 @@ class EvictionProcessor:
             The async backend to use for writing.
         """
         deps_backend = getattr(ctx.deps, "backend", None)
-        if deps_backend is not None and isinstance(deps_backend, (AsyncBackendProtocol, AsyncBackendAdapter)):
+        if deps_backend is not None and isinstance(deps_backend, AsyncBackendProtocol):
             return deps_backend
-        return self.backend  # type: ignore[return-value,unused-ignore]
+        return self.backend
 
     async def __call__(
         self, ctx: RunContext[Any], messages: list[ModelMessage]
@@ -477,7 +476,7 @@ def create_eviction_processor(
         ```
     """
     return EvictionProcessor(
-        backend=backend,
+        backend=ensure_async(backend),
         token_limit=token_limit,
         eviction_path=eviction_path,
         head_lines=head_lines,
@@ -526,7 +525,7 @@ class EvictionCapability(AbstractCapability[Any]):
         on_eviction: Optional callback `(tool_name, file_path, original_chars, preview_chars)`.
     """
 
-    backend: BackendProtocol | None = None
+    backend: AsyncBackendProtocol | None = None
     token_limit: int = DEFAULT_TOKEN_LIMIT
     eviction_path: str = DEFAULT_EVICTION_PATH
     head_lines: int = DEFAULT_HEAD_LINES
@@ -534,12 +533,12 @@ class EvictionCapability(AbstractCapability[Any]):
     max_binary_content: int | None = DEFAULT_MAX_BINARY_CONTENT
     on_eviction: Callable[[str, str, int, int], Any] | None = None
 
-    def _resolve_backend(self, ctx: RunContext[Any]) -> AsyncBackendProtocol | AsyncBackendAdapter | None:
+    def _resolve_backend(self, ctx: RunContext[Any]) -> AsyncBackendProtocol | None:
         """Resolve backend from deps or fallback."""
         deps_backend = getattr(ctx.deps, "backend", None)
-        if deps_backend is not None and isinstance(deps_backend, (AsyncBackendProtocol, AsyncBackendAdapter)):
+        if deps_backend is not None and isinstance(deps_backend, AsyncBackendProtocol):
             return deps_backend
-        return self.backend  # type: ignore[return-value,unused-ignore]
+        return self.backend
 
     async def after_tool_execute(
         self,
@@ -659,7 +658,7 @@ async def _prune_binaries_in_messages(
     messages: list[ModelMessage],
     *,
     max_binary_content: int,
-    backend: AsyncBackendProtocol | AsyncBackendAdapter,
+    backend: AsyncBackendProtocol,
     eviction_path: str,
 ) -> list[ModelMessage]:
     """Return `messages` with older binary parts pruned and stored in `backend`."""
@@ -725,7 +724,7 @@ async def _prune_user_content(
     *,
     kept: int,
     max_binary_content: int,
-    backend: AsyncBackendProtocol | AsyncBackendAdapter,
+    backend: AsyncBackendProtocol,
     eviction_path: str,
 ) -> tuple[str | list[Any], int, bool]:
     """Prune binaries from a `UserPromptPart.content` value.
@@ -747,7 +746,9 @@ async def _prune_user_content(
         if kept < max_binary_content:
             kept += 1
             continue
-        replacement = await _store_and_replace_binary(item, backend=backend, eviction_path=eviction_path)
+        replacement = await _store_and_replace_binary(
+            item, backend=backend, eviction_path=eviction_path
+        )
         if replacement is None:
             kept += 1
             continue
@@ -762,7 +763,7 @@ async def _prune_tool_return_content(
     *,
     kept: int,
     max_binary_content: int,
-    backend: AsyncBackendProtocol | AsyncBackendAdapter,
+    backend: AsyncBackendProtocol,
     eviction_path: str,
 ) -> tuple[Any, int, bool]:
     """Prune binaries from a `ToolReturnPart.content` value.
@@ -812,7 +813,7 @@ async def _prune_tool_return_content(
 async def _store_and_replace_binary(
     binary: BinaryContent,
     *,
-    backend: AsyncBackendProtocol | AsyncBackendAdapter,
+    backend: AsyncBackendProtocol,
     eviction_path: str,
 ) -> str | None:
     """Persist `binary` to the backend and return a text replacement.

--- a/pydantic_deep/processors/eviction.py
+++ b/pydantic_deep/processors/eviction.py
@@ -30,7 +30,8 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 from pydantic_ai.tools import RunContext
-from pydantic_ai_backends import BackendProtocol
+from pydantic_ai_backends import AsyncBackendProtocol, BackendProtocol
+from pydantic_ai_backends.adapter import AsyncBackendAdapter
 
 NUM_CHARS_PER_TOKEN = 4
 """Approximate number of characters per token.
@@ -315,23 +316,23 @@ class EvictionProcessor:
         while len(self._evicted_ids) > self.max_evicted_ids:
             self._evicted_ids.popitem(last=False)
 
-    def _resolve_backend(self, ctx: RunContext[Any]) -> BackendProtocol:
+    def _resolve_backend(self, ctx: RunContext[Any]) -> AsyncBackendProtocol | AsyncBackendAdapter:
         """Resolve the backend to use for writing evicted content.
 
-        Prefers the runtime backend from `ctx.deps.backend` to ensure
+        Prefers the runtime backend from ``ctx.deps.backend`` to ensure
         evicted files are accessible by console tools (read_file, grep).
-        Falls back to `self.backend` if deps has no backend attribute.
+        Falls back to ``self.backend`` if deps has no backend attribute.
 
         Args:
             ctx: The run context from pydantic-ai.
 
         Returns:
-            The backend to use for writing.
+            The async backend to use for writing.
         """
         deps_backend = getattr(ctx.deps, "backend", None)
-        if deps_backend is not None and isinstance(deps_backend, BackendProtocol):
+        if deps_backend is not None and isinstance(deps_backend, (AsyncBackendProtocol, AsyncBackendAdapter)):
             return deps_backend
-        return self.backend
+        return self.backend  # type: ignore[return-value,unused-ignore]
 
     async def __call__(
         self, ctx: RunContext[Any], messages: list[ModelMessage]
@@ -387,7 +388,7 @@ class EvictionProcessor:
                 # Evict: save to backend, replace with preview
                 sanitized_id = _sanitize_id(part.tool_call_id)
                 file_path = f"{self.eviction_path}/{sanitized_id}"
-                write_result = backend.write(file_path, content_str)
+                write_result = await backend.write(file_path, content_str)
 
                 if write_result.error:
                     # Keep original on write failure
@@ -533,12 +534,12 @@ class EvictionCapability(AbstractCapability[Any]):
     max_binary_content: int | None = DEFAULT_MAX_BINARY_CONTENT
     on_eviction: Callable[[str, str, int, int], Any] | None = None
 
-    def _resolve_backend(self, ctx: RunContext[Any]) -> BackendProtocol | None:
+    def _resolve_backend(self, ctx: RunContext[Any]) -> AsyncBackendProtocol | AsyncBackendAdapter | None:
         """Resolve backend from deps or fallback."""
         deps_backend = getattr(ctx.deps, "backend", None)
-        if deps_backend is not None and isinstance(deps_backend, BackendProtocol):
+        if deps_backend is not None and isinstance(deps_backend, (AsyncBackendProtocol, AsyncBackendAdapter)):
             return deps_backend
-        return self.backend
+        return self.backend  # type: ignore[return-value,unused-ignore]
 
     async def after_tool_execute(
         self,
@@ -598,7 +599,7 @@ class EvictionCapability(AbstractCapability[Any]):
 
         sanitized_id = _sanitize_id(call.tool_call_id)
         file_path = f"{self.eviction_path}/{sanitized_id}"
-        write_result = backend.write(file_path, content_str)
+        write_result = await backend.write(file_path, content_str)
 
         if write_result.error:
             return None
@@ -645,7 +646,7 @@ class EvictionCapability(AbstractCapability[Any]):
         if backend is None:
             return request_context
 
-        request_context.messages = _prune_binaries_in_messages(
+        request_context.messages = await _prune_binaries_in_messages(
             request_context.messages,
             max_binary_content=limit,
             backend=backend,
@@ -654,11 +655,11 @@ class EvictionCapability(AbstractCapability[Any]):
         return request_context
 
 
-def _prune_binaries_in_messages(
+async def _prune_binaries_in_messages(
     messages: list[ModelMessage],
     *,
     max_binary_content: int,
-    backend: BackendProtocol,
+    backend: AsyncBackendProtocol | AsyncBackendAdapter,
     eviction_path: str,
 ) -> list[ModelMessage]:
     """Return `messages` with older binary parts pruned and stored in `backend`."""
@@ -677,7 +678,7 @@ def _prune_binaries_in_messages(
             part = new_parts[part_idx]
 
             if isinstance(part, UserPromptPart):
-                new_content, kept, part_modified = _prune_user_content(
+                new_content, kept, part_modified = await _prune_user_content(
                     part.content,
                     kept=kept,
                     max_binary_content=max_binary_content,
@@ -692,7 +693,7 @@ def _prune_binaries_in_messages(
                     modified = True
 
             elif isinstance(part, ToolReturnPart):
-                new_content, kept, part_modified = _prune_tool_return_content(
+                new_content, kept, part_modified = await _prune_tool_return_content(
                     part.content,
                     kept=kept,
                     max_binary_content=max_binary_content,
@@ -719,12 +720,12 @@ def _prune_binaries_in_messages(
     return new_messages
 
 
-def _prune_user_content(
+async def _prune_user_content(
     content: str | Sequence[Any],
     *,
     kept: int,
     max_binary_content: int,
-    backend: BackendProtocol,
+    backend: AsyncBackendProtocol | AsyncBackendAdapter,
     eviction_path: str,
 ) -> tuple[str | list[Any], int, bool]:
     """Prune binaries from a `UserPromptPart.content` value.
@@ -746,7 +747,7 @@ def _prune_user_content(
         if kept < max_binary_content:
             kept += 1
             continue
-        replacement = _store_and_replace_binary(item, backend=backend, eviction_path=eviction_path)
+        replacement = await _store_and_replace_binary(item, backend=backend, eviction_path=eviction_path)
         if replacement is None:
             kept += 1
             continue
@@ -756,12 +757,12 @@ def _prune_user_content(
     return items, kept, modified
 
 
-def _prune_tool_return_content(
+async def _prune_tool_return_content(
     content: Any,
     *,
     kept: int,
     max_binary_content: int,
-    backend: BackendProtocol,
+    backend: AsyncBackendProtocol | AsyncBackendAdapter,
     eviction_path: str,
 ) -> tuple[Any, int, bool]:
     """Prune binaries from a `ToolReturnPart.content` value.
@@ -776,7 +777,7 @@ def _prune_tool_return_content(
     if isinstance(content, BinaryContent):
         if kept < max_binary_content:
             return content, kept + 1, False
-        replacement = _store_and_replace_binary(
+        replacement = await _store_and_replace_binary(
             content, backend=backend, eviction_path=eviction_path
         )
         if replacement is None:
@@ -794,7 +795,7 @@ def _prune_tool_return_content(
             if kept < max_binary_content:
                 kept += 1
                 continue
-            replacement = _store_and_replace_binary(
+            replacement = await _store_and_replace_binary(
                 item, backend=backend, eviction_path=eviction_path
             )
             if replacement is None:
@@ -808,10 +809,10 @@ def _prune_tool_return_content(
     return content, kept, False
 
 
-def _store_and_replace_binary(
+async def _store_and_replace_binary(
     binary: BinaryContent,
     *,
-    backend: BackendProtocol,
+    backend: AsyncBackendProtocol | AsyncBackendAdapter,
     eviction_path: str,
 ) -> str | None:
     """Persist `binary` to the backend and return a text replacement.
@@ -820,7 +821,7 @@ def _store_and_replace_binary(
     keep the original binary in place.
     """
     file_path = _binary_storage_path(eviction_path, binary)
-    write_result = backend.write(file_path, binary.data)  # type: ignore[attr-defined, unused-ignore]
+    write_result = await backend.write(file_path, binary.data)  # type: ignore[attr-defined, unused-ignore]
     if write_result.error:
         return None
     return _binary_replacement_text(binary, file_path)

--- a/pydantic_deep/toolsets/context.py
+++ b/pydantic_deep/toolsets/context.py
@@ -15,7 +15,7 @@ from typing import Any
 from pydantic_ai import RunContext
 from pydantic_ai.messages import InstructionPart
 from pydantic_ai.toolsets import FunctionToolset
-from pydantic_ai_backends import AsyncBackendProtocol, BackendProtocol
+from pydantic_ai_backends import AsyncBackendProtocol
 
 DEFAULT_CONTEXT_FILENAMES: list[str] = [
     "AGENTS.md",

--- a/pydantic_deep/toolsets/context.py
+++ b/pydantic_deep/toolsets/context.py
@@ -15,7 +15,7 @@ from typing import Any
 from pydantic_ai import RunContext
 from pydantic_ai.messages import InstructionPart
 from pydantic_ai.toolsets import FunctionToolset
-from pydantic_ai_backends import BackendProtocol
+from pydantic_ai_backends import AsyncBackendProtocol, BackendProtocol
 
 DEFAULT_CONTEXT_FILENAMES: list[str] = [
     "AGENTS.md",
@@ -70,8 +70,8 @@ class ContextFile:
     """File content."""
 
 
-def load_context_files(
-    backend: BackendProtocol,
+async def load_context_files(
+    backend: AsyncBackendProtocol,
     paths: list[str],
 ) -> list[ContextFile]:
     """Load context files from backend.
@@ -79,7 +79,7 @@ def load_context_files(
     Missing files are silently skipped.
 
     Args:
-        backend: Backend to read files from.
+        backend: Async backend to read files from.
         paths: List of file paths to load.
 
     Returns:
@@ -87,7 +87,7 @@ def load_context_files(
     """
     result: list[ContextFile] = []
     for path in paths:
-        raw = backend.read_bytes(path)
+        raw = await backend.read_bytes(path)
         if not raw:
             continue
         content = raw.decode("utf-8", errors="replace")
@@ -96,15 +96,15 @@ def load_context_files(
     return result
 
 
-def discover_context_files(
-    backend: BackendProtocol,
+async def discover_context_files(
+    backend: AsyncBackendProtocol,
     search_path: str = "/",
     filenames: list[str] | None = None,
 ) -> list[str]:
     """Auto-discover context files in backend root.
 
     Args:
-        backend: Backend to search in.
+        backend: Async backend to search in.
         search_path: Root path to search (default: "/").
         filenames: Filenames to look for (default: DEFAULT_CONTEXT_FILENAMES).
 
@@ -115,14 +115,14 @@ def discover_context_files(
     found: list[str] = []
     for name in filenames:
         path = f"{search_path.rstrip('/')}/{name}"
-        raw = backend.read_bytes(path)
+        raw = await backend.read_bytes(path)
         if raw:
             found.append(path)
     return found
 
 
-def _discover_and_load(
-    backend: BackendProtocol,
+async def _discover_and_load(
+    backend: AsyncBackendProtocol,
     search_path: str = "/",
     filenames: list[str] | None = None,
 ) -> list[ContextFile]:
@@ -132,7 +132,7 @@ def _discover_and_load(
     this reads each file's bytes only once. Missing files are silently skipped.
 
     Args:
-        backend: Backend to search and read from.
+        backend: Async backend to search and read from.
         search_path: Root path to search (default: "/").
         filenames: Filenames to look for (default: DEFAULT_CONTEXT_FILENAMES).
 
@@ -143,7 +143,7 @@ def _discover_and_load(
     result: list[ContextFile] = []
     for name in filenames:
         path = f"{search_path.rstrip('/')}/{name}"
-        raw = backend.read_bytes(path)
+        raw = await backend.read_bytes(path)
         if not raw:
             continue
         content = raw.decode("utf-8", errors="replace")
@@ -243,14 +243,14 @@ class ContextToolset(FunctionToolset[Any]):
         Returns:
             Formatted context prompt, or None if no files found.
         """
-        backend: BackendProtocol | None = getattr(ctx.deps, "backend", None)
+        backend: AsyncBackendProtocol | None = getattr(ctx.deps, "backend", None)
         if backend is None:
             return None
 
         if self._context_discovery:
-            loaded = _discover_and_load(backend)
+            loaded = await _discover_and_load(backend)
         elif self._context_files:
-            loaded = load_context_files(backend, self._context_files)
+            loaded = await load_context_files(backend, self._context_files)
         else:
             return None
 

--- a/pydantic_deep/toolsets/forking/__init__.py
+++ b/pydantic_deep/toolsets/forking/__init__.py
@@ -21,7 +21,7 @@ from pydantic_ai import RunContext
 from pydantic_ai.messages import ModelRequest as _ModelRequest
 from pydantic_ai.toolsets import FunctionToolset
 
-from pydantic_deep.deps import DeepAgentDeps
+from pydantic_deep.deps import DeepAgentDeps, unwrap_backend
 from pydantic_deep.toolsets.forking.coordinator import (
     BranchRuntime,
     ForkBranchLimitError,
@@ -339,7 +339,7 @@ def create_fork_toolset(  # noqa: C901
             branch.
         """
         backend = ctx.deps.backend
-        raw = getattr(backend, "unwrap", lambda: backend)()
+        raw = unwrap_backend(backend)
         if not isinstance(raw, BranchOverlay):
             return "delete_file is only available inside a fork branch."
         if not raw.exists(path):

--- a/pydantic_deep/toolsets/forking/__init__.py
+++ b/pydantic_deep/toolsets/forking/__init__.py
@@ -339,11 +339,12 @@ def create_fork_toolset(  # noqa: C901
             branch.
         """
         backend = ctx.deps.backend
-        if not isinstance(backend, BranchOverlay):
+        raw = getattr(backend, "unwrap", lambda: backend)()
+        if not isinstance(raw, BranchOverlay):
             return "delete_file is only available inside a fork branch."
-        if not backend.exists(path):
+        if not raw.exists(path):
             return f"error: '{path}' does not exist in this branch"
-        backend.delete(path)
+        raw.delete(path)
         return f"deleted: {path}"
 
     @toolset.tool
@@ -402,7 +403,7 @@ def create_fork_toolset(  # noqa: C901
                 f"diff_branches failed: fork_id {fork_id!r} does not match the "
                 f"active fork {active_fork_id!r}."
             )
-        return build_diff_report(
+        return await build_diff_report(
             active_fork_id,
             list(coordinator.branches.values()),
             paths_filter=paths,

--- a/pydantic_deep/toolsets/forking/coordinator.py
+++ b/pydantic_deep/toolsets/forking/coordinator.py
@@ -578,8 +578,11 @@ class ForkCoordinator:
             for spec in specs:
                 branch_id = str(uuid.uuid4())
                 cloned_deps = clone_for_branch(self.parent_deps, effective_isolation)
+                # Unwrap async adapter — BranchOverlay is a sync backend that
+                # gets auto-wrapped by DeepAgentDeps.__post_init__.
+                raw_cloned = getattr(cloned_deps.backend, "unwrap", lambda: cloned_deps.backend)()
                 overlay = (
-                    cloned_deps.backend if isinstance(cloned_deps.backend, BranchOverlay) else None
+                    raw_cloned if isinstance(raw_cloned, BranchOverlay) else None
                 )
                 if overlay is not None and self.materializer is not None:
                     overlay.attach_materializer(self.materializer, spec.label)
@@ -966,7 +969,11 @@ class ForkCoordinator:
                     if self.materializer is not None
                     else None
                 )
-                report = winner_overlay.flush_to(self.parent_deps.backend, snapshot)
+                # Unwrap adapter — flush_to is sync and expects a raw BackendProtocol.
+                raw_parent: Any = getattr(
+                    self.parent_deps.backend, "unwrap", lambda: self.parent_deps.backend
+                )()
+                report = winner_overlay.flush_to(raw_parent, snapshot)
                 applied_paths = list(report.applied_paths)
                 applied_changes = report.applied_changes
                 conflicts = list(report.conflicts)
@@ -1075,8 +1082,9 @@ class ForkCoordinator:
         """
         if self.test_command is None:
             return None
-        parent = self.parent_deps.backend
-        parent_root_obj: Any = getattr(parent, "root_dir", None)
+        # Unwrap adapter — root_dir is an attribute on the raw backend (e.g. LocalBackend).
+        raw_parent = getattr(self.parent_deps.backend, "unwrap", lambda: self.parent_deps.backend)()
+        parent_root_obj: Any = getattr(raw_parent, "root_dir", None)
         if not isinstance(parent_root_obj, (str, Path)):
             return None
         overlay = rt.overlay
@@ -1297,7 +1305,7 @@ class ForkCoordinator:
             return self._cached_outcome
 
         outcomes, goal = await self._build_branch_outcomes()
-        diff_report = build_diff_report(self._handle.fork_id, list(self.branches.values()))
+        diff_report = await build_diff_report(self._handle.fork_id, list(self.branches.values()))
 
         verdict, judge_usage = await self._run_judges(
             effective_strategy, goal, diff_report, outcomes

--- a/pydantic_deep/toolsets/forking/coordinator.py
+++ b/pydantic_deep/toolsets/forking/coordinator.py
@@ -30,7 +30,7 @@ from pydantic_ai.messages import ModelRequest, ModelResponse, UserPromptPart
 from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults
 from pydantic_ai_shields import CostInfo, CostTracking
 
-from pydantic_deep.deps import DeepAgentDeps
+from pydantic_deep.deps import DeepAgentDeps, unwrap_backend
 from pydantic_deep.toolsets.checkpointing import Checkpoint, CheckpointStore
 from pydantic_deep.toolsets.forking.diff import build_diff_report
 from pydantic_deep.toolsets.forking.isolation import BranchOverlay, clone_for_branch
@@ -580,10 +580,8 @@ class ForkCoordinator:
                 cloned_deps = clone_for_branch(self.parent_deps, effective_isolation)
                 # Unwrap async adapter — BranchOverlay is a sync backend that
                 # gets auto-wrapped by DeepAgentDeps.__post_init__.
-                raw_cloned = getattr(cloned_deps.backend, "unwrap", lambda: cloned_deps.backend)()
-                overlay = (
-                    raw_cloned if isinstance(raw_cloned, BranchOverlay) else None
-                )
+                raw_cloned = unwrap_backend(cloned_deps.backend)
+                overlay = raw_cloned if isinstance(raw_cloned, BranchOverlay) else None
                 if overlay is not None and self.materializer is not None:
                     overlay.attach_materializer(self.materializer, spec.label)
 
@@ -970,9 +968,7 @@ class ForkCoordinator:
                     else None
                 )
                 # Unwrap adapter — flush_to is sync and expects a raw BackendProtocol.
-                raw_parent: Any = getattr(
-                    self.parent_deps.backend, "unwrap", lambda: self.parent_deps.backend
-                )()
+                raw_parent: Any = unwrap_backend(self.parent_deps.backend)
                 report = winner_overlay.flush_to(raw_parent, snapshot)
                 applied_paths = list(report.applied_paths)
                 applied_changes = report.applied_changes
@@ -1083,7 +1079,7 @@ class ForkCoordinator:
         if self.test_command is None:
             return None
         # Unwrap adapter — root_dir is an attribute on the raw backend (e.g. LocalBackend).
-        raw_parent = getattr(self.parent_deps.backend, "unwrap", lambda: self.parent_deps.backend)()
+        raw_parent = unwrap_backend(self.parent_deps.backend)
         parent_root_obj: Any = getattr(raw_parent, "root_dir", None)
         if not isinstance(parent_root_obj, (str, Path)):
             return None

--- a/pydantic_deep/toolsets/forking/diff.py
+++ b/pydantic_deep/toolsets/forking/diff.py
@@ -86,13 +86,17 @@ async def _read_path_bytes(backend: _BytesReadable, path: str) -> bytes | None:
     Handles both sync (BranchOverlay) and async (AsyncBackendAdapter) backends.
     """
     exists_result = backend.exists(path)
-    if inspect.isawaitable(exists_result):
+    if inspect.isawaitable(
+        exists_result
+    ):  # pragma: no cover - async path unreachable with current callers
         exists_result = await exists_result
     if not exists_result:
         return None
     try:
         result: Any = backend.read_bytes(path)
-        if inspect.isawaitable(result):
+        if inspect.isawaitable(
+            result
+        ):  # pragma: no cover - async path unreachable with current callers
             result = await result
         return bytes(result) if result is not None else None
     except (FileNotFoundError, KeyError):  # pragma: no cover - defensive

--- a/pydantic_deep/toolsets/forking/diff.py
+++ b/pydantic_deep/toolsets/forking/diff.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import difflib
 import hashlib
-import inspect
 from typing import TYPE_CHECKING, Any, Protocol
 
 from pydantic_deep.processors.eviction import create_content_preview
@@ -39,16 +38,15 @@ if TYPE_CHECKING:
 
 
 class _BytesReadable(Protocol):
-    """Minimal read surface needed by the diff builder.
+    """Minimal sync read surface needed by the diff builder.
 
-    Accepts both sync backends (BackendProtocol, BranchOverlay) and async
-    backends (AsyncBackendAdapter). The ``_read_path_bytes`` helper uses
-    ``inspect.isawaitable`` to dispatch correctly at runtime, so method
-    return types are ``Any`` to accommodate both signatures.
+    Both ``BackendProtocol`` and ``BranchOverlay`` satisfy this. Using a
+    narrow local protocol keeps strict typing happy without depending on
+    backend-level method signature quirks.
     """
 
-    def exists(self, path: str) -> Any: ...
-    def read_bytes(self, path: str) -> Any: ...
+    def exists(self, path: str) -> bool: ...
+    def read_bytes(self, path: str) -> bytes: ...
 
 
 #: Bytes read from the start of a file when sniffing for binary content.
@@ -83,22 +81,13 @@ def _binary_placeholder(data: bytes, *, digest: str | None = None) -> str:
 async def _read_path_bytes(backend: _BytesReadable, path: str) -> bytes | None:
     """Read `path` from `backend` as raw bytes, or `None` if absent.
 
-    Handles both sync (BranchOverlay) and async (AsyncBackendAdapter) backends.
+    Uses ``exists()`` first because some backends (notably ``StateBackend``)
+    silently return ``b""`` for missing paths instead of raising.
     """
-    exists_result = backend.exists(path)
-    if inspect.isawaitable(
-        exists_result
-    ):  # pragma: no cover - async path unreachable with current callers
-        exists_result = await exists_result
-    if not exists_result:
+    if not backend.exists(path):
         return None
     try:
-        result: Any = backend.read_bytes(path)
-        if inspect.isawaitable(
-            result
-        ):  # pragma: no cover - async path unreachable with current callers
-            result = await result
-        return bytes(result) if result is not None else None
+        return backend.read_bytes(path)
     except (FileNotFoundError, KeyError):  # pragma: no cover - defensive
         return None
 

--- a/pydantic_deep/toolsets/forking/diff.py
+++ b/pydantic_deep/toolsets/forking/diff.py
@@ -21,7 +21,8 @@ from __future__ import annotations
 
 import difflib
 import hashlib
-from typing import TYPE_CHECKING, Protocol
+import inspect
+from typing import TYPE_CHECKING, Any, Protocol
 
 from pydantic_deep.processors.eviction import create_content_preview
 from pydantic_deep.types import (
@@ -40,13 +41,14 @@ if TYPE_CHECKING:
 class _BytesReadable(Protocol):
     """Minimal read surface needed by the diff builder.
 
-    Both `BackendProtocol` and `BranchOverlay` satisfy this - using a
-    narrow local protocol keeps strict typing happy without depending on
-    backend-level method signature quirks (e.g. `grep_raw` arity).
+    Accepts both sync backends (BackendProtocol, BranchOverlay) and async
+    backends (AsyncBackendAdapter). The ``_read_path_bytes`` helper uses
+    ``inspect.isawaitable`` to dispatch correctly at runtime, so method
+    return types are ``Any`` to accommodate both signatures.
     """
 
-    def exists(self, path: str) -> bool: ...
-    def read_bytes(self, path: str) -> bytes: ...
+    def exists(self, path: str) -> Any: ...
+    def read_bytes(self, path: str) -> Any: ...
 
 
 #: Bytes read from the start of a file when sniffing for binary content.
@@ -78,18 +80,21 @@ def _binary_placeholder(data: bytes, *, digest: str | None = None) -> str:
     return f"[binary · {len(data)} · sha256:{full[:_BINARY_HASH_PREFIX_HEX_LEN]}]"
 
 
-def _read_path_bytes(backend: _BytesReadable, path: str) -> bytes | None:
+async def _read_path_bytes(backend: _BytesReadable, path: str) -> bytes | None:
     """Read `path` from `backend` as raw bytes, or `None` if absent.
 
-    Uses `exists()` first because some backends (notably `StateBackend`)
-    silently return `b""` for missing paths instead of raising - we need
-    to distinguish "empty file" from "no file" for the `operation`
-    classification (created vs modified).
+    Handles both sync (BranchOverlay) and async (AsyncBackendAdapter) backends.
     """
-    if not backend.exists(path):
+    exists_result = backend.exists(path)
+    if inspect.isawaitable(exists_result):
+        exists_result = await exists_result
+    if not exists_result:
         return None
     try:
-        return backend.read_bytes(path)
+        result: Any = backend.read_bytes(path)
+        if inspect.isawaitable(result):
+            result = await result
+        return bytes(result) if result is not None else None
     except (FileNotFoundError, KeyError):  # pragma: no cover - defensive
         return None
 
@@ -167,7 +172,7 @@ def _classify_agreement(branches: dict[str, BranchChange]) -> BranchDiffAgreemen
     return "unanimous_change"
 
 
-def _resolve_parent_content(
+async def _resolve_parent_content(
     parent_backend: _BytesReadable,
     path: str,
 ) -> tuple[str | None, bytes | None]:
@@ -177,7 +182,7 @@ def _resolve_parent_content(
     still detect binary status without exposing undecodable bytes through
     the text field of :class:`PathDiff`.
     """
-    raw = _read_path_bytes(parent_backend, path)
+    raw = await _read_path_bytes(parent_backend, path)
     if raw is None:
         return None, None
     if _is_binary_bytes(raw):
@@ -185,7 +190,7 @@ def _resolve_parent_content(
     return _decode_text(raw), raw
 
 
-def _build_branch_change(
+async def _build_branch_change(
     *,
     runtime: BranchRuntime,
     path: str,
@@ -230,7 +235,7 @@ def _build_branch_change(
         )
 
     # raise > assert so the invariant guard survives python -O.
-    raw = _read_path_bytes(overlay, path)
+    raw = await _read_path_bytes(overlay, path)
     if raw is None:  # pragma: no cover - invariant guard; see comment above
         raise RuntimeError(
             f"overlay recorded a change for {path!r} but its content is missing — "
@@ -269,7 +274,7 @@ def _build_branch_change(
     )
 
 
-def build_diff_report(
+async def build_diff_report(
     fork_id: str,
     runtimes: list[BranchRuntime],
     *,
@@ -334,11 +339,11 @@ def build_diff_report(
         if parent_backend is None:
             parent_text, parent_raw = None, None
         else:
-            parent_text, parent_raw = _resolve_parent_content(parent_backend, path)
+            parent_text, parent_raw = await _resolve_parent_content(parent_backend, path)
 
         branches_for_path: dict[str, BranchChange] = {}
         for runtime in runtimes:
-            change = _build_branch_change(
+            change = await _build_branch_change(
                 runtime=runtime,
                 path=path,
                 touched_paths=touched_per_branch[runtime.status.id],

--- a/pydantic_deep/toolsets/forking/diff.py
+++ b/pydantic_deep/toolsets/forking/diff.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import difflib
 import hashlib
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Protocol
 
 from pydantic_deep.processors.eviction import create_content_preview
 from pydantic_deep.types import (

--- a/pydantic_deep/toolsets/forking/isolation.py
+++ b/pydantic_deep/toolsets/forking/isolation.py
@@ -477,7 +477,7 @@ class BranchOverlay:
         """
         if self._is_deleted(path):
             return False
-        return bool(self._overlay.exists(path) or self._parent.exists(path))  # type: ignore[union-attr]
+        return bool(self._overlay.exists(path) or self._parent.exists(path))
 
     def read(self, path: str, offset: int = 0, limit: int = 2000) -> str:
         if self._is_deleted(path):

--- a/pydantic_deep/toolsets/forking/isolation.py
+++ b/pydantic_deep/toolsets/forking/isolation.py
@@ -50,9 +50,14 @@ logger = logging.getLogger(__name__)
 
 
 def _read_backend_bytes(backend: Any, path: str) -> bytes:
-    """Read bytes from a sync backend, preferring ``_read_bytes`` over ``read_bytes``."""
-    reader: Any = getattr(backend, "_read_bytes", None) or backend.read_bytes
+    """Read bytes from a sync backend.
+
+    Uses ``read_bytes`` when available, falls back to ``_read_bytes``
+    (some backends like ``LocalBackend`` only expose the private method).
+    """
+    reader: Any = getattr(backend, "read_bytes", None) or backend._read_bytes
     return bytes(reader(path))
+
 
 #: Heavy/ephemeral dirs - skipped to keep snapshot creation fast.
 _SNAP_SKIP_DIRS: frozenset[str] = frozenset(
@@ -470,7 +475,7 @@ class BranchOverlay:
         """
         if self._is_deleted(path):
             return False
-        return bool(self._overlay.exists(path) or self._parent.exists(path))
+        return bool(self._overlay.exists(path) or self._parent.exists(path))  # type: ignore[union-attr]
 
     def read(self, path: str, offset: int = 0, limit: int = 2000) -> str:
         if self._is_deleted(path):
@@ -997,13 +1002,13 @@ def clone_for_branch(deps: DeepAgentDeps, isolation: BranchIsolation) -> DeepAge
     reference by default.
     """
 
+    from pydantic_deep.deps import unwrap_backend
+
     # Unwrap async adapter — BranchOverlay operates synchronously on the
     # raw sync backend; the adapter is only needed for async callers.
-    raw_backend: Any = getattr(deps.backend, "unwrap", lambda: deps.backend)()
+    raw_backend: Any = unwrap_backend(deps.backend)
 
-    new_backend: Any = (
-        BranchOverlay(raw_backend) if isolation.backend == "copy" else deps.backend
-    )
+    new_backend: Any = BranchOverlay(raw_backend) if isolation.backend == "copy" else deps.backend
 
     # "copy" → independent copy so branch todo edits stay local; "share" → same list.
     new_todos = list(deps.todos) if isolation.todos == "copy" else deps.todos

--- a/pydantic_deep/toolsets/forking/isolation.py
+++ b/pydantic_deep/toolsets/forking/isolation.py
@@ -48,6 +48,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+def _read_backend_bytes(backend: Any, path: str) -> bytes:
+    """Read bytes from a sync backend, preferring ``_read_bytes`` over ``read_bytes``."""
+    reader: Any = getattr(backend, "_read_bytes", None) or backend.read_bytes
+    return bytes(reader(path))
+
 #: Heavy/ephemeral dirs - skipped to keep snapshot creation fast.
 _SNAP_SKIP_DIRS: frozenset[str] = frozenset(
     {
@@ -480,7 +486,7 @@ class BranchOverlay:
         if self._has(path):
             data: bytes = self._overlay.read_bytes(path)
             return data
-        parent_data: bytes = self._parent.read_bytes(path)
+        parent_data: bytes = _read_backend_bytes(self._parent, path)
         return parent_data
 
     def _undelete(self, path: str) -> None:
@@ -511,7 +517,7 @@ class BranchOverlay:
         # first so edits don't leak back to the parent.
         if not self._has(path):
             try:
-                parent_bytes = self._parent.read_bytes(path)
+                parent_bytes = _read_backend_bytes(self._parent, path)
             except (FileNotFoundError, KeyError):  # pragma: no cover - defensive
                 # File doesn't exist in parent either - let overlay.edit surface
                 # the not-found error to the caller via EditResult.error.
@@ -675,7 +681,7 @@ class BranchOverlay:
         if materializer is None:
             return
         try:
-            parent_bytes: bytes | None = self._parent.read_bytes(path)
+            parent_bytes: bytes | None = _read_backend_bytes(self._parent, path)
         except (FileNotFoundError, KeyError):
             parent_bytes = None
         materializer.snapshot_parent_path(path, parent_bytes)
@@ -971,7 +977,7 @@ class BranchOverlay:
                 continue
             snapshot_bytes = pre_flush_snapshot[path]
             try:
-                current_bytes: bytes | None = parent.read_bytes(path)
+                current_bytes: bytes | None = _read_backend_bytes(parent, path)
             except (FileNotFoundError, KeyError):
                 current_bytes = None
             if current_bytes != snapshot_bytes:
@@ -991,8 +997,12 @@ def clone_for_branch(deps: DeepAgentDeps, isolation: BranchIsolation) -> DeepAge
     reference by default.
     """
 
-    new_backend: BackendProtocol = (
-        BranchOverlay(deps.backend) if isolation.backend == "copy" else deps.backend
+    # Unwrap async adapter — BranchOverlay operates synchronously on the
+    # raw sync backend; the adapter is only needed for async callers.
+    raw_backend: Any = getattr(deps.backend, "unwrap", lambda: deps.backend)()
+
+    new_backend: Any = (
+        BranchOverlay(raw_backend) if isolation.backend == "copy" else deps.backend
     )
 
     # "copy" → independent copy so branch todo edits stay local; "share" → same list.

--- a/pydantic_deep/toolsets/forking/isolation.py
+++ b/pydantic_deep/toolsets/forking/isolation.py
@@ -55,7 +55,9 @@ def _read_backend_bytes(backend: Any, path: str) -> bytes:
     Uses ``read_bytes`` when available, falls back to ``_read_bytes``
     (some backends like ``LocalBackend`` only expose the private method).
     """
-    reader: Any = getattr(backend, "read_bytes", None) or backend._read_bytes
+    reader: Any = getattr(backend, "read_bytes", None)
+    if reader is None:
+        reader = backend._read_bytes
     return bytes(reader(path))
 
 

--- a/pydantic_deep/toolsets/liteparse.py
+++ b/pydantic_deep/toolsets/liteparse.py
@@ -143,7 +143,7 @@ class LiteparseToolset(FunctionToolset[Any]):
             if not _HAS_LITEPARSE:
                 return _NOT_INSTALLED_MSG
             backend = ctx.deps.backend
-            file_bytes: bytes | None = backend.read_bytes(path)
+            file_bytes: bytes | None = await backend.read_bytes(path)
             if not file_bytes:
                 return f"File not found: {path}"
             try:
@@ -179,7 +179,7 @@ class LiteparseToolset(FunctionToolset[Any]):
             if not _HAS_LITEPARSE:
                 return _NOT_INSTALLED_MSG
             backend = ctx.deps.backend
-            file_bytes = backend.read_bytes(path)
+            file_bytes = await backend.read_bytes(path)
             if not file_bytes:
                 return f"File not found: {path}"
             try:
@@ -204,7 +204,7 @@ class LiteparseToolset(FunctionToolset[Any]):
                     for screenshot in ss_result:
                         if screenshot.image_bytes:
                             out_path = f"{output_dir.rstrip('/')}/page_{screenshot.page_num}.png"
-                            backend.write(out_path, screenshot.image_bytes)
+                            await backend.write(out_path, screenshot.image_bytes)
                             saved.append(out_path)
 
                     if not saved:

--- a/pydantic_deep/toolsets/memory.py
+++ b/pydantic_deep/toolsets/memory.py
@@ -17,7 +17,7 @@ from typing import Any
 from pydantic_ai import RunContext
 from pydantic_ai.messages import InstructionPart
 from pydantic_ai.toolsets import FunctionToolset
-from pydantic_ai_backends import BackendProtocol
+from pydantic_ai_backends import AsyncBackendProtocol
 
 
 class MemoryAccessError(Exception):
@@ -93,8 +93,8 @@ def get_memory_path(memory_dir: str, agent_name: str) -> str:
     return f"{memory_dir.rstrip('/')}/{agent_name}/{DEFAULT_MEMORY_FILENAME}"
 
 
-def load_memory(
-    backend: BackendProtocol,
+async def load_memory(
+    backend: AsyncBackendProtocol,
     path: str,
     agent_name: str = "main",
 ) -> MemoryFile | None:
@@ -106,7 +106,7 @@ def load_memory(
     (issue #135).
 
     Args:
-        backend: Backend to read from.
+        backend: Async backend to read from.
         path: Full path to the memory file.
         agent_name: Name of the agent owning this memory.
 
@@ -116,7 +116,7 @@ def load_memory(
     Raises:
         MemoryAccessError: If the backend denied access to the path.
     """
-    raw = backend.read_bytes(path)
+    raw = await backend.read_bytes(path)
     if raw:
         content = raw.decode("utf-8", errors="replace")
         return MemoryFile(agent_name=agent_name, path=path, content=content)
@@ -125,7 +125,7 @@ def load_memory(
     # are indistinguishable there. Probe via `read`, which surfaces access
     # errors as an "Error: ..." string while reporting a missing file as
     # "Error: ... not found". Anything else (or empty) is missing/empty memory.
-    probe = backend.read(path)
+    probe = await backend.read(path)
     if probe.startswith("Error:") and "not found" not in probe.lower():
         raise MemoryAccessError(probe.removeprefix("Error:").strip() or "access denied")
     return None
@@ -199,9 +199,9 @@ class AgentMemoryToolset(FunctionToolset[Any]):
         @self.tool(description=self._descs.get("read_memory", READ_MEMORY_DESCRIPTION))
         async def read_memory(ctx: RunContext[Any]) -> str:
             """Read your persistent memory."""
-            backend: BackendProtocol = ctx.deps.backend
+            backend: AsyncBackendProtocol = ctx.deps.backend
             try:
-                mem = load_memory(backend, self._path, self._agent_name)
+                mem = await load_memory(backend, self._path, self._agent_name)
             except MemoryAccessError as exc:
                 return f"Error: cannot read memory at '{self._path}': {exc}"
             if mem is None:
@@ -215,13 +215,13 @@ class AgentMemoryToolset(FunctionToolset[Any]):
             Args:
                 content: Text to append to memory (markdown recommended).
             """
-            backend: BackendProtocol = ctx.deps.backend
+            backend: AsyncBackendProtocol = ctx.deps.backend
             try:
-                existing = load_memory(backend, self._path, self._agent_name)
+                existing = await load_memory(backend, self._path, self._agent_name)
             except MemoryAccessError as exc:
                 return f"Error: cannot access memory at '{self._path}': {exc}"
             new_content = existing.content.rstrip("\n") + "\n\n" + content if existing else content
-            result = backend.write(self._path, new_content.encode("utf-8"))
+            result = await backend.write(self._path, new_content.encode("utf-8"))
             if result.error:
                 return f"Error: failed to save memory to '{self._path}': {result.error}"
             line_count = len(new_content.splitlines())
@@ -243,9 +243,9 @@ class AgentMemoryToolset(FunctionToolset[Any]):
                 old_text: The exact text to find in memory (must be unique).
                 new_text: The text to replace it with.
             """
-            backend: BackendProtocol = ctx.deps.backend
+            backend: AsyncBackendProtocol = ctx.deps.backend
             try:
-                mem = load_memory(backend, self._path, self._agent_name)
+                mem = await load_memory(backend, self._path, self._agent_name)
             except MemoryAccessError as exc:
                 return f"Error: cannot access memory at '{self._path}': {exc}"
             if mem is None:
@@ -260,7 +260,7 @@ class AgentMemoryToolset(FunctionToolset[Any]):
                     "so it matches exactly once."
                 )
             updated = mem.content.replace(old_text, new_text, 1)
-            result = backend.write(self._path, updated.encode("utf-8"))
+            result = await backend.write(self._path, updated.encode("utf-8"))
             if result.error:
                 return f"Error: failed to save memory to '{self._path}': {result.error}"
             line_count = len(updated.splitlines())
@@ -275,9 +275,9 @@ class AgentMemoryToolset(FunctionToolset[Any]):
         Returns:
             Formatted memory prompt, or None if no memory exists.
         """
-        backend: BackendProtocol = ctx.deps.backend
+        backend: AsyncBackendProtocol = ctx.deps.backend
         try:
-            mem = load_memory(backend, self._path, self._agent_name)
+            mem = await load_memory(backend, self._path, self._agent_name)
         except MemoryAccessError:
             # Prompt injection runs on every request; a denied path must not
             # abort the run. Skip injection here — the failure is surfaced

--- a/pydantic_deep/toolsets/plan/toolset.py
+++ b/pydantic_deep/toolsets/plan/toolset.py
@@ -224,7 +224,7 @@ def create_plan_toolset(
         path = f"{plans_dir}/{filename}"
 
         # Write to backend
-        result = ctx.deps.backend.write(path, content.encode("utf-8"))
+        result = await ctx.deps.backend.write(path, content.encode("utf-8"))
         if hasattr(result, "error") and result.error:
             return f"Error saving plan: {result.error}"
 

--- a/pydantic_deep/toolsets/skills/backend.py
+++ b/pydantic_deep/toolsets/skills/backend.py
@@ -16,7 +16,7 @@ import json
 import shlex
 import warnings
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 from pydantic_ai_backends import (
     AsyncBackendProtocol,
@@ -552,7 +552,7 @@ class BackendSkillsDirectory:
         scripts: list[BackendSkillScript] = []
         if isinstance(self._backend, SandboxProtocol):
             executor = BackendSkillScriptExecutor(
-                backend=async_backend,  # type: ignore[arg-type]
+                backend=cast("AsyncSandboxProtocol", async_backend),
                 timeout=self._script_timeout,
             )
             scripts = _discover_backend_scripts(self._backend, skill_dir, name, executor)

--- a/pydantic_deep/toolsets/skills/backend.py
+++ b/pydantic_deep/toolsets/skills/backend.py
@@ -551,9 +551,8 @@ class BackendSkillsDirectory:
         # Discover scripts (only if backend supports execution)
         scripts: list[BackendSkillScript] = []
         if isinstance(self._backend, SandboxProtocol):
-            sandbox_async = ensure_async(self._backend)
             executor = BackendSkillScriptExecutor(
-                backend=sandbox_async,  # type: ignore[arg-type]
+                backend=async_backend,  # type: ignore[arg-type]
                 timeout=self._script_timeout,
             )
             scripts = _discover_backend_scripts(self._backend, skill_dir, name, executor)

--- a/pydantic_deep/toolsets/skills/backend.py
+++ b/pydantic_deep/toolsets/skills/backend.py
@@ -18,8 +18,16 @@ import warnings
 from dataclasses import dataclass, field
 from typing import Any
 
-from pydantic_ai_backends import AsyncBackendProtocol, AsyncSandboxProtocol, BackendProtocol, SandboxProtocol, ensure_async
+from pydantic_ai_backends import (
+    AsyncBackendProtocol,
+    AsyncSandboxProtocol,
+    BackendProtocol,
+    SandboxProtocol,
+    ensure_async,
+)
 from pydantic_ai_backends.types import ExecuteResponse
+
+from pydantic_deep.deps import unwrap_backend
 
 from .directory import _parse_skill_md, _validate_skill_metadata
 from .exceptions import (
@@ -441,7 +449,7 @@ class BackendSkillsDirectory:
         """
         # Unwrap adapter if needed — discovery calls sync backend methods
         # directly because __init__ cannot be async.
-        raw = getattr(backend, "unwrap", lambda: backend)()
+        raw = unwrap_backend(backend)
         self._backend = raw
         self._path = path
         self._validate = validate
@@ -504,7 +512,7 @@ class BackendSkillsDirectory:
         Returns:
             Loaded Skill object, or None if skill should be skipped.
         """
-        content_bytes = self._backend._read_bytes(skill_file_path)
+        content_bytes = self._backend.read_bytes(skill_file_path)
         content = content_bytes.decode("utf-8")
 
         frontmatter, instructions = _parse_skill_md(content)
@@ -543,8 +551,9 @@ class BackendSkillsDirectory:
         # Discover scripts (only if backend supports execution)
         scripts: list[BackendSkillScript] = []
         if isinstance(self._backend, SandboxProtocol):
+            sandbox_async = ensure_async(self._backend)
             executor = BackendSkillScriptExecutor(
-                backend=async_backend,
+                backend=sandbox_async,  # type: ignore[arg-type]
                 timeout=self._script_timeout,
             )
             scripts = _discover_backend_scripts(self._backend, skill_dir, name, executor)

--- a/pydantic_deep/toolsets/skills/backend.py
+++ b/pydantic_deep/toolsets/skills/backend.py
@@ -18,7 +18,7 @@ import warnings
 from dataclasses import dataclass, field
 from typing import Any
 
-from pydantic_ai_backends import BackendProtocol, SandboxProtocol
+from pydantic_ai_backends import AsyncBackendProtocol, AsyncSandboxProtocol, BackendProtocol, SandboxProtocol, ensure_async
 from pydantic_ai_backends.types import ExecuteResponse
 
 from .directory import _parse_skill_md, _validate_skill_metadata
@@ -54,7 +54,7 @@ class BackendSkillResource(SkillResource):
         backend: Backend instance used for reading the resource.
     """
 
-    backend: BackendProtocol = field(default=None, repr=False)  # pyright: ignore[reportAssignmentType]
+    backend: AsyncBackendProtocol = field(default=None, repr=False)  # pyright: ignore[reportAssignmentType]
 
     async def load(self, ctx: Any, args: dict[str, Any] | None = None) -> Any:
         """Load resource content from the backend.
@@ -79,7 +79,7 @@ class BackendSkillResource(SkillResource):
             raise SkillResourceLoadError(f"Resource '{self.name}' has no backend configured")
 
         try:
-            content_bytes = self.backend.read_bytes(self.uri)
+            content_bytes = await self.backend.read_bytes(self.uri)
             content = content_bytes.decode("utf-8")
         except Exception as e:
             raise SkillResourceLoadError(
@@ -118,13 +118,13 @@ class BackendSkillScriptExecutor:
 
     def __init__(
         self,
-        backend: SandboxProtocol,
+        backend: AsyncSandboxProtocol,
         timeout: int = 30,
     ) -> None:
         """Initialize the backend script executor.
 
         Args:
-            backend: Sandbox backend with execute() support.
+            backend: Async sandbox backend with execute() support.
             timeout: Execution timeout in seconds (default: 30).
         """
         self._backend = backend
@@ -172,7 +172,7 @@ class BackendSkillScriptExecutor:
         command = " ".join(cmd_parts)
 
         try:
-            result: ExecuteResponse = self._backend.execute(command, self.timeout)
+            result: ExecuteResponse = await self._backend.execute(command, self.timeout)
         except Exception as e:
             raise SkillScriptExecutionError(
                 f"Failed to execute script '{script.name}' via backend: {e}"
@@ -228,7 +228,7 @@ class BackendSkillScript(SkillScript):
 def create_backend_resource(
     name: str,
     uri: str,
-    backend: BackendProtocol,
+    backend: AsyncBackendProtocol,
     description: str | None = None,
 ) -> BackendSkillResource:
     """Create a backend-based resource.
@@ -236,7 +236,7 @@ def create_backend_resource(
     Args:
         name: Resource name (e.g., "FORMS.md", "data.json").
         uri: Path to the resource file within the backend.
-        backend: Backend instance for reading the resource.
+        backend: Async backend instance for reading the resource.
         description: Optional resource description.
 
     Returns:
@@ -311,13 +311,15 @@ def _get_relative_path(file_path: str, base_dir: str) -> str:
 
 
 def _discover_backend_resources(
-    backend: BackendProtocol,
+    sync_backend: BackendProtocol,
+    async_backend: AsyncBackendProtocol,
     skill_dir: str,
 ) -> list[BackendSkillResource]:
     """Discover resource files in a skill directory via backend.
 
     Args:
-        backend: Backend to read from.
+        sync_backend: Raw sync backend used for ``glob_info`` discovery.
+        async_backend: Async-wrapped backend stored on resources for ``read_bytes`` at load time.
         skill_dir: Skill directory path in the backend.
 
     Returns:
@@ -327,7 +329,7 @@ def _discover_backend_resources(
 
     for ext in sorted(_SUPPORTED_EXTENSIONS):
         try:
-            matches = backend.glob_info(f"**/*{ext}", skill_dir)
+            matches = sync_backend.glob_info(f"**/*{ext}", skill_dir)
         except Exception:
             continue
 
@@ -341,7 +343,7 @@ def _discover_backend_resources(
                 create_backend_resource(
                     name=rel_path,
                     uri=file_info["path"],
-                    backend=backend,
+                    backend=async_backend,
                 )
             )
 
@@ -437,27 +439,25 @@ class BackendSkillsDirectory:
             max_depth: Maximum depth for skill discovery (None for unlimited).
             script_timeout: Timeout for script execution in seconds.
         """
-        self._backend = backend
+        # Unwrap adapter if needed — discovery calls sync backend methods
+        # directly because __init__ cannot be async.
+        raw = getattr(backend, "unwrap", lambda: backend)()
+        self._backend = raw
         self._path = path
         self._validate = validate
         self._max_depth = max_depth
         self._script_timeout = script_timeout
 
-        # Discover skills from backend
+        # Discover skills from backend (sync — raw backend is always sync)
         self._skills: dict[str, Skill] = self.get_skills()
 
     def get_skills(self) -> dict[str, Skill]:
-        """Discover and load all skills from the backend.
-
-        Returns:
-            Dictionary mapping skill name to Skill objects.
-        """
+        """Discover and load all skills from the backend."""
         skills: dict[str, Skill] = {}
 
         # Find all SKILL.md files
         try:
             if self._max_depth is not None:
-                # Build depth-limited patterns
                 skill_files = []
                 for depth in range(self._max_depth + 1):
                     pattern = "SKILL.md" if depth == 0 else "/".join(["*"] * depth) + "/SKILL.md"
@@ -504,7 +504,7 @@ class BackendSkillsDirectory:
         Returns:
             Loaded Skill object, or None if skill should be skipped.
         """
-        content_bytes = self._backend.read_bytes(skill_file_path)
+        content_bytes = self._backend._read_bytes(skill_file_path)
         content = content_bytes.decode("utf-8")
 
         frontmatter, instructions = _parse_skill_md(content)
@@ -520,7 +520,6 @@ class BackendSkillsDirectory:
                     stacklevel=3,
                 )
                 return None
-            # Use last directory component as name
             skill_dir = _get_skill_dir(skill_file_path)
             name = skill_dir.rsplit("/", 1)[-1]
 
@@ -537,14 +536,15 @@ class BackendSkillsDirectory:
 
         skill_dir = _get_skill_dir(skill_file_path)
 
-        # Discover resources
-        resources = _discover_backend_resources(self._backend, skill_dir)
+        # Discover resources — sync backend for glob_info, async for resource loading
+        async_backend = ensure_async(self._backend)
+        resources = _discover_backend_resources(self._backend, async_backend, skill_dir)
 
         # Discover scripts (only if backend supports execution)
         scripts: list[BackendSkillScript] = []
         if isinstance(self._backend, SandboxProtocol):
             executor = BackendSkillScriptExecutor(
-                backend=self._backend,
+                backend=async_backend,
                 timeout=self._script_timeout,
             )
             scripts = _discover_backend_scripts(self._backend, skill_dir, name, executor)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,5 +245,7 @@ disable_error_code = ["arg-type", "list-item", "abstract"]
 [tool.codespell]
 skip = ".git,.venv*,uv.lock,site,htmlcov,.coverage"
 
+# TODO: Remove before merge — needed until pydantic-ai-backend with
+# AsyncBackendProtocol / ensure_async is published to PyPI.
 [tool.uv.sources]
 pydantic-ai-backend = { path = "../pydantic-ai-backend", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,3 +244,6 @@ disable_error_code = ["arg-type", "list-item", "abstract"]
 # Codespell configuration
 [tool.codespell]
 skip = ".git,.venv*,uv.lock,site,htmlcov,.coverage"
+
+[tool.uv.sources]
+pydantic-ai-backend = { path = "../pydantic-ai-backend", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,6 +244,3 @@ disable_error_code = ["arg-type", "list-item", "abstract"]
 # Codespell configuration
 [tool.codespell]
 skip = ".git,.venv*,uv.lock,site,htmlcov,.coverage"
-
-[tool.uv.sources]
-pydantic-ai-backend = { path = "../pydantic-ai-backend", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,8 +244,3 @@ disable_error_code = ["arg-type", "list-item", "abstract"]
 # Codespell configuration
 [tool.codespell]
 skip = ".git,.venv*,uv.lock,site,htmlcov,.coverage"
-
-# TODO: Remove before merge — needed until pydantic-ai-backend with
-# AsyncBackendProtocol / ensure_async is published to PyPI.
-[tool.uv.sources]
-pydantic-ai-backend = { path = "../pydantic-ai-backend", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 dependencies = [
     "pydantic-ai-slim[web-fetch]>=1.97.0",
     "pydantic-ai-todo>=0.2.4",
-    "pydantic-ai-backend[console]>=0.2.11",
+    "pydantic-ai-backend[console]>=0.2.14",
     "summarization-pydantic-ai>=0.1.7",
     "subagents-pydantic-ai>=0.2.7",
     "pydantic-ai-shields>=0.3.4",
@@ -52,7 +52,7 @@ dependencies = [
 
 [project.optional-dependencies]
 # Docker sandbox support
-sandbox = ["pydantic-ai-backend[docker]>=0.2.11"]
+sandbox = ["pydantic-ai-backend[docker]>=0.2.14"]
 # YAML support for skills (pyyaml-based frontmatter parsing)
 yaml = ["pyyaml>=6.0"]
 # CLI tools + TUI (terminal assistant)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -258,7 +258,7 @@ class TestCreateDefaultDeps:
         deps = create_default_deps()
 
         assert deps is not None
-        assert isinstance(deps.backend, StateBackend)
+        assert isinstance(deps.backend.unwrap(), StateBackend)
         assert deps.todos == []
         assert deps.subagents == {}
 
@@ -267,7 +267,7 @@ class TestCreateDefaultDeps:
         backend = StateBackend()
         deps = create_default_deps(backend=backend)
 
-        assert deps.backend is backend
+        assert deps.backend.unwrap() is backend
 
 
 class TestDeepAgentDeps:
@@ -356,18 +356,18 @@ class TestDeepAgentDeps:
         cloned = original.clone_for_subagent()
         assert cloned.checkpoint_store is store
 
-    def test_upload_file(self):
+    async def test_upload_file(self):
         """Test uploading a file."""
         deps = DeepAgentDeps(backend=StateBackend())
 
         content = b"id,name,value\n1,foo,100\n2,bar,200\n"
-        path = deps.upload_file("data.csv", content)
+        path = await deps.upload_file("data.csv", content)
 
         # Check path is correct
         assert path == "/uploads/data.csv"
 
         # Check file is in backend
-        file_data = deps.backend.read(path)
+        file_data = await deps.backend.read(path)
         assert file_data is not None
         assert "id,name,value" in file_data
 
@@ -377,17 +377,17 @@ class TestDeepAgentDeps:
         assert deps.uploads[path]["size"] == len(content)
         assert deps.uploads[path]["line_count"] == 3
 
-    def test_upload_file_custom_dir(self):
+    async def test_upload_file_custom_dir(self):
         """Test uploading a file to a custom directory."""
         deps = DeepAgentDeps(backend=StateBackend())
 
         content = b"test content"
-        path = deps.upload_file("test.txt", content, upload_dir="/custom/dir")
+        path = await deps.upload_file("test.txt", content, upload_dir="/custom/dir")
 
         assert path == "/custom/dir/test.txt"
         assert path in deps.uploads
 
-    def test_upload_file_binary(self):
+    async def test_upload_file_binary(self):
         """Test uploading a binary file (non-UTF-8)."""
         from unittest.mock import patch
 
@@ -396,13 +396,13 @@ class TestDeepAgentDeps:
         # Binary content - mock chardet to return no encoding (platform-dependent)
         content = bytes([0x80, 0x81, 0x82, 0xFF])
         with patch("pydantic_deep.deps.chardet.detect", return_value={"encoding": None}):
-            path = deps.upload_file("binary.dat", content)
+            path = await deps.upload_file("binary.dat", content)
 
         assert path == "/uploads/binary.dat"
         # Binary files should have line_count = None
         assert deps.uploads[path]["line_count"] is None
 
-    def test_upload_files_skips_failures(self):
+    async def test_upload_files_skips_failures(self):
         """A failing file should not abort the rest of the batch."""
         from unittest.mock import patch
 
@@ -410,15 +410,15 @@ class TestDeepAgentDeps:
 
         real_upload_file = deps.upload_file
 
-        def flaky_upload_file(name, content, *, upload_dir="/uploads"):
+        async def flaky_upload_file(name, content, *, upload_dir="/uploads"):
             # Simulate a non-RuntimeError failure mid-batch (e.g. an
             # encoding/metadata error or a backend that raises directly).
             if name == "bad.bin":
                 raise ValueError("boom")
-            return real_upload_file(name, content, upload_dir=upload_dir)
+            return await real_upload_file(name, content, upload_dir=upload_dir)
 
         with patch.object(deps, "upload_file", side_effect=flaky_upload_file):
-            paths = deps.upload_files(
+            paths = await deps.upload_files(
                 [
                     ("good1.csv", b"a,b\n1,2\n"),
                     ("bad.bin", b"\x00\x01"),
@@ -436,12 +436,12 @@ class TestDeepAgentDeps:
 
         assert summary == ""
 
-    def test_get_uploads_summary_with_files(self):
+    async def test_get_uploads_summary_with_files(self):
         """Test uploads summary with uploaded files."""
         deps = DeepAgentDeps(backend=StateBackend())
 
-        deps.upload_file("data.csv", b"a,b,c\n1,2,3\n")
-        deps.upload_file("config.json", b'{"key": "value"}')
+        await deps.upload_file("data.csv", b"a,b,c\n1,2,3\n")
+        await deps.upload_file("config.json", b'{"key": "value"}')
 
         summary = deps.get_uploads_summary()
 
@@ -451,7 +451,7 @@ class TestDeepAgentDeps:
         assert "2 lines" in summary  # data.csv has 2 lines
         assert "read_file" in summary  # instruction about how to use files
 
-    def test_get_uploads_summary_with_binary_files(self):
+    async def test_get_uploads_summary_with_binary_files(self):
         """Test uploads summary with binary files (no line count)."""
         from unittest.mock import patch
 
@@ -459,7 +459,7 @@ class TestDeepAgentDeps:
 
         # Binary file - mock chardet to return no encoding (platform-dependent)
         with patch("pydantic_deep.deps.chardet.detect", return_value={"encoding": None}):
-            deps.upload_file("binary.dat", bytes([0x80, 0x81, 0x82]))
+            await deps.upload_file("binary.dat", bytes([0x80, 0x81, 0x82]))
 
         summary = deps.get_uploads_summary()
 

--- a/tests/test_agent_extended.py
+++ b/tests/test_agent_extended.py
@@ -709,7 +709,7 @@ class TestFallbackModel:
         from pydantic_deep.agent import _wrap_with_fallback_and_hooks
         from pydantic_deep.capabilities.hooks import Hook, HookEvent
 
-        class _CommandBackend(StateBackend):
+        class _CommandBackend(StateBackend):  # type: ignore[misc]
             id = "command-backend"
 
             def __init__(self) -> None:

--- a/tests/test_agent_extended.py
+++ b/tests/test_agent_extended.py
@@ -267,7 +267,7 @@ class TestDeepAgentDepsExtended:
         """Test that __post_init__ works with non-StateBackend."""
         # This covers the branch where backend is NOT a StateBackend
         deps = DeepAgentDeps(backend=local_backend)
-        assert deps.backend is local_backend
+        assert deps.backend.unwrap() is local_backend
         # files dict should remain empty (not synced from backend)
         assert deps.files == {}
 

--- a/tests/test_agent_extended.py
+++ b/tests/test_agent_extended.py
@@ -698,6 +698,44 @@ class TestFallbackModel:
         pairs = {(r.tool_input["primary"], r.tool_input["fallback"]) for r in received}
         assert len(pairs) == 1, f"primary→fallback pair drifted across requests: {pairs}"
 
+    async def test_model_fallback_command_hook_wraps_sync_sandbox_backend(self) -> None:
+        """Regression: fallback command hooks receive the factory's sync backend.
+
+        The async migration made command hook dispatch require an async sandbox;
+        the fallback wrapper must normalize the sync sandbox before dispatching.
+        """
+        from pydantic_ai_backends import ExecuteResponse
+
+        from pydantic_deep.agent import _wrap_with_fallback_and_hooks
+        from pydantic_deep.capabilities.hooks import Hook, HookEvent
+
+        class _CommandBackend(StateBackend):
+            id = "command-backend"
+
+            def __init__(self) -> None:
+                super().__init__()
+                self.executed: list[str] = []
+
+            def execute(self, command: str, timeout: int | None = None) -> ExecuteResponse:
+                self.executed.append(command)
+                return ExecuteResponse(output="", exit_code=0)
+
+        backend = _CommandBackend()
+        model = _wrap_with_fallback_and_hooks(
+            TestModel(),
+            [TestModel()],
+            [Hook(event=HookEvent.MODEL_FALLBACK_TRIGGERED, command="cat")],
+            backend,
+        )
+
+        _fallback_on = cast(
+            "Awaitable[bool]",
+            model._exception_handlers[0](ModelAPIError("primary-model", "rate limit exceeded")),
+        )
+        assert await _fallback_on is True
+        assert len(backend.executed) == 1
+        assert "model_fallback_triggered" in backend.executed[0]
+
     async def test_request_stream_resets_hop_counter(self) -> None:
         """`request_stream` must also zero the per-context hop counter."""
         from pydantic_ai.messages import ModelRequest, UserPromptPart

--- a/tests/test_cli_agent.py
+++ b/tests/test_cli_agent.py
@@ -165,7 +165,7 @@ class TestCreateCliAgent:
         # Local sandbox — workspace ignored when Docker is not active
         from pydantic_ai_backends import LocalBackend
 
-        assert isinstance(deps.backend, LocalBackend)
+        assert isinstance(deps.backend.unwrap(), LocalBackend)
 
     def test_sandbox_local_is_default(self, tmp_path: Path) -> None:
         """Default sandbox is local (no Docker)."""
@@ -175,7 +175,7 @@ class TestCreateCliAgent:
         )
         from pydantic_ai_backends import LocalBackend
 
-        assert isinstance(deps.backend, LocalBackend)
+        assert isinstance(deps.backend.unwrap(), LocalBackend)
 
 
 class TestShellAllowListHook:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -463,15 +463,15 @@ class TestContextToolset:
         ctx = _make_ctx(backend)
 
         read_counts: dict[str, int] = {}
-        # _read_bytes is the sync read that AsyncBackendAdapter delegates to.
-        original_read = backend._read_bytes
+        # read_bytes is the sync read that AsyncBackendAdapter delegates to.
+        original_read = backend.read_bytes
 
         def _counting_read(path: str) -> bytes:
             read_counts[path] = read_counts.get(path, 0) + 1
             data: bytes = original_read(path)
             return data
 
-        monkeypatch.setattr(backend, "_read_bytes", _counting_read)
+        monkeypatch.setattr(backend, "read_bytes", _counting_read)
 
         toolset = ContextToolset(context_discovery=True)
         result = await toolset.get_instructions(ctx)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -463,6 +463,7 @@ class TestContextToolset:
         ctx = _make_ctx(backend)
 
         read_counts: dict[str, int] = {}
+        # _read_bytes is the sync read that AsyncBackendAdapter delegates to.
         original_read = backend._read_bytes
 
         def _counting_read(path: str) -> bytes:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -4,7 +4,7 @@ import pytest
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import RunContext
 from pydantic_ai.usage import RunUsage
-from pydantic_ai_backends import StateBackend
+from pydantic_ai_backends import StateBackend, ensure_async
 
 from pydantic_deep import (
     DEFAULT_CONTEXT_FILENAMES,
@@ -48,64 +48,64 @@ class TestContextFile:
 class TestLoadContextFiles:
     """Tests for load_context_files function."""
 
-    def test_load_existing_file(self):
+    async def test_load_existing_file(self):
         """Test loading an existing context file."""
         backend = StateBackend()
         backend.write("/DEEP.md", "# Project Rules\nUse Python 3.12")
 
-        files = load_context_files(backend, ["/DEEP.md"])
+        files = await load_context_files(ensure_async(backend), ["/DEEP.md"])
         assert len(files) == 1
         assert files[0].name == "DEEP.md"
         assert files[0].path == "/DEEP.md"
         assert "Project Rules" in files[0].content
 
-    def test_load_multiple_files(self):
+    async def test_load_multiple_files(self):
         """Test loading multiple context files."""
         backend = StateBackend()
         backend.write("/DEEP.md", "# Deep rules")
         backend.write("/AGENTS.md", "# Agent instructions")
 
-        files = load_context_files(backend, ["/DEEP.md", "/AGENTS.md"])
+        files = await load_context_files(ensure_async(backend), ["/DEEP.md", "/AGENTS.md"])
         assert len(files) == 2
         assert files[0].name == "DEEP.md"
         assert files[1].name == "AGENTS.md"
 
-    def test_skip_missing_files(self):
+    async def test_skip_missing_files(self):
         """Test that missing files are silently skipped."""
         backend = StateBackend()
         backend.write("/DEEP.md", "# Exists")
 
-        files = load_context_files(backend, ["/DEEP.md", "/MISSING.md"])
+        files = await load_context_files(ensure_async(backend), ["/DEEP.md", "/MISSING.md"])
         assert len(files) == 1
         assert files[0].name == "DEEP.md"
 
-    def test_all_missing(self):
+    async def test_all_missing(self):
         """Test that all missing files returns empty list."""
         backend = StateBackend()
-        files = load_context_files(backend, ["/MISSING.md", "/ALSO_MISSING.md"])
+        files = await load_context_files(ensure_async(backend), ["/MISSING.md", "/ALSO_MISSING.md"])
         assert files == []
 
-    def test_empty_paths(self):
+    async def test_empty_paths(self):
         """Test with empty paths list."""
         backend = StateBackend()
-        files = load_context_files(backend, [])
+        files = await load_context_files(ensure_async(backend), [])
         assert files == []
 
-    def test_utf8_content(self):
+    async def test_utf8_content(self):
         """Test loading file with non-ASCII content."""
         backend = StateBackend()
         backend.write("/DEEP.md", "# Projekt\nUżyj polskich znaków: ąęćżź")
 
-        files = load_context_files(backend, ["/DEEP.md"])
+        files = await load_context_files(ensure_async(backend), ["/DEEP.md"])
         assert len(files) == 1
         assert "ąęćżź" in files[0].content
 
-    def test_nested_path(self):
+    async def test_nested_path(self):
         """Test loading file from nested path."""
         backend = StateBackend()
         backend.write("/project/config/DEEP.md", "# Nested")
 
-        files = load_context_files(backend, ["/project/config/DEEP.md"])
+        files = await load_context_files(ensure_async(backend), ["/project/config/DEEP.md"])
         assert len(files) == 1
         assert files[0].name == "DEEP.md"
         assert files[0].path == "/project/config/DEEP.md"
@@ -114,82 +114,84 @@ class TestLoadContextFiles:
 class TestDiscoverContextFiles:
     """Tests for discover_context_files function."""
 
-    def test_discover_at_root(self):
+    async def test_discover_at_root(self):
         """Test discovering context files at root."""
         backend = StateBackend()
         backend.write("/AGENTS.md", "# Agents")
 
-        found = discover_context_files(backend)
+        found = await discover_context_files(ensure_async(backend))
         assert "/AGENTS.md" in found
 
-    def test_discover_partial(self):
+    async def test_discover_partial(self):
         """Test discovering when only some files exist."""
         backend = StateBackend()
         backend.write("/AGENTS.md", "# Agents")
 
-        found = discover_context_files(backend)
+        found = await discover_context_files(ensure_async(backend))
         assert found == ["/AGENTS.md"]
 
-    def test_discover_none_found(self):
+    async def test_discover_none_found(self):
         """Test discovering when no files exist."""
         backend = StateBackend()
-        found = discover_context_files(backend)
+        found = await discover_context_files(ensure_async(backend))
         assert found == []
 
-    def test_discover_custom_filenames(self):
+    async def test_discover_custom_filenames(self):
         """Test discovering with custom filenames."""
         backend = StateBackend()
         backend.write("/CUSTOM.md", "# Custom")
         backend.write("/RULES.md", "# Rules")
 
-        found = discover_context_files(backend, filenames=["CUSTOM.md", "RULES.md", "MISSING.md"])
+        found = await discover_context_files(
+            ensure_async(backend), filenames=["CUSTOM.md", "RULES.md", "MISSING.md"]
+        )
         assert "/CUSTOM.md" in found
         assert "/RULES.md" in found
         assert len(found) == 2
 
-    def test_discover_custom_search_path(self):
+    async def test_discover_custom_search_path(self):
         """Test discovering at a custom search path."""
         backend = StateBackend()
         backend.write("/project/AGENTS.md", "# Agents")
 
-        found = discover_context_files(backend, search_path="/project")
+        found = await discover_context_files(ensure_async(backend), search_path="/project")
         assert found == ["/project/AGENTS.md"]
 
-    def test_discover_trailing_slash(self):
+    async def test_discover_trailing_slash(self):
         """Test that trailing slash is handled correctly."""
         backend = StateBackend()
         backend.write("/project/AGENTS.md", "# Agents")
 
-        found = discover_context_files(backend, search_path="/project/")
+        found = await discover_context_files(ensure_async(backend), search_path="/project/")
         assert found == ["/project/AGENTS.md"]
 
 
 class TestDiscoverAndLoad:
     """Tests for the _discover_and_load single-pass helper."""
 
-    def test_returns_loaded_files(self):
+    async def test_returns_loaded_files(self):
         """Test discovery and loading in one pass."""
         backend = StateBackend()
         backend.write("/AGENTS.md", "# Agents")
         backend.write("/SOUL.md", "# Soul")
 
-        files = _discover_and_load(backend)
+        files = await _discover_and_load(ensure_async(backend))
         names = {f.name for f in files}
         assert "AGENTS.md" in names
         assert "SOUL.md" in names
 
-    def test_none_found(self):
+    async def test_none_found(self):
         """Test empty backend returns empty list."""
         backend = StateBackend()
-        assert _discover_and_load(backend) == []
+        assert await _discover_and_load(ensure_async(backend)) == []
 
-    def test_custom_filenames_and_search_path(self):
+    async def test_custom_filenames_and_search_path(self):
         """Test custom filenames and search path with trailing slash."""
         backend = StateBackend()
         backend.write("/project/CUSTOM.md", "# Custom")
 
-        files = _discover_and_load(
-            backend, search_path="/project/", filenames=["CUSTOM.md", "MISSING.md"]
+        files = await _discover_and_load(
+            ensure_async(backend), search_path="/project/", filenames=["CUSTOM.md", "MISSING.md"]
         )
         assert len(files) == 1
         assert files[0].name == "CUSTOM.md"
@@ -461,14 +463,14 @@ class TestContextToolset:
         ctx = _make_ctx(backend)
 
         read_counts: dict[str, int] = {}
-        original_read = backend.read_bytes
+        original_read = backend._read_bytes
 
         def _counting_read(path: str) -> bytes:
             read_counts[path] = read_counts.get(path, 0) + 1
             data: bytes = original_read(path)
             return data
 
-        monkeypatch.setattr(backend, "read_bytes", _counting_read)
+        monkeypatch.setattr(backend, "_read_bytes", _counting_read)
 
         toolset = ContextToolset(context_discovery=True)
         result = await toolset.get_instructions(ctx)

--- a/tests/test_eviction.py
+++ b/tests/test_eviction.py
@@ -1,7 +1,7 @@
 """Tests for the large tool output eviction processor."""
 
 from datetime import datetime, timezone
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pydantic_ai.messages import (
@@ -16,7 +16,7 @@ from pydantic_ai.messages import (
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import RunContext, ToolDefinition
 from pydantic_ai.usage import RunUsage
-from pydantic_ai_backends import StateBackend, WriteResult
+from pydantic_ai_backends import StateBackend, WriteResult, ensure_async
 
 from pydantic_deep import (
     DEFAULT_EVICTION_PATH,
@@ -243,7 +243,7 @@ class TestEvictionProcessor:
     async def test_small_content_unchanged(self):
         """Content below threshold is not modified."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=backend, token_limit=100)
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=100)
         ctx = _make_ctx(backend)
 
         # 100 tokens * 4 chars = 400 chars threshold
@@ -261,7 +261,7 @@ class TestEvictionProcessor:
     async def test_large_content_evicted(self):
         """Content above threshold is evicted to backend."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=backend, token_limit=10)  # 40 chars threshold
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10)  # 40 chars threshold
         ctx = _make_ctx(backend)
 
         large_content = _make_large_content(20)
@@ -279,7 +279,7 @@ class TestEvictionProcessor:
         assert "read_file" in str(tool_part.content)
 
         # File should be written to backend
-        evicted_content = backend.read_bytes("/large_tool_results/call_123")
+        evicted_content = backend._read_bytes("/large_tool_results/call_123")
         assert evicted_content == large_content.encode()
 
     @pytest.mark.anyio
@@ -289,7 +289,7 @@ class TestEvictionProcessor:
         from pydantic_ai.messages import BinaryContent
 
         backend = StateBackend()
-        processor = EvictionProcessor(backend=backend, token_limit=10)  # 40-char threshold
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10)  # 40-char threshold
         ctx = _make_ctx(backend)
 
         image = BinaryContent(data=b"\x89PNG" + b"\x00" * 100_000, media_type="image/png")
@@ -303,7 +303,7 @@ class TestEvictionProcessor:
         assert isinstance(out_part, ToolReturnPart)
         # Content is the original BinaryContent, untouched.
         assert out_part.content is image
-        assert backend.read_bytes("/large_tool_results/call_bin") in (None, b"")
+        assert backend._read_bytes("/large_tool_results/call_bin") in (None, b"")
 
     async def test_evicted_ids_bounded_fifo(self):
         """The evicted-id tracking set is bounded: oldest IDs drop past the cap."""
@@ -322,7 +322,7 @@ class TestEvictionProcessor:
     async def test_eviction_preserves_metadata(self):
         """Evicted ToolReturnPart preserves metadata and timestamp."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=backend, token_limit=10)
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10)
         ctx = _make_ctx(backend)
 
         ts = datetime(2024, 6, 15, tzinfo=timezone.utc)
@@ -349,7 +349,7 @@ class TestEvictionProcessor:
     async def test_write_failure_keeps_original(self):
         """On write failure, original content is preserved."""
         mock_backend = MagicMock()
-        mock_backend.write.return_value = WriteResult(error="disk full")
+        mock_backend.write = AsyncMock(return_value=WriteResult(error="disk full"))
 
         processor = EvictionProcessor(backend=mock_backend, token_limit=10)
         # ctx.deps.backend will be from DeepAgentDeps, but we want to test
@@ -370,7 +370,7 @@ class TestEvictionProcessor:
     async def test_non_str_content_evicted(self):
         """Dict/list content is converted to string and evicted."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=backend, token_limit=10)
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10)
         ctx = _make_ctx(backend)
 
         # Dict content that serializes to >40 chars
@@ -388,7 +388,7 @@ class TestEvictionProcessor:
     async def test_skips_non_model_request(self):
         """ModelResponse messages pass through unchanged."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=backend, token_limit=10)
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10)
         ctx = _make_ctx(backend)
 
         response = ModelResponse(
@@ -404,7 +404,7 @@ class TestEvictionProcessor:
     async def test_skips_non_tool_return_parts(self):
         """UserPromptPart and other parts pass through unchanged."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=backend, token_limit=10)
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10)
         ctx = _make_ctx(backend)
 
         request = ModelRequest(
@@ -426,7 +426,7 @@ class TestEvictionProcessor:
     async def test_mixed_parts_only_large_evicted(self):
         """In a request with multiple tool returns, only large ones are evicted."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=backend, token_limit=10)
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10)
         ctx = _make_ctx(backend)
 
         small_return = _make_tool_return("small", tool_call_id="call_small")
@@ -454,7 +454,7 @@ class TestEvictionProcessor:
     async def test_idempotent_no_re_eviction(self):
         """Already-evicted tool outputs are not re-evicted on subsequent calls."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=backend, token_limit=10)
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10)
         ctx = _make_ctx(backend)
 
         large_content = "x" * 500
@@ -479,7 +479,7 @@ class TestEvictionProcessor:
     async def test_custom_token_limit(self):
         """Custom token_limit is respected."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=backend, token_limit=1000)
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=1000)
         ctx = _make_ctx(backend)
 
         # 1000 tokens * 4 = 4000 chars threshold
@@ -508,7 +508,7 @@ class TestEvictionProcessor:
         """Custom eviction_path is used for file storage."""
         backend = StateBackend()
         processor = EvictionProcessor(
-            backend=backend, token_limit=10, eviction_path="/custom/evicted"
+            backend=ensure_async(backend), token_limit=10, eviction_path="/custom/evicted"
         )
         ctx = _make_ctx(backend)
 
@@ -523,14 +523,14 @@ class TestEvictionProcessor:
         assert "/custom/evicted/" in str(tool_part.content)
 
         # Check file was written to custom path
-        evicted = backend.read_bytes("/custom/evicted/call_custom")
+        evicted = backend._read_bytes("/custom/evicted/call_custom")
         assert evicted == large_content.encode()
 
     @pytest.mark.anyio
     async def test_custom_head_tail_lines(self):
         """Custom head_lines and tail_lines are used in preview."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=backend, token_limit=10, head_lines=2, tail_lines=2)
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10, head_lines=2, tail_lines=2)
         ctx = _make_ctx(backend)
 
         large_content = _make_large_content(20)
@@ -548,7 +548,7 @@ class TestEvictionProcessor:
     async def test_preserves_request_timestamp(self):
         """Evicted ModelRequest preserves the original timestamp."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=backend, token_limit=10)
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10)
         ctx = _make_ctx(backend)
 
         ts = datetime(2024, 3, 15, 10, 30, tzinfo=timezone.utc)
@@ -566,7 +566,7 @@ class TestEvictionProcessor:
     async def test_preserves_request_instructions(self):
         """Evicted ModelRequest preserves the original instructions."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=backend, token_limit=10)
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10)
         ctx = _make_ctx(backend)
 
         request = ModelRequest(
@@ -584,7 +584,7 @@ class TestEvictionProcessor:
     async def test_multiple_messages_mixed(self):
         """Processes multiple messages correctly, only evicting large tool outputs."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=backend, token_limit=10)
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10)
         ctx = _make_ctx(backend)
 
         messages: list[ModelMessage] = [
@@ -626,7 +626,7 @@ class TestEvictionProcessor:
     async def test_empty_messages(self):
         """Empty message list returns empty."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=backend)
+        processor = EvictionProcessor(backend=ensure_async(backend))
         ctx = _make_ctx(backend)
         result = await processor(ctx, [])
         assert result == []
@@ -635,7 +635,7 @@ class TestEvictionProcessor:
     async def test_unmodified_request_not_reconstructed(self):
         """Requests with no evictions return the original object."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=backend, token_limit=10000)
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10000)
         ctx = _make_ctx(backend)
 
         original = _make_request_with_tool_return("small content")
@@ -654,7 +654,7 @@ class TestResolveBackend:
         creation_backend = StateBackend()
         runtime_backend = StateBackend()
 
-        processor = EvictionProcessor(backend=creation_backend, token_limit=10)
+        processor = EvictionProcessor(backend=ensure_async(creation_backend), token_limit=10)
         ctx = _make_ctx(runtime_backend)
 
         large_content = "x" * 500
@@ -665,17 +665,17 @@ class TestResolveBackend:
         await processor(ctx, messages)
 
         # File should be in RUNTIME backend, not creation backend
-        evicted = runtime_backend.read_bytes("/large_tool_results/call_rt")
+        evicted = runtime_backend._read_bytes("/large_tool_results/call_rt")
         assert evicted == large_content.encode()
 
         # Creation backend should NOT have the file
-        assert creation_backend.read_bytes("/large_tool_results/call_rt") == b""
+        assert creation_backend._read_bytes("/large_tool_results/call_rt") == b""
 
     @pytest.mark.anyio
     async def test_falls_back_to_self_backend(self):
         """Falls back to self.backend when deps has no backend attribute."""
         creation_backend = StateBackend()
-        processor = EvictionProcessor(backend=creation_backend, token_limit=10)
+        processor = EvictionProcessor(backend=ensure_async(creation_backend), token_limit=10)
         ctx = _make_ctx_no_backend()
 
         large_content = "x" * 500
@@ -686,7 +686,7 @@ class TestResolveBackend:
         await processor(ctx, messages)
 
         # File should be in creation (fallback) backend
-        evicted = creation_backend.read_bytes("/large_tool_results/call_fb")
+        evicted = creation_backend._read_bytes("/large_tool_results/call_fb")
         assert evicted == large_content.encode()
 
 
@@ -737,7 +737,7 @@ class TestOnEvictionCallback:
         def on_eviction(tool_name: str, file_path: str, orig: int, preview: int) -> None:
             calls.append((tool_name, file_path, orig, preview))
 
-        processor = EvictionProcessor(backend=backend, token_limit=10, on_eviction=on_eviction)
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10, on_eviction=on_eviction)
         ctx = _make_ctx(backend)
 
         large_content = _make_large_content(20)
@@ -759,7 +759,7 @@ class TestOnEvictionCallback:
         async def on_eviction(tool_name: str, file_path: str, orig: int, preview: int) -> None:
             calls.append(tool_name)
 
-        processor = EvictionProcessor(backend=backend, token_limit=10, on_eviction=on_eviction)
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10, on_eviction=on_eviction)
         ctx = _make_ctx(backend)
 
         large_content = _make_large_content(20)
@@ -774,7 +774,7 @@ class TestOnEvictionCallback:
         """on_eviction is NOT called when content is small."""
         backend = StateBackend()
         cb = MagicMock()
-        processor = EvictionProcessor(backend=backend, token_limit=100, on_eviction=cb)
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=100, on_eviction=cb)
         ctx = _make_ctx(backend)
 
         messages: list[ModelMessage] = [_make_request_with_tool_return("small")]
@@ -872,7 +872,7 @@ class TestEvictionPreviewFormat:
     async def test_preview_contains_head_and_tail(self):
         """Eviction preview shows head and tail lines of original content."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=backend, token_limit=10, head_lines=3, tail_lines=3)
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10, head_lines=3, tail_lines=3)
         ctx = _make_ctx(backend)
 
         lines = [f"line_{i}" for i in range(20)]
@@ -901,7 +901,7 @@ class TestEvictionPreviewFormat:
     async def test_evicted_file_readable(self):
         """Evicted file content matches the original tool output."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=backend, token_limit=10)
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10)
         ctx = _make_ctx(backend)
 
         original_content = _make_large_content(50)
@@ -912,7 +912,7 @@ class TestEvictionPreviewFormat:
         await processor(ctx, messages)
 
         # Read back from backend
-        stored = backend.read_bytes("/large_tool_results/call_read")
+        stored = backend._read_bytes("/large_tool_results/call_read")
         assert stored.decode() == original_content
 
 
@@ -923,7 +923,7 @@ class TestEdgeCases:
     async def test_tool_call_id_with_special_chars(self):
         """Tool call IDs with special characters are sanitized in file paths."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=backend, token_limit=10)
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10)
         ctx = _make_ctx(backend)
 
         messages: list[ModelMessage] = [
@@ -940,7 +940,7 @@ class TestEdgeCases:
     async def test_content_exactly_at_threshold(self):
         """Content exactly at the threshold is NOT evicted (uses <=)."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=backend, token_limit=10)  # 40 chars
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10)  # 40 chars
         ctx = _make_ctx(backend)
 
         exact_content = "x" * 40  # Exactly at threshold
@@ -957,7 +957,7 @@ class TestEdgeCases:
     async def test_content_one_over_threshold(self):
         """Content one char over the threshold IS evicted."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=backend, token_limit=10)  # 40 chars
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10)  # 40 chars
         ctx = _make_ctx(backend)
 
         over_content = "x" * 41  # One over threshold
@@ -974,7 +974,7 @@ class TestEdgeCases:
     async def test_request_with_only_user_prompt(self):
         """Request with only UserPromptPart passes through unchanged."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=backend, token_limit=10)
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10)
         ctx = _make_ctx(backend)
 
         request = ModelRequest(
@@ -990,7 +990,7 @@ class TestEdgeCases:
     async def test_model_response_with_tool_call(self):
         """ModelResponse containing ToolCallPart is not processed (not ModelRequest)."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=backend, token_limit=10)
+        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10)
         ctx = _make_ctx(backend)
 
         response = ModelResponse(
@@ -1029,7 +1029,7 @@ class TestEvictionCapability:
     async def test_small_result_unchanged(self):
         """Results below threshold pass through unchanged."""
         backend = StateBackend()
-        cap = EvictionCapability(backend=backend, token_limit=100)
+        cap = EvictionCapability(backend=ensure_async(backend), token_limit=100)
         ctx = _make_ctx(backend)
 
         result = await cap.after_tool_execute(
@@ -1045,7 +1045,7 @@ class TestEvictionCapability:
     async def test_large_result_evicted(self):
         """Results above threshold are saved to file and replaced with preview."""
         backend = StateBackend()
-        cap = EvictionCapability(backend=backend, token_limit=10)  # 40 chars
+        cap = EvictionCapability(backend=ensure_async(backend), token_limit=10)  # 40 chars
         ctx = _make_ctx(backend)
 
         large = _make_large_content(20)
@@ -1060,7 +1060,7 @@ class TestEvictionCapability:
         assert "Tool result too large" in result
         assert "/large_tool_results/call_big" in result
         # File was written
-        evicted = backend.read_bytes("/large_tool_results/call_big")
+        evicted = backend._read_bytes("/large_tool_results/call_big")
         assert evicted == large.encode()
 
     @pytest.mark.anyio
@@ -1068,7 +1068,7 @@ class TestEvictionCapability:
         """Resolves backend from ctx.deps over fallback."""
         fallback = StateBackend()
         deps_backend = StateBackend()
-        cap = EvictionCapability(backend=fallback, token_limit=10)
+        cap = EvictionCapability(backend=ensure_async(fallback), token_limit=10)
         ctx = _make_ctx(deps_backend)
 
         large = "x" * 500
@@ -1081,8 +1081,8 @@ class TestEvictionCapability:
         )
 
         # Written to deps_backend, not fallback
-        assert deps_backend.read_bytes("/large_tool_results/call_deps") not in (None, b"")
-        assert fallback.read_bytes("/large_tool_results/call_deps") in (None, b"")
+        assert deps_backend._read_bytes("/large_tool_results/call_deps") not in (None, b"")
+        assert fallback._read_bytes("/large_tool_results/call_deps") in (None, b"")
 
     @pytest.mark.anyio
     async def test_no_backend_passes_through(self):
@@ -1105,7 +1105,7 @@ class TestEvictionCapability:
         """on_eviction callback is invoked on eviction."""
         backend = StateBackend()
         callback = MagicMock()
-        cap = EvictionCapability(backend=backend, token_limit=10, on_eviction=callback)
+        cap = EvictionCapability(backend=ensure_async(backend), token_limit=10, on_eviction=callback)
         ctx = _make_ctx(backend)
 
         await cap.after_tool_execute(
@@ -1131,7 +1131,7 @@ class TestEvictionCapability:
             return WriteResult(path=path, error="disk full")
 
         backend.write = failing_write
-        cap = EvictionCapability(backend=backend, token_limit=10)
+        cap = EvictionCapability(backend=ensure_async(backend), token_limit=10)
         ctx = _make_ctx(backend)
 
         large = "x" * 500
@@ -1153,7 +1153,7 @@ class TestEvictionCapability:
         async def async_cb(tool_name: str, file_path: str, orig: int, preview: int) -> None:
             called_with.append((tool_name, file_path, orig, preview))
 
-        cap = EvictionCapability(backend=backend, token_limit=10, on_eviction=async_cb)
+        cap = EvictionCapability(backend=ensure_async(backend), token_limit=10, on_eviction=async_cb)
         ctx = _make_ctx(backend)
 
         await cap.after_tool_execute(
@@ -1172,7 +1172,7 @@ class TestEvictionCapability:
     async def test_dict_result_evicted(self):
         """Non-string results (dicts) are also evicted when large."""
         backend = StateBackend()
-        cap = EvictionCapability(backend=backend, token_limit=10)
+        cap = EvictionCapability(backend=ensure_async(backend), token_limit=10)
         ctx = _make_ctx(backend)
 
         large_dict = {"data": "x" * 500}
@@ -1207,7 +1207,7 @@ class TestEvictionCapabilityToolReturn:
         from pydantic_ai.messages import BinaryContent, ToolReturn
 
         backend = StateBackend()
-        cap = EvictionCapability(backend=backend, token_limit=10)
+        cap = EvictionCapability(backend=ensure_async(backend), token_limit=10)
         ctx = _make_ctx(backend)
 
         screenshot = BinaryContent(data=b"\xff\xd8" + b"x" * 1024, media_type="image/jpeg")
@@ -1230,7 +1230,7 @@ class TestEvictionCapabilityToolReturn:
         # content (with the BinaryContent) is preserved as-is
         assert result.content == original.content
         # Backend was not asked to store anything (no eviction)
-        assert backend.read_bytes("/large_tool_results/call_screenshot") in (None, b"")
+        assert backend._read_bytes("/large_tool_results/call_screenshot") in (None, b"")
 
     @pytest.mark.anyio
     async def test_toolreturn_evicts_only_return_value(self):
@@ -1238,7 +1238,7 @@ class TestEvictionCapabilityToolReturn:
         from pydantic_ai.messages import BinaryContent, ToolReturn
 
         backend = StateBackend()
-        cap = EvictionCapability(backend=backend, token_limit=10)  # 40 chars
+        cap = EvictionCapability(backend=ensure_async(backend), token_limit=10)  # 40 chars
         ctx = _make_ctx(backend)
 
         large_text = _make_large_content(20)
@@ -1266,7 +1266,7 @@ class TestEvictionCapabilityToolReturn:
         # metadata is preserved
         assert result.metadata == {"trace_id": "abc"}
         # The text value was actually written to the backend
-        assert backend.read_bytes("/large_tool_results/call_big_tr") == large_text.encode()
+        assert backend._read_bytes("/large_tool_results/call_big_tr") == large_text.encode()
 
     @pytest.mark.anyio
     async def test_toolreturn_small_passes_through(self):
@@ -1274,7 +1274,7 @@ class TestEvictionCapabilityToolReturn:
         from pydantic_ai.messages import BinaryContent, ToolReturn
 
         backend = StateBackend()
-        cap = EvictionCapability(backend=backend, token_limit=1000)
+        cap = EvictionCapability(backend=ensure_async(backend), token_limit=1000)
         ctx = _make_ctx(backend)
 
         screenshot = BinaryContent(data=b"x" * 32, media_type="image/jpeg")
@@ -1297,7 +1297,7 @@ class TestEvictionCapabilityToolReturn:
         from pydantic_ai.messages import BinaryContent
 
         backend = StateBackend()
-        cap = EvictionCapability(backend=backend, token_limit=10)  # 40-char threshold
+        cap = EvictionCapability(backend=ensure_async(backend), token_limit=10)  # 40-char threshold
         ctx = _make_ctx(backend)
 
         image = BinaryContent(data=b"\x89PNG" + b"\x00" * 100_000, media_type="image/png")
@@ -1313,7 +1313,7 @@ class TestEvictionCapabilityToolReturn:
         assert result is image
         assert isinstance(result, BinaryContent)
         # Nothing was written to the eviction path.
-        assert backend.read_bytes("/large_tool_results/call_bare_img") in (None, b"")
+        assert backend._read_bytes("/large_tool_results/call_bare_img") in (None, b"")
 
     @pytest.mark.anyio
     async def test_list_with_binary_content_returned_unchanged(self):
@@ -1322,7 +1322,7 @@ class TestEvictionCapabilityToolReturn:
         from pydantic_ai.messages import BinaryContent
 
         backend = StateBackend()
-        cap = EvictionCapability(backend=backend, token_limit=10)
+        cap = EvictionCapability(backend=ensure_async(backend), token_limit=10)
         ctx = _make_ctx(backend)
 
         image = BinaryContent(data=b"\xff\xd8" + b"x" * 100_000, media_type="image/jpeg")
@@ -1336,7 +1336,7 @@ class TestEvictionCapabilityToolReturn:
         )
 
         assert result is original
-        assert backend.read_bytes("/large_tool_results/call_list_img") in (None, b"")
+        assert backend._read_bytes("/large_tool_results/call_list_img") in (None, b"")
 
 
 # ---------------------------------------------------------------------------
@@ -1401,7 +1401,7 @@ class TestBinaryContentRetention:
         from pydantic_ai.messages import BinaryContent
 
         backend = StateBackend()
-        cap = EvictionCapability(backend=backend, max_binary_content=2)
+        cap = EvictionCapability(backend=ensure_async(backend), max_binary_content=2)
         ctx = _make_ctx(backend)
 
         # 4 messages, each with one image - newest last
@@ -1435,7 +1435,7 @@ class TestBinaryContentRetention:
         # Pruned binaries were stored to backend with deterministic paths
         first_bin = BinaryContent(data=b"image-0-bytes" * 8, media_type="image/jpeg")
         path = f"/large_tool_results/binary_{first_bin.identifier}.jpg"
-        assert backend.read_bytes(path) == b"image-0-bytes" * 8
+        assert backend._read_bytes(path) == b"image-0-bytes" * 8
 
         # Older messages now contain the text reference
         first_part = new_messages[0].parts[0]
@@ -1449,7 +1449,7 @@ class TestBinaryContentRetention:
     async def test_under_limit_unchanged(self):
         """When binaries are at or under the limit, messages pass through unchanged."""
         backend = StateBackend()
-        cap = EvictionCapability(backend=backend, max_binary_content=3)
+        cap = EvictionCapability(backend=ensure_async(backend), max_binary_content=3)
         ctx = _make_ctx(backend)
 
         messages: list[ModelMessage] = [
@@ -1471,7 +1471,7 @@ class TestBinaryContentRetention:
         from pydantic_ai.messages import BinaryContent
 
         backend = StateBackend()
-        cap = EvictionCapability(backend=backend, max_binary_content=None)
+        cap = EvictionCapability(backend=ensure_async(backend), max_binary_content=None)
         ctx = _make_ctx(backend)
 
         messages: list[ModelMessage] = [
@@ -1493,7 +1493,7 @@ class TestBinaryContentRetention:
         from pydantic_ai.messages import BinaryContent
 
         backend = StateBackend()
-        cap = EvictionCapability(backend=backend, max_binary_content=1)
+        cap = EvictionCapability(backend=ensure_async(backend), max_binary_content=1)
         ctx = _make_ctx(backend)
 
         old_bytes = b"old-image-bytes" * 4
@@ -1526,7 +1526,7 @@ class TestBinaryContentRetention:
         # Stored bytes match the original BinaryContent.data
         old_bin = BinaryContent(data=old_bytes, media_type="image/jpeg")
         path = f"/large_tool_results/binary_{old_bin.identifier}.jpg"
-        assert backend.read_bytes(path) == old_bytes
+        assert backend._read_bytes(path) == old_bytes
 
         # ToolReturnPart metadata is preserved
         assert old_part.tool_name == "browser_screenshot"
@@ -1565,7 +1565,7 @@ class TestBinaryContentRetention:
             return WriteResult(path=path, error="disk full")
 
         backend.write = failing_write
-        cap = EvictionCapability(backend=backend, max_binary_content=1)
+        cap = EvictionCapability(backend=ensure_async(backend), max_binary_content=1)
         ctx = _make_ctx(backend)
 
         messages: list[ModelMessage] = [
@@ -1675,7 +1675,7 @@ class TestBinaryRetentionEdgeCases:
         from pydantic_ai.messages import BinaryContent
 
         backend = StateBackend()
-        cap = EvictionCapability(backend=backend, max_binary_content=1)
+        cap = EvictionCapability(backend=ensure_async(backend), max_binary_content=1)
         ctx = _make_ctx(backend)
 
         old_bytes = b"old-bare-binary"
@@ -1721,7 +1721,7 @@ class TestBinaryRetentionEdgeCases:
         # Stored bytes match the original
         old_bin = BinaryContent(data=old_bytes, media_type="image/png")
         path = f"/large_tool_results/binary_{old_bin.identifier}.png"
-        assert backend.read_bytes(path) == old_bytes
+        assert backend._read_bytes(path) == old_bytes
 
     @pytest.mark.anyio
     async def test_bare_binary_under_limit_unchanged(self):
@@ -1729,7 +1729,7 @@ class TestBinaryRetentionEdgeCases:
         from pydantic_ai.messages import BinaryContent
 
         backend = StateBackend()
-        cap = EvictionCapability(backend=backend, max_binary_content=3)
+        cap = EvictionCapability(backend=ensure_async(backend), max_binary_content=3)
         ctx = _make_ctx(backend)
 
         msg = ModelRequest(
@@ -1760,7 +1760,7 @@ class TestBinaryRetentionEdgeCases:
             return WriteResult(path=path, error="disk full")
 
         backend.write = failing_write
-        cap = EvictionCapability(backend=backend, max_binary_content=1)
+        cap = EvictionCapability(backend=ensure_async(backend), max_binary_content=1)
         ctx = _make_ctx(backend)
 
         old_bin = BinaryContent(data=b"old-bare", media_type="image/png")
@@ -1812,7 +1812,7 @@ class TestBinaryRetentionEdgeCases:
             return WriteResult(path=path, error="disk full")
 
         backend.write = failing_write
-        cap = EvictionCapability(backend=backend, max_binary_content=1)
+        cap = EvictionCapability(backend=ensure_async(backend), max_binary_content=1)
         ctx = _make_ctx(backend)
 
         msg_old = ModelRequest(
@@ -1858,7 +1858,7 @@ class TestBinaryRetentionEdgeCases:
         from pydantic_ai.messages import RetryPromptPart
 
         backend = StateBackend()
-        cap = EvictionCapability(backend=backend, max_binary_content=1)
+        cap = EvictionCapability(backend=ensure_async(backend), max_binary_content=1)
         ctx = _make_ctx(backend)
 
         retry_msg = ModelRequest(
@@ -1878,7 +1878,7 @@ class TestBinaryRetentionEdgeCases:
         from pydantic_ai.messages import BinaryContent
 
         backend = StateBackend()
-        cap = EvictionCapability(backend=backend, max_binary_content=1)
+        cap = EvictionCapability(backend=ensure_async(backend), max_binary_content=1)
         ctx = _make_ctx(backend)
 
         # A dict-form content that should not be touched, alongside a binary

--- a/tests/test_eviction.py
+++ b/tests/test_eviction.py
@@ -261,7 +261,9 @@ class TestEvictionProcessor:
     async def test_large_content_evicted(self):
         """Content above threshold is evicted to backend."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10)  # 40 chars threshold
+        processor = EvictionProcessor(
+            backend=ensure_async(backend), token_limit=10
+        )  # 40 chars threshold
         ctx = _make_ctx(backend)
 
         large_content = _make_large_content(20)
@@ -279,6 +281,7 @@ class TestEvictionProcessor:
         assert "read_file" in str(tool_part.content)
 
         # File should be written to backend
+        # _read_bytes is the sync read that AsyncBackendAdapter delegates to.
         evicted_content = backend._read_bytes("/large_tool_results/call_123")
         assert evicted_content == large_content.encode()
 
@@ -289,7 +292,9 @@ class TestEvictionProcessor:
         from pydantic_ai.messages import BinaryContent
 
         backend = StateBackend()
-        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10)  # 40-char threshold
+        processor = EvictionProcessor(
+            backend=ensure_async(backend), token_limit=10
+        )  # 40-char threshold
         ctx = _make_ctx(backend)
 
         image = BinaryContent(data=b"\x89PNG" + b"\x00" * 100_000, media_type="image/png")
@@ -530,7 +535,9 @@ class TestEvictionProcessor:
     async def test_custom_head_tail_lines(self):
         """Custom head_lines and tail_lines are used in preview."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10, head_lines=2, tail_lines=2)
+        processor = EvictionProcessor(
+            backend=ensure_async(backend), token_limit=10, head_lines=2, tail_lines=2
+        )
         ctx = _make_ctx(backend)
 
         large_content = _make_large_content(20)
@@ -698,7 +705,7 @@ class TestCreateEvictionProcessor:
         backend = StateBackend()
         processor = create_eviction_processor(backend)
         assert isinstance(processor, EvictionProcessor)
-        assert processor.backend is backend
+        assert processor.backend.unwrap() is backend
         assert processor.token_limit == DEFAULT_TOKEN_LIMIT
         assert processor.eviction_path == DEFAULT_EVICTION_PATH
 
@@ -737,7 +744,9 @@ class TestOnEvictionCallback:
         def on_eviction(tool_name: str, file_path: str, orig: int, preview: int) -> None:
             calls.append((tool_name, file_path, orig, preview))
 
-        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10, on_eviction=on_eviction)
+        processor = EvictionProcessor(
+            backend=ensure_async(backend), token_limit=10, on_eviction=on_eviction
+        )
         ctx = _make_ctx(backend)
 
         large_content = _make_large_content(20)
@@ -759,7 +768,9 @@ class TestOnEvictionCallback:
         async def on_eviction(tool_name: str, file_path: str, orig: int, preview: int) -> None:
             calls.append(tool_name)
 
-        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10, on_eviction=on_eviction)
+        processor = EvictionProcessor(
+            backend=ensure_async(backend), token_limit=10, on_eviction=on_eviction
+        )
         ctx = _make_ctx(backend)
 
         large_content = _make_large_content(20)
@@ -774,7 +785,9 @@ class TestOnEvictionCallback:
         """on_eviction is NOT called when content is small."""
         backend = StateBackend()
         cb = MagicMock()
-        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=100, on_eviction=cb)
+        processor = EvictionProcessor(
+            backend=ensure_async(backend), token_limit=100, on_eviction=cb
+        )
         ctx = _make_ctx(backend)
 
         messages: list[ModelMessage] = [_make_request_with_tool_return("small")]
@@ -872,7 +885,9 @@ class TestEvictionPreviewFormat:
     async def test_preview_contains_head_and_tail(self):
         """Eviction preview shows head and tail lines of original content."""
         backend = StateBackend()
-        processor = EvictionProcessor(backend=ensure_async(backend), token_limit=10, head_lines=3, tail_lines=3)
+        processor = EvictionProcessor(
+            backend=ensure_async(backend), token_limit=10, head_lines=3, tail_lines=3
+        )
         ctx = _make_ctx(backend)
 
         lines = [f"line_{i}" for i in range(20)]
@@ -1105,7 +1120,9 @@ class TestEvictionCapability:
         """on_eviction callback is invoked on eviction."""
         backend = StateBackend()
         callback = MagicMock()
-        cap = EvictionCapability(backend=ensure_async(backend), token_limit=10, on_eviction=callback)
+        cap = EvictionCapability(
+            backend=ensure_async(backend), token_limit=10, on_eviction=callback
+        )
         ctx = _make_ctx(backend)
 
         await cap.after_tool_execute(
@@ -1153,7 +1170,9 @@ class TestEvictionCapability:
         async def async_cb(tool_name: str, file_path: str, orig: int, preview: int) -> None:
             called_with.append((tool_name, file_path, orig, preview))
 
-        cap = EvictionCapability(backend=ensure_async(backend), token_limit=10, on_eviction=async_cb)
+        cap = EvictionCapability(
+            backend=ensure_async(backend), token_limit=10, on_eviction=async_cb
+        )
         ctx = _make_ctx(backend)
 
         await cap.after_tool_execute(

--- a/tests/test_eviction.py
+++ b/tests/test_eviction.py
@@ -281,8 +281,8 @@ class TestEvictionProcessor:
         assert "read_file" in str(tool_part.content)
 
         # File should be written to backend
-        # _read_bytes is the sync read that AsyncBackendAdapter delegates to.
-        evicted_content = backend._read_bytes("/large_tool_results/call_123")
+        # read_bytes is the sync read that AsyncBackendAdapter delegates to.
+        evicted_content = backend.read_bytes("/large_tool_results/call_123")
         assert evicted_content == large_content.encode()
 
     @pytest.mark.anyio
@@ -308,7 +308,7 @@ class TestEvictionProcessor:
         assert isinstance(out_part, ToolReturnPart)
         # Content is the original BinaryContent, untouched.
         assert out_part.content is image
-        assert backend._read_bytes("/large_tool_results/call_bin") in (None, b"")
+        assert backend.read_bytes("/large_tool_results/call_bin") in (None, b"")
 
     async def test_evicted_ids_bounded_fifo(self):
         """The evicted-id tracking set is bounded: oldest IDs drop past the cap."""
@@ -528,7 +528,7 @@ class TestEvictionProcessor:
         assert "/custom/evicted/" in str(tool_part.content)
 
         # Check file was written to custom path
-        evicted = backend._read_bytes("/custom/evicted/call_custom")
+        evicted = backend.read_bytes("/custom/evicted/call_custom")
         assert evicted == large_content.encode()
 
     @pytest.mark.anyio
@@ -672,11 +672,11 @@ class TestResolveBackend:
         await processor(ctx, messages)
 
         # File should be in RUNTIME backend, not creation backend
-        evicted = runtime_backend._read_bytes("/large_tool_results/call_rt")
+        evicted = runtime_backend.read_bytes("/large_tool_results/call_rt")
         assert evicted == large_content.encode()
 
         # Creation backend should NOT have the file
-        assert creation_backend._read_bytes("/large_tool_results/call_rt") == b""
+        assert creation_backend.read_bytes("/large_tool_results/call_rt") == b""
 
     @pytest.mark.anyio
     async def test_falls_back_to_self_backend(self):
@@ -693,7 +693,7 @@ class TestResolveBackend:
         await processor(ctx, messages)
 
         # File should be in creation (fallback) backend
-        evicted = creation_backend._read_bytes("/large_tool_results/call_fb")
+        evicted = creation_backend.read_bytes("/large_tool_results/call_fb")
         assert evicted == large_content.encode()
 
 
@@ -927,7 +927,7 @@ class TestEvictionPreviewFormat:
         await processor(ctx, messages)
 
         # Read back from backend
-        stored = backend._read_bytes("/large_tool_results/call_read")
+        stored = backend.read_bytes("/large_tool_results/call_read")
         assert stored.decode() == original_content
 
 
@@ -1075,7 +1075,7 @@ class TestEvictionCapability:
         assert "Tool result too large" in result
         assert "/large_tool_results/call_big" in result
         # File was written
-        evicted = backend._read_bytes("/large_tool_results/call_big")
+        evicted = backend.read_bytes("/large_tool_results/call_big")
         assert evicted == large.encode()
 
     @pytest.mark.anyio
@@ -1096,8 +1096,8 @@ class TestEvictionCapability:
         )
 
         # Written to deps_backend, not fallback
-        assert deps_backend._read_bytes("/large_tool_results/call_deps") not in (None, b"")
-        assert fallback._read_bytes("/large_tool_results/call_deps") in (None, b"")
+        assert deps_backend.read_bytes("/large_tool_results/call_deps") not in (None, b"")
+        assert fallback.read_bytes("/large_tool_results/call_deps") in (None, b"")
 
     @pytest.mark.anyio
     async def test_no_backend_passes_through(self):
@@ -1249,7 +1249,7 @@ class TestEvictionCapabilityToolReturn:
         # content (with the BinaryContent) is preserved as-is
         assert result.content == original.content
         # Backend was not asked to store anything (no eviction)
-        assert backend._read_bytes("/large_tool_results/call_screenshot") in (None, b"")
+        assert backend.read_bytes("/large_tool_results/call_screenshot") in (None, b"")
 
     @pytest.mark.anyio
     async def test_toolreturn_evicts_only_return_value(self):
@@ -1285,7 +1285,7 @@ class TestEvictionCapabilityToolReturn:
         # metadata is preserved
         assert result.metadata == {"trace_id": "abc"}
         # The text value was actually written to the backend
-        assert backend._read_bytes("/large_tool_results/call_big_tr") == large_text.encode()
+        assert backend.read_bytes("/large_tool_results/call_big_tr") == large_text.encode()
 
     @pytest.mark.anyio
     async def test_toolreturn_small_passes_through(self):
@@ -1332,7 +1332,7 @@ class TestEvictionCapabilityToolReturn:
         assert result is image
         assert isinstance(result, BinaryContent)
         # Nothing was written to the eviction path.
-        assert backend._read_bytes("/large_tool_results/call_bare_img") in (None, b"")
+        assert backend.read_bytes("/large_tool_results/call_bare_img") in (None, b"")
 
     @pytest.mark.anyio
     async def test_list_with_binary_content_returned_unchanged(self):
@@ -1355,7 +1355,7 @@ class TestEvictionCapabilityToolReturn:
         )
 
         assert result is original
-        assert backend._read_bytes("/large_tool_results/call_list_img") in (None, b"")
+        assert backend.read_bytes("/large_tool_results/call_list_img") in (None, b"")
 
 
 # ---------------------------------------------------------------------------
@@ -1454,7 +1454,7 @@ class TestBinaryContentRetention:
         # Pruned binaries were stored to backend with deterministic paths
         first_bin = BinaryContent(data=b"image-0-bytes" * 8, media_type="image/jpeg")
         path = f"/large_tool_results/binary_{first_bin.identifier}.jpg"
-        assert backend._read_bytes(path) == b"image-0-bytes" * 8
+        assert backend.read_bytes(path) == b"image-0-bytes" * 8
 
         # Older messages now contain the text reference
         first_part = new_messages[0].parts[0]
@@ -1545,7 +1545,7 @@ class TestBinaryContentRetention:
         # Stored bytes match the original BinaryContent.data
         old_bin = BinaryContent(data=old_bytes, media_type="image/jpeg")
         path = f"/large_tool_results/binary_{old_bin.identifier}.jpg"
-        assert backend._read_bytes(path) == old_bytes
+        assert backend.read_bytes(path) == old_bytes
 
         # ToolReturnPart metadata is preserved
         assert old_part.tool_name == "browser_screenshot"
@@ -1740,7 +1740,7 @@ class TestBinaryRetentionEdgeCases:
         # Stored bytes match the original
         old_bin = BinaryContent(data=old_bytes, media_type="image/png")
         path = f"/large_tool_results/binary_{old_bin.identifier}.png"
-        assert backend._read_bytes(path) == old_bytes
+        assert backend.read_bytes(path) == old_bytes
 
     @pytest.mark.anyio
     async def test_bare_binary_under_limit_unchanged(self):

--- a/tests/test_forking_core.py
+++ b/tests/test_forking_core.py
@@ -33,6 +33,7 @@ from pydantic_deep import (
 from pydantic_deep.capabilities.message_queue import MessageQueue
 from pydantic_deep.toolsets.checkpointing import InMemoryCheckpointStore
 from pydantic_deep.toolsets.forking import NOT_ENABLED_MESSAGE, create_fork_toolset
+from pydantic_deep.toolsets.forking.isolation import _read_backend_bytes
 
 
 def _make_test_agent() -> Agent[DeepAgentDeps, str]:
@@ -246,6 +247,15 @@ def test_branch_overlay_read_bytes_overlay_and_parent():
 
     overlay.write("/a.py", "from-overlay")
     assert overlay.read_bytes("/a.py") == b"from-overlay"
+
+
+def test_read_backend_bytes_falls_back_to_private_reader():
+    class LegacyBackend:
+        def _read_bytes(self, path: str) -> bytes:
+            assert path == "/legacy.txt"
+            return b"legacy"
+
+    assert _read_backend_bytes(LegacyBackend(), "/legacy.txt") == b"legacy"
 
 
 def test_branch_overlay_parent_property():

--- a/tests/test_forking_core.py
+++ b/tests/test_forking_core.py
@@ -510,9 +510,9 @@ def test_clone_for_branch_share_readonly_backend_no_overlay():
     parent_backend = StateBackend()
     deps = DeepAgentDeps(backend=parent_backend)
     cloned = clone_for_branch(deps, BranchIsolation(backend="share_readonly"))
-    assert cloned.backend is parent_backend
+    assert cloned.backend.unwrap() is parent_backend
     cloned2 = clone_for_branch(deps, BranchIsolation(backend="share"))
-    assert cloned2.backend is parent_backend
+    assert cloned2.backend.unwrap() is parent_backend
 
 
 def test_clone_for_branch_increments_depth():

--- a/tests/test_forking_diff.py
+++ b/tests/test_forking_diff.py
@@ -99,7 +99,7 @@ async def test_diff_split_when_branches_modify_same_path_differently() -> None:
     runtime_a = await _make_runtime(branch_id="a", label="alpha", overlay=overlay_a)
     runtime_b = await _make_runtime(branch_id="b", label="beta", overlay=overlay_b)
 
-    report = build_diff_report("fork-1", [runtime_a, runtime_b])
+    report = await build_diff_report("fork-1", [runtime_a, runtime_b])
 
     assert len(report.paths) == 1
     pd = report.paths[0]
@@ -127,7 +127,7 @@ async def test_diff_unanimous_change_when_branches_modify_identically() -> None:
     overlay_a = await _overlay_with_writes(parent, {"shared.py": "v2\n"})
     overlay_b = await _overlay_with_writes(parent, {"shared.py": "v2\n"})
 
-    report = build_diff_report(
+    report = await build_diff_report(
         "fork-2",
         [
             await _make_runtime(branch_id="a", label="alpha", overlay=overlay_a),
@@ -153,7 +153,7 @@ async def test_diff_unique_when_only_one_branch_touches_path() -> None:
     overlay_a = await _overlay_with_writes(parent, {"only-a.py": "hello\n"})
     overlay_b = BranchOverlay(parent)  # b touched nothing
 
-    report = build_diff_report(
+    report = await build_diff_report(
         "fork-3",
         [
             await _make_runtime(branch_id="a", label="alpha", overlay=overlay_a),
@@ -181,7 +181,7 @@ async def test_diff_binary_file_returns_placeholder() -> None:
     binary_payload = b"\x00\x01\x02\x03" * 64
     overlay_a = await _overlay_with_writes(parent, {"asset.bin": binary_payload})
 
-    report = build_diff_report(
+    report = await build_diff_report(
         "fork-4",
         [await _make_runtime(branch_id="a", label="alpha", overlay=overlay_a)],
     )
@@ -205,7 +205,7 @@ async def test_diff_divergent_binary_writes_are_split() -> None:
     overlay_a = await _overlay_with_writes(parent, {"asset.bin": b"\x00\x01\x02" * 64})
     overlay_b = await _overlay_with_writes(parent, {"asset.bin": b"\x00\x09\x09" * 64})
 
-    report = build_diff_report(
+    report = await build_diff_report(
         "fork-bin",
         [
             await _make_runtime(branch_id="a", label="alpha", overlay=overlay_a),
@@ -226,7 +226,7 @@ async def test_diff_identical_binary_writes_are_unanimous() -> None:
     overlay_a = await _overlay_with_writes(parent, {"asset.bin": payload})
     overlay_b = await _overlay_with_writes(parent, {"asset.bin": payload})
 
-    report = build_diff_report(
+    report = await build_diff_report(
         "fork-bin2",
         [
             await _make_runtime(branch_id="a", label="alpha", overlay=overlay_a),
@@ -303,7 +303,7 @@ async def test_build_diff_report_rejects_duplicate_status_ids() -> None:
     runtime_a = await _make_runtime(branch_id="dup", label="alpha", overlay=overlay_a)
     runtime_b = await _make_runtime(branch_id="dup", label="beta", overlay=overlay_b)
     with pytest.raises(ValueError, match="unique runtime status ids"):
-        build_diff_report("fork-dup", [runtime_a, runtime_b])
+        await build_diff_report("fork-dup", [runtime_a, runtime_b])
 
 
 def test_decode_text_returns_none_for_invalid_utf8() -> None:
@@ -335,7 +335,7 @@ async def test_diff_large_file_truncated() -> None:
     big_content = "\n".join(f"line {i}" for i in range(700)) + "\n"
     overlay_a = await _overlay_with_writes(parent, {"big.py": big_content})
 
-    report = build_diff_report(
+    report = await build_diff_report(
         "fork-5",
         [await _make_runtime(branch_id="a", label="alpha", overlay=overlay_a)],
     )
@@ -353,7 +353,7 @@ async def test_diff_respects_paths_filter() -> None:
     parent = StateBackend()
     overlay_a = await _overlay_with_writes(parent, {"keep.py": "x\n", "ignore.py": "y\n"})
 
-    report = build_diff_report(
+    report = await build_diff_report(
         "fork-6",
         [await _make_runtime(branch_id="a", label="alpha", overlay=overlay_a)],
         paths_filter=["keep.py"],
@@ -367,7 +367,7 @@ async def test_diff_paths_filter_keeps_untouched_paths_for_transparency() -> Non
     parent = StateBackend()
     overlay_a = await _overlay_with_writes(parent, {"touched.py": "y\n"})
 
-    report = build_diff_report(
+    report = await build_diff_report(
         "fork-6b",
         [await _make_runtime(branch_id="a", label="alpha", overlay=overlay_a)],
         paths_filter=["never-touched.py"],
@@ -391,7 +391,7 @@ async def test_diff_agreement_score_not_falsely_perfect_when_split_filtered_out(
     overlay_a = await _overlay_with_writes(parent, {"conflict.py": "alpha\n"})
     overlay_b = await _overlay_with_writes(parent, {"conflict.py": "beta\n"})
 
-    report = build_diff_report(
+    report = await build_diff_report(
         "fork-6c",
         [
             await _make_runtime(branch_id="a", label="alpha", overlay=overlay_a),
@@ -421,7 +421,7 @@ async def test_diff_agreement_score_all_split() -> None:
     overlay_a = await _overlay_with_writes(parent, {"p1.py": "a1\n", "p2.py": "a2\n"})
     overlay_b = await _overlay_with_writes(parent, {"p1.py": "b1\n", "p2.py": "b2\n"})
 
-    report = build_diff_report(
+    report = await build_diff_report(
         "fork-7a",
         [
             await _make_runtime(branch_id="a", label="alpha", overlay=overlay_a),
@@ -438,7 +438,7 @@ async def test_diff_agreement_score_all_unanimous() -> None:
     overlay_a = await _overlay_with_writes(parent, {"p1.py": "same\n"})
     overlay_b = await _overlay_with_writes(parent, {"p1.py": "same\n"})
 
-    report = build_diff_report(
+    report = await build_diff_report(
         "fork-7b",
         [
             await _make_runtime(branch_id="a", label="alpha", overlay=overlay_a),
@@ -461,7 +461,7 @@ async def test_diff_agreement_score_mixed() -> None:
         parent, {"p1.py": "same\n", "p2.py": "same\n", "p3.py": "b3\n"}
     )
 
-    report = build_diff_report(
+    report = await build_diff_report(
         "fork-7c",
         [
             await _make_runtime(branch_id="a", label="alpha", overlay=overlay_a),
@@ -525,7 +525,7 @@ async def test_diff_untouched_paths_excluded() -> None:
     overlay_a = await _overlay_with_writes(parent, {"changed.py": "new\n"})
     overlay_b = BranchOverlay(parent)
 
-    report = build_diff_report(
+    report = await build_diff_report(
         "fork-9",
         [
             await _make_runtime(branch_id="a", label="alpha", overlay=overlay_a),
@@ -547,7 +547,7 @@ async def test_diff_branch_with_no_overlay_marked_untouched() -> None:
     parent = StateBackend()
     overlay_a = await _overlay_with_writes(parent, {"foo.py": "a-content\n"})
 
-    report = build_diff_report(
+    report = await build_diff_report(
         "fork-share",
         [
             await _make_runtime(branch_id="a", label="alpha", overlay=overlay_a),
@@ -572,7 +572,7 @@ async def test_diff_all_branches_no_overlay_with_filter() -> None:
     loop — only reachable when a `paths_filter` forces at least one
     iteration even though no branch has an overlay.
     """
-    report = build_diff_report(
+    report = await build_diff_report(
         "fork-noparent",
         [
             await _make_runtime(branch_id="a", label="alpha", overlay=None),
@@ -597,7 +597,7 @@ async def test_diff_unique_when_first_branch_is_untouched() -> None:
     overlay_b = await _overlay_with_writes(parent, {"owned.py": "b!\n"})
 
     # Insert the untouched runtime FIRST so the unique-tally loop must skip it.
-    report = build_diff_report(
+    report = await build_diff_report(
         "fork-unique-order",
         [
             await _make_runtime(branch_id="a", label="alpha", overlay=None),
@@ -614,7 +614,7 @@ async def test_diff_no_branches_touched_anything() -> None:
     overlay_a = BranchOverlay(parent)
     overlay_b = BranchOverlay(parent)
 
-    report = build_diff_report(
+    report = await build_diff_report(
         "fork-empty",
         [
             await _make_runtime(branch_id="a", label="alpha", overlay=overlay_a),
@@ -632,8 +632,8 @@ async def test_diff_no_branches_touched_anything() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_diff_empty_runtimes_list() -> None:
-    report = build_diff_report("fork-noop", [])
+async def test_diff_empty_runtimes_list() -> None:
+    report = await build_diff_report("fork-noop", [])
     assert report.paths == []
     assert report.summary.total_paths_touched == 0
     assert report.summary.agreement_score == 1.0
@@ -654,7 +654,7 @@ async def test_diff_branch_with_delete_produces_deleted_operation() -> None:
     overlay_modifier = BranchOverlay(parent)
     overlay_modifier.write("/x.py", "modified\n")
 
-    report = build_diff_report(
+    report = await build_diff_report(
         "fork-delete",
         [
             await _make_runtime(branch_id="a", label="alpha", overlay=overlay_deleter),
@@ -686,7 +686,7 @@ async def test_diff_lone_deleter_branch_classified_unique() -> None:
 
     overlay_untouched = BranchOverlay(parent)
 
-    report = build_diff_report(
+    report = await build_diff_report(
         "fork-lone-delete",
         [
             await _make_runtime(branch_id="a", label="alpha", overlay=overlay_deleter),
@@ -708,7 +708,7 @@ async def test_diff_unanimous_delete_classified_as_unanimous_change() -> None:
     overlay_b = BranchOverlay(parent)
     overlay_b.delete("/x.py")
 
-    report = build_diff_report(
+    report = await build_diff_report(
         "fork-unanimous-delete",
         [
             await _make_runtime(branch_id="a", label="alpha", overlay=overlay_a),
@@ -730,7 +730,7 @@ async def test_diff_binary_parent_content() -> None:
     parent.write("img.bin", b"\x00\x01" * 32)
     overlay_a = await _overlay_with_writes(parent, {"img.bin": b"\x00\x02" * 32})
 
-    report = build_diff_report(
+    report = await build_diff_report(
         "fork-binparent",
         [await _make_runtime(branch_id="a", label="alpha", overlay=overlay_a)],
     )
@@ -886,7 +886,7 @@ async def test_public_build_diff_report_entry_point() -> None:
     overlay_a = await _overlay_with_writes(parent, {"foo.py": "a\n"})
     overlay_b = await _overlay_with_writes(parent, {"foo.py": "b\n"})
 
-    report = build_diff_report(
+    report = await build_diff_report(
         "fork-public",
         [
             await _make_runtime(branch_id="a", label="alpha", overlay=overlay_a),

--- a/tests/test_forking_judge.py
+++ b/tests/test_forking_judge.py
@@ -1749,7 +1749,7 @@ async def test_run_tests_materializes_overlay_writes_as_real_file(tmp_path: Any)
     overlay = BranchOverlay(backend)
     overlay.write("marker.txt", "branch\n")
 
-    with overlay.snapshot(_Path(deps.backend.root_dir)) as snap:
+    with overlay.snapshot(_Path(deps.backend.unwrap().root_dir)) as snap:
         target = _Path(snap) / "marker.txt"
         assert target.exists()
         assert target.is_file()

--- a/tests/test_forking_merge_apply.py
+++ b/tests/test_forking_merge_apply.py
@@ -204,18 +204,18 @@ async def test_conflict_surfaced_when_parent_path_deleted_between_fork_and_merge
     )
     await asyncio.gather(*[rt.task for rt in coord.branches.values()])
 
-    # Simulate a third-actor deletion: monkey-patch _read_bytes to raise for
+    # Simulate a third-actor deletion: monkey-patch read_bytes to raise for
     # this one path. flush_to should detect the conflict (snapshot had bytes,
     # parent now lacks the file) and NOT replay the branch's write over it.
-    real_read_bytes = parent._read_bytes
+    real_read_bytes = parent.read_bytes
 
-    def _read_bytes_with_deletion(path: str) -> bytes:
+    def read_bytes_with_deletion(path: str) -> bytes:
         if path == "cat.md":
             raise FileNotFoundError(path)
         result: bytes = real_read_bytes(path)
         return result
 
-    with patch.object(parent, "_read_bytes", side_effect=_read_bytes_with_deletion):
+    with patch.object(parent, "read_bytes", side_effect=read_bytes_with_deletion):
         result = await coord.merge_or_select(f"pick:{handle.branches[0]}")
 
     assert "cat.md" in result.conflicts
@@ -492,7 +492,7 @@ def test_overlay_snapshot_records_none_when_parent_read_raises(tmp_path: Path) -
     overlay = BranchOverlay(parent)
     overlay.attach_materializer(materializer, "approach_a")
 
-    real_read_bytes = parent._read_bytes
+    real_read_bytes = parent.read_bytes
 
     def _raising_read_bytes(path: str) -> bytes:
         if path == "brand_new.py":
@@ -500,7 +500,7 @@ def test_overlay_snapshot_records_none_when_parent_read_raises(tmp_path: Path) -
         result: bytes = real_read_bytes(path)
         return result
 
-    with patch.object(parent, "_read_bytes", side_effect=_raising_read_bytes):
+    with patch.object(parent, "read_bytes", side_effect=_raising_read_bytes):
         overlay.write("brand_new.py", "content")
 
     assert materializer.pre_flush_snapshot() == {"brand_new.py": None}
@@ -516,7 +516,7 @@ def test_overlay_snapshot_records_none_on_keyerror(tmp_path: Path) -> None:
     overlay = BranchOverlay(parent)
     overlay.attach_materializer(materializer, "approach_a")
 
-    real_read_bytes = parent._read_bytes
+    real_read_bytes = parent.read_bytes
 
     def _raising_read_bytes(path: str) -> bytes:
         if path == "missing.py":
@@ -524,7 +524,7 @@ def test_overlay_snapshot_records_none_on_keyerror(tmp_path: Path) -> None:
         result: bytes = real_read_bytes(path)
         return result
 
-    with patch.object(parent, "_read_bytes", side_effect=_raising_read_bytes):
+    with patch.object(parent, "read_bytes", side_effect=_raising_read_bytes):
         overlay.write("missing.py", "content")
 
     assert materializer.pre_flush_snapshot() == {"missing.py": None}
@@ -552,7 +552,7 @@ def test_detect_conflicts_handles_keyerror_in_parent_read_bytes(tmp_path: Path) 
     overlay = BranchOverlay(parent)
     overlay.write("foo.py", "branch_v1")
 
-    real_read_bytes = parent._read_bytes
+    real_read_bytes = parent.read_bytes
 
     def _raise_keyerror(path: str) -> bytes:
         if path == "foo.py":
@@ -560,7 +560,7 @@ def test_detect_conflicts_handles_keyerror_in_parent_read_bytes(tmp_path: Path) 
         result: bytes = real_read_bytes(path)
         return result
 
-    with patch.object(parent, "_read_bytes", side_effect=_raise_keyerror):
+    with patch.object(parent, "read_bytes", side_effect=_raise_keyerror):
         report = overlay.flush_to(parent, pre_flush_snapshot={"foo.py": b"v1"})
 
     # Snapshot bytes (b"v1") vs current parent (KeyError → treated as None) differs → conflict.

--- a/tests/test_forking_merge_apply.py
+++ b/tests/test_forking_merge_apply.py
@@ -46,8 +46,8 @@ class _StubAgent:
     async def run(
         self, steer: str, *, message_history: Any = None, deps: Any = None
     ) -> _StubResult:
-        deps.backend.write("cat.md", f"{steer} wrote cat")
-        deps.backend.write("dog.md", f"{steer} wrote dog")
+        await deps.backend.write("cat.md", f"{steer} wrote cat")
+        await deps.backend.write("dog.md", f"{steer} wrote dog")
         return _StubResult()
 
 
@@ -204,11 +204,10 @@ async def test_conflict_surfaced_when_parent_path_deleted_between_fork_and_merge
     )
     await asyncio.gather(*[rt.task for rt in coord.branches.values()])
 
-    # Simulate a third-actor deletion: StateBackend doesn't expose delete,
-    # so monkey-patch read_bytes to raise for this one path. flush_to should
-    # detect the conflict (snapshot had bytes, parent now lacks the file) and
-    # NOT replay the branch's write over it.
-    real_read_bytes = parent.read_bytes
+    # Simulate a third-actor deletion: monkey-patch _read_bytes to raise for
+    # this one path. flush_to should detect the conflict (snapshot had bytes,
+    # parent now lacks the file) and NOT replay the branch's write over it.
+    real_read_bytes = parent._read_bytes
 
     def _read_bytes_with_deletion(path: str) -> bytes:
         if path == "cat.md":
@@ -216,7 +215,7 @@ async def test_conflict_surfaced_when_parent_path_deleted_between_fork_and_merge
         result: bytes = real_read_bytes(path)
         return result
 
-    with patch.object(parent, "read_bytes", side_effect=_read_bytes_with_deletion):
+    with patch.object(parent, "_read_bytes", side_effect=_read_bytes_with_deletion):
         result = await coord.merge_or_select(f"pick:{handle.branches[0]}")
 
     assert "cat.md" in result.conflicts
@@ -493,7 +492,7 @@ def test_overlay_snapshot_records_none_when_parent_read_raises(tmp_path: Path) -
     overlay = BranchOverlay(parent)
     overlay.attach_materializer(materializer, "approach_a")
 
-    real_read_bytes = parent.read_bytes
+    real_read_bytes = parent._read_bytes
 
     def _raising_read_bytes(path: str) -> bytes:
         if path == "brand_new.py":
@@ -501,7 +500,7 @@ def test_overlay_snapshot_records_none_when_parent_read_raises(tmp_path: Path) -
         result: bytes = real_read_bytes(path)
         return result
 
-    with patch.object(parent, "read_bytes", side_effect=_raising_read_bytes):
+    with patch.object(parent, "_read_bytes", side_effect=_raising_read_bytes):
         overlay.write("brand_new.py", "content")
 
     assert materializer.pre_flush_snapshot() == {"brand_new.py": None}
@@ -517,7 +516,7 @@ def test_overlay_snapshot_records_none_on_keyerror(tmp_path: Path) -> None:
     overlay = BranchOverlay(parent)
     overlay.attach_materializer(materializer, "approach_a")
 
-    real_read_bytes = parent.read_bytes
+    real_read_bytes = parent._read_bytes
 
     def _raising_read_bytes(path: str) -> bytes:
         if path == "missing.py":
@@ -525,7 +524,7 @@ def test_overlay_snapshot_records_none_on_keyerror(tmp_path: Path) -> None:
         result: bytes = real_read_bytes(path)
         return result
 
-    with patch.object(parent, "read_bytes", side_effect=_raising_read_bytes):
+    with patch.object(parent, "_read_bytes", side_effect=_raising_read_bytes):
         overlay.write("missing.py", "content")
 
     assert materializer.pre_flush_snapshot() == {"missing.py": None}
@@ -553,7 +552,7 @@ def test_detect_conflicts_handles_keyerror_in_parent_read_bytes(tmp_path: Path) 
     overlay = BranchOverlay(parent)
     overlay.write("foo.py", "branch_v1")
 
-    real_read_bytes = parent.read_bytes
+    real_read_bytes = parent._read_bytes
 
     def _raise_keyerror(path: str) -> bytes:
         if path == "foo.py":
@@ -561,7 +560,7 @@ def test_detect_conflicts_handles_keyerror_in_parent_read_bytes(tmp_path: Path) 
         result: bytes = real_read_bytes(path)
         return result
 
-    with patch.object(parent, "read_bytes", side_effect=_raise_keyerror):
+    with patch.object(parent, "_read_bytes", side_effect=_raise_keyerror):
         report = overlay.flush_to(parent, pre_flush_snapshot={"foo.py": b"v1"})
 
     # Snapshot bytes (b"v1") vs current parent (KeyError → treated as None) differs → conflict.
@@ -792,7 +791,8 @@ async def test_coordinator_merge_propagates_deleted_paths_into_result(
         async def run(
             self, steer: str, *, message_history: Any = None, deps: Any = None
         ) -> _StubResult:
-            deps.backend.delete("doomed.py")
+            raw = getattr(deps.backend, "unwrap", lambda: deps.backend)()
+            raw.delete("doomed.py")
             return _StubResult()
 
     parent = _DeleteCapturingBackend()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -371,7 +371,9 @@ class TestExecuteCommandHook:
         assert "execute" in cmd  # tool_name in JSON
 
     async def test_command_deny(self):
-        raw_backend = FakeSandboxBackend({"blocker": ExecuteResponse(output="Blocked!", exit_code=2)})
+        raw_backend = FakeSandboxBackend(
+            {"blocker": ExecuteResponse(output="Blocked!", exit_code=2)}
+        )
         backend = ensure_async(raw_backend)
         hook = Hook(event=HookEvent.PRE_TOOL_USE, command="blocker")
         hook_input = HookInput(

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -17,7 +17,7 @@ from pydantic_ai.messages import ToolCallPart
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.usage import RunUsage
-from pydantic_ai_backends import ExecuteResponse, SandboxProtocol, StateBackend
+from pydantic_ai_backends import ExecuteResponse, SandboxProtocol, StateBackend, ensure_async
 
 from pydantic_deep import DeepAgentDeps, create_deep_agent, default_security_hook
 from pydantic_deep.capabilities.hooks import (
@@ -342,7 +342,8 @@ class TestParseCommandResult:
 
 class TestExecuteCommandHook:
     async def test_basic_command(self):
-        backend = FakeSandboxBackend({"checker": ExecuteResponse(output="", exit_code=0)})
+        raw_backend = FakeSandboxBackend({"checker": ExecuteResponse(output="", exit_code=0)})
+        backend = ensure_async(raw_backend)
         hook = Hook(event=HookEvent.PRE_TOOL_USE, command="checker")
         hook_input = HookInput(
             event="pre_tool_use",
@@ -351,11 +352,12 @@ class TestExecuteCommandHook:
         )
         result = await _execute_command_hook(hook, hook_input, backend)
         assert result.allow is True
-        assert len(backend.executed) == 1
-        assert "checker" in backend.executed[0]
+        assert len(raw_backend.executed) == 1
+        assert "checker" in raw_backend.executed[0]
 
     async def test_command_receives_json_stdin(self):
-        backend = FakeSandboxBackend()
+        raw_backend = FakeSandboxBackend()
+        backend = ensure_async(raw_backend)
         hook = Hook(event=HookEvent.PRE_TOOL_USE, command="my-checker")
         hook_input = HookInput(
             event="pre_tool_use",
@@ -363,13 +365,14 @@ class TestExecuteCommandHook:
             tool_input={"command": "ls"},
         )
         await _execute_command_hook(hook, hook_input, backend)
-        cmd = backend.executed[0]
+        cmd = raw_backend.executed[0]
         assert "printf" in cmd
         assert "my-checker" in cmd
         assert "execute" in cmd  # tool_name in JSON
 
     async def test_command_deny(self):
-        backend = FakeSandboxBackend({"blocker": ExecuteResponse(output="Blocked!", exit_code=2)})
+        raw_backend = FakeSandboxBackend({"blocker": ExecuteResponse(output="Blocked!", exit_code=2)})
+        backend = ensure_async(raw_backend)
         hook = Hook(event=HookEvent.PRE_TOOL_USE, command="blocker")
         hook_input = HookInput(
             event="pre_tool_use",
@@ -381,11 +384,12 @@ class TestExecuteCommandHook:
         assert result.reason == "Blocked!"
 
     async def test_command_with_timeout(self):
-        backend = FakeSandboxBackend()
+        raw_backend = FakeSandboxBackend()
+        backend = ensure_async(raw_backend)
         hook = Hook(event=HookEvent.PRE_TOOL_USE, command="slow-check", timeout=60)
         hook_input = HookInput(event="pre_tool_use", tool_name="t", tool_input={})
         await _execute_command_hook(hook, hook_input, backend)
-        assert len(backend.executed) == 1
+        assert len(raw_backend.executed) == 1
 
 
 class TestExecuteHandlerHook:
@@ -425,7 +429,7 @@ class TestExecuteHandlerHook:
 
 class TestRunHook:
     async def test_command_hook(self):
-        backend = FakeSandboxBackend()
+        backend = ensure_async(FakeSandboxBackend())
         hook = Hook(event=HookEvent.PRE_TOOL_USE, command="check")
         hook_input = HookInput(event="pre_tool_use", tool_name="t", tool_input={})
         result = await _run_hook(hook, hook_input, backend)
@@ -488,7 +492,7 @@ class TestGetSandboxBackend:
     def test_sandbox_backend(self):
         backend = FakeSandboxBackend()
         deps = DeepAgentDeps(backend=backend)
-        assert _get_sandbox_backend(deps) is backend
+        assert _get_sandbox_backend(deps) is deps.backend
 
 
 class TestHooksCapability:

--- a/tests/test_liteparse.py
+++ b/tests/test_liteparse.py
@@ -142,7 +142,7 @@ class TestParseDocument:
     async def test_file_not_found(self) -> None:
         ts = LiteparseToolset()
         backend = MagicMock()
-        backend.read_bytes.return_value = None
+        backend.read_bytes = AsyncMock(return_value=None)
         ctx = _ctx(backend)
         with patch("pydantic_deep.toolsets.liteparse._HAS_LITEPARSE", True):
             result = await ts.tools["parse_document"].function(ctx, path="/missing.pdf")
@@ -153,7 +153,7 @@ class TestParseDocument:
     async def test_success(self) -> None:
         ts = LiteparseToolset()
         backend = MagicMock()
-        backend.read_bytes.return_value = b"%PDF-1.4 fake content"
+        backend.read_bytes = AsyncMock(return_value=b"%PDF-1.4 fake content")
         ctx = _ctx(backend)
 
         mock_result = MagicMock()
@@ -182,7 +182,7 @@ class TestParseDocument:
     async def test_cli_not_found_error(self) -> None:
         ts = LiteparseToolset()
         backend = MagicMock()
-        backend.read_bytes.return_value = b"data"
+        backend.read_bytes = AsyncMock(return_value=b"data")
         ctx = _ctx(backend)
 
         mock_parser = MagicMock()
@@ -199,7 +199,7 @@ class TestParseDocument:
     async def test_generic_exception(self) -> None:
         ts = LiteparseToolset()
         backend = MagicMock()
-        backend.read_bytes.return_value = b"data"
+        backend.read_bytes = AsyncMock(return_value=b"data")
         ctx = _ctx(backend)
 
         mock_parser = MagicMock()
@@ -229,7 +229,7 @@ class TestScreenshotDocument:
     async def test_file_not_found(self) -> None:
         ts = LiteparseToolset()
         backend = MagicMock()
-        backend.read_bytes.return_value = None
+        backend.read_bytes = AsyncMock(return_value=None)
         ctx = _ctx(backend)
         with patch("pydantic_deep.toolsets.liteparse._HAS_LITEPARSE", True):
             result = await ts.tools["screenshot_document"].function(ctx, path="/missing.pdf")
@@ -239,7 +239,8 @@ class TestScreenshotDocument:
     async def test_success(self) -> None:
         ts = LiteparseToolset()
         backend = MagicMock()
-        backend.read_bytes.return_value = b"pdfdata"
+        backend.read_bytes = AsyncMock(return_value=b"pdfdata")
+        backend.write = AsyncMock(return_value=MagicMock(error=None, path="/ok"))
         ctx = _ctx(backend)
 
         shot1 = MagicMock()
@@ -272,7 +273,7 @@ class TestScreenshotDocument:
     async def test_no_screenshots_generated(self) -> None:
         ts = LiteparseToolset()
         backend = MagicMock()
-        backend.read_bytes.return_value = b"pdfdata"
+        backend.read_bytes = AsyncMock(return_value=b"pdfdata")
         ctx = _ctx(backend)
 
         ss_result = MagicMock()
@@ -292,7 +293,7 @@ class TestScreenshotDocument:
         """Screenshots with no image_bytes are skipped."""
         ts = LiteparseToolset()
         backend = MagicMock()
-        backend.read_bytes.return_value = b"pdfdata"
+        backend.read_bytes = AsyncMock(return_value=b"pdfdata")
         ctx = _ctx(backend)
 
         shot = MagicMock()
@@ -316,7 +317,7 @@ class TestScreenshotDocument:
     async def test_target_pages_forwarded(self) -> None:
         ts = LiteparseToolset()
         backend = MagicMock()
-        backend.read_bytes.return_value = b"pdfdata"
+        backend.read_bytes = AsyncMock(return_value=b"pdfdata")
         ctx = _ctx(backend)
 
         shot = MagicMock()
@@ -340,7 +341,7 @@ class TestScreenshotDocument:
     async def test_cli_not_found_error(self) -> None:
         ts = LiteparseToolset()
         backend = MagicMock()
-        backend.read_bytes.return_value = b"data"
+        backend.read_bytes = AsyncMock(return_value=b"data")
         ctx = _ctx(backend)
 
         mock_parser = MagicMock()
@@ -356,7 +357,7 @@ class TestScreenshotDocument:
     async def test_generic_exception(self) -> None:
         ts = LiteparseToolset()
         backend = MagicMock()
-        backend.read_bytes.return_value = b"data"
+        backend.read_bytes = AsyncMock(return_value=b"data")
         ctx = _ctx(backend)
 
         mock_parser = MagicMock()

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -273,6 +273,7 @@ class TestMemoryTools:
 
         assert "Memory updated" in result
         # Verify file was created
+        # _read_bytes is the sync read that AsyncBackendAdapter delegates to.
         raw = backend._read_bytes("/.deep/memory/main/MEMORY.md")
         assert raw is not None
         assert b"First entry" in raw

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -6,7 +6,7 @@ from typing import Any
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import RunContext
 from pydantic_ai.usage import RunUsage
-from pydantic_ai_backends import StateBackend, WriteResult
+from pydantic_ai_backends import StateBackend, WriteResult, ensure_async
 
 from pydantic_deep import (
     DEFAULT_MAX_MEMORY_LINES,
@@ -86,38 +86,38 @@ class TestGetMemoryPath:
 class TestLoadMemory:
     """Tests for load_memory function."""
 
-    def test_load_existing(self):
+    async def test_load_existing(self):
         """Test loading an existing memory file."""
         backend = StateBackend()
         backend.write("/.deep/memory/main/MEMORY.md", "# Memory\n- item 1")
 
-        mem = load_memory(backend, "/.deep/memory/main/MEMORY.md", "main")
+        mem = await load_memory(ensure_async(backend), "/.deep/memory/main/MEMORY.md", "main")
         assert mem is not None
         assert mem.agent_name == "main"
         assert mem.path == "/.deep/memory/main/MEMORY.md"
         assert "item 1" in mem.content
 
-    def test_load_missing(self):
+    async def test_load_missing(self):
         """Test loading a missing memory file returns None."""
         backend = StateBackend()
-        mem = load_memory(backend, "/.deep/memory/main/MEMORY.md", "main")
+        mem = await load_memory(ensure_async(backend), "/.deep/memory/main/MEMORY.md", "main")
         assert mem is None
 
-    def test_load_utf8(self):
+    async def test_load_utf8(self):
         """Test loading memory with non-ASCII content."""
         backend = StateBackend()
         backend.write("/.deep/memory/main/MEMORY.md", "Polskie znaki: ąęćżź")
 
-        mem = load_memory(backend, "/.deep/memory/main/MEMORY.md", "main")
+        mem = await load_memory(ensure_async(backend), "/.deep/memory/main/MEMORY.md", "main")
         assert mem is not None
         assert "ąęćżź" in mem.content
 
-    def test_load_default_agent_name(self):
+    async def test_load_default_agent_name(self):
         """Test load_memory with default agent_name."""
         backend = StateBackend()
         backend.write("/mem/MEMORY.md", "content")
 
-        mem = load_memory(backend, "/mem/MEMORY.md")
+        mem = await load_memory(ensure_async(backend), "/mem/MEMORY.md")
         assert mem is not None
         assert mem.agent_name == "main"
 
@@ -273,7 +273,7 @@ class TestMemoryTools:
 
         assert "Memory updated" in result
         # Verify file was created
-        raw = backend.read_bytes("/.deep/memory/main/MEMORY.md")
+        raw = backend._read_bytes("/.deep/memory/main/MEMORY.md")
         assert raw is not None
         assert b"First entry" in raw
 
@@ -287,7 +287,7 @@ class TestMemoryTools:
         result = await toolset.tools["write_memory"].function(ctx, "New entry")
 
         assert "Memory updated" in result
-        raw = backend.read_bytes("/.deep/memory/main/MEMORY.md")
+        raw = backend._read_bytes("/.deep/memory/main/MEMORY.md")
         assert raw is not None
         content = raw.decode("utf-8")
         assert "Existing" in content
@@ -305,7 +305,7 @@ class TestMemoryTools:
         result = await toolset.tools["update_memory"].function(ctx, "Python 3.11", "Python 3.12")
 
         assert "Memory updated" in result
-        raw = backend.read_bytes("/.deep/memory/main/MEMORY.md")
+        raw = backend._read_bytes("/.deep/memory/main/MEMORY.md")
         assert raw is not None
         assert b"Python 3.12" in raw
         assert b"Python 3.11" not in raw
@@ -340,7 +340,7 @@ class TestMemoryTools:
         assert "appears 2 times" in result
         assert "must be" in result
         # Memory is left unchanged.
-        raw = backend.read_bytes("/.deep/memory/main/MEMORY.md")
+        raw = backend._read_bytes("/.deep/memory/main/MEMORY.md")
         assert raw == b"foo\nfoo\nbar"
 
     async def test_write_memory_custom_path(self):
@@ -354,7 +354,7 @@ class TestMemoryTools:
         )
         await toolset.tools["write_memory"].function(ctx, "Review notes")
 
-        raw = backend.read_bytes("/custom/reviewer/MEMORY.md")
+        raw = backend._read_bytes("/custom/reviewer/MEMORY.md")
         assert raw is not None
         assert b"Review notes" in raw
 
@@ -594,24 +594,25 @@ def _denied_backend_and_dir(tmp_path: Path) -> tuple[Any, str]:
 class TestMemoryFailureSurfacing:
     """Issue #135 — backend write/permission failures must be visible."""
 
-    def test_load_memory_raises_on_denied_path(self, tmp_path):
+    async def test_load_memory_raises_on_denied_path(self, tmp_path):
         """A denied path raises MemoryAccessError, not a silent None."""
         from pydantic_deep import MemoryAccessError
 
         backend, memory_dir = _denied_backend_and_dir(tmp_path)
+        async_backend = ensure_async(backend)
         path = get_memory_path(memory_dir, "main")
         try:
-            load_memory(backend, path, "main")
+            await load_memory(async_backend, path, "main")
             raise AssertionError("expected MemoryAccessError")
         except MemoryAccessError as exc:
             assert "denied" in str(exc).lower() or "outside" in str(exc).lower()
 
-    def test_load_memory_empty_existing_file_returns_none(self):
+    async def test_load_memory_empty_existing_file_returns_none(self):
         """An empty (but accessible) file is missing/empty memory, not an error."""
         backend = StateBackend()
         path = get_memory_path(DEFAULT_MEMORY_DIR, "main")
         backend.write(path, b"")
-        assert load_memory(backend, path, "main") is None
+        assert await load_memory(ensure_async(backend), path, "main") is None
 
     async def test_read_memory_surfaces_denied_access(self, tmp_path):
         """read_memory reports an error instead of 'No memory saved yet.'."""

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -273,8 +273,8 @@ class TestMemoryTools:
 
         assert "Memory updated" in result
         # Verify file was created
-        # _read_bytes is the sync read that AsyncBackendAdapter delegates to.
-        raw = backend._read_bytes("/.deep/memory/main/MEMORY.md")
+        # read_bytes is the sync read that AsyncBackendAdapter delegates to.
+        raw = backend.read_bytes("/.deep/memory/main/MEMORY.md")
         assert raw is not None
         assert b"First entry" in raw
 
@@ -288,7 +288,7 @@ class TestMemoryTools:
         result = await toolset.tools["write_memory"].function(ctx, "New entry")
 
         assert "Memory updated" in result
-        raw = backend._read_bytes("/.deep/memory/main/MEMORY.md")
+        raw = backend.read_bytes("/.deep/memory/main/MEMORY.md")
         assert raw is not None
         content = raw.decode("utf-8")
         assert "Existing" in content
@@ -306,7 +306,7 @@ class TestMemoryTools:
         result = await toolset.tools["update_memory"].function(ctx, "Python 3.11", "Python 3.12")
 
         assert "Memory updated" in result
-        raw = backend._read_bytes("/.deep/memory/main/MEMORY.md")
+        raw = backend.read_bytes("/.deep/memory/main/MEMORY.md")
         assert raw is not None
         assert b"Python 3.12" in raw
         assert b"Python 3.11" not in raw
@@ -341,7 +341,7 @@ class TestMemoryTools:
         assert "appears 2 times" in result
         assert "must be" in result
         # Memory is left unchanged.
-        raw = backend._read_bytes("/.deep/memory/main/MEMORY.md")
+        raw = backend.read_bytes("/.deep/memory/main/MEMORY.md")
         assert raw == b"foo\nfoo\nbar"
 
     async def test_write_memory_custom_path(self):
@@ -355,7 +355,7 @@ class TestMemoryTools:
         )
         await toolset.tools["write_memory"].function(ctx, "Review notes")
 
-        raw = backend._read_bytes("/custom/reviewer/MEMORY.md")
+        raw = backend.read_bytes("/custom/reviewer/MEMORY.md")
         assert raw is not None
         assert b"Review notes" in raw
 

--- a/tests/test_skills_backend.py
+++ b/tests/test_skills_backend.py
@@ -189,6 +189,7 @@ class TestBackendSkillResource:
 
     async def test_load_backend_error_raises(self):
         """If read_bytes raises, SkillResourceLoadError is raised."""
+        # _read_bytes is the sync read that AsyncBackendAdapter delegates to.
         failing_backend = MagicMock()
         failing_backend._read_bytes.side_effect = OSError("disk error")
 

--- a/tests/test_skills_backend.py
+++ b/tests/test_skills_backend.py
@@ -6,7 +6,7 @@ import json
 from unittest.mock import MagicMock
 
 import pytest
-from pydantic_ai_backends import StateBackend
+from pydantic_ai_backends import StateBackend, ensure_async
 from pydantic_ai_backends.types import ExecuteResponse
 
 from pydantic_deep.toolsets.skills.backend import (
@@ -105,7 +105,7 @@ class TestBackendSkillResource:
         resource = BackendSkillResource(
             name="readme.md",
             uri="/skills/test/readme.md",
-            backend=backend,
+            backend=ensure_async(backend),
         )
         result = await resource.load(ctx=None)
         assert result == "# Hello World"
@@ -114,7 +114,7 @@ class TestBackendSkillResource:
         resource = BackendSkillResource(
             name="data.json",
             uri="/skills/test/data.json",
-            backend=backend,
+            backend=ensure_async(backend),
         )
         result = await resource.load(ctx=None)
         assert result == {"key": "value"}
@@ -123,7 +123,7 @@ class TestBackendSkillResource:
         resource = BackendSkillResource(
             name="config.yaml",
             uri="/skills/test/config.yaml",
-            backend=backend,
+            backend=ensure_async(backend),
         )
         result = await resource.load(ctx=None)
         assert result == {"name": "test", "version": 1}
@@ -133,7 +133,7 @@ class TestBackendSkillResource:
         resource = BackendSkillResource(
             name="config.yml",
             uri="/skills/test/config.yml",
-            backend=backend,
+            backend=ensure_async(backend),
         )
         result = await resource.load(ctx=None)
         assert result == {"items": ["one", "two"]}
@@ -142,7 +142,7 @@ class TestBackendSkillResource:
         resource = BackendSkillResource(
             name="plain.txt",
             uri="/skills/test/plain.txt",
-            backend=backend,
+            backend=ensure_async(backend),
         )
         result = await resource.load(ctx=None)
         assert result == "plain text content"
@@ -152,7 +152,7 @@ class TestBackendSkillResource:
         resource = BackendSkillResource(
             name="bad.json",
             uri="/skills/test/bad.json",
-            backend=backend,
+            backend=ensure_async(backend),
         )
         result = await resource.load(ctx=None)
         assert result == "not json {"
@@ -162,7 +162,7 @@ class TestBackendSkillResource:
         resource = BackendSkillResource(
             name="bad.yaml",
             uri="/skills/test/bad.yaml",
-            backend=backend,
+            backend=ensure_async(backend),
         )
         result = await resource.load(ctx=None)
         assert result == "invalid: yaml: ["
@@ -190,12 +190,12 @@ class TestBackendSkillResource:
     async def test_load_backend_error_raises(self):
         """If read_bytes raises, SkillResourceLoadError is raised."""
         failing_backend = MagicMock()
-        failing_backend.read_bytes.side_effect = OSError("disk error")
+        failing_backend._read_bytes.side_effect = OSError("disk error")
 
         resource = BackendSkillResource(
             name="missing.txt",
             uri="/skills/test/missing.txt",
-            backend=failing_backend,
+            backend=ensure_async(failing_backend),
         )
         with pytest.raises(SkillResourceLoadError, match="Failed to read resource"):
             await resource.load(ctx=None)
@@ -205,7 +205,7 @@ class TestBackendSkillResource:
         resource = BackendSkillResource(
             name="Makefile",
             uri="/skills/test/Makefile",
-            backend=backend,
+            backend=ensure_async(backend),
         )
         result = await resource.load(ctx=None)
         assert result == "all: build"
@@ -226,7 +226,7 @@ class TestBackendSkillScriptExecutor:
 
     async def test_run_basic(self):
         backend = MockSandboxBackend(ExecuteResponse(output="hello world", exit_code=0))
-        executor = BackendSkillScriptExecutor(backend=backend, timeout=30)
+        executor = BackendSkillScriptExecutor(backend=ensure_async(backend), timeout=30)
         script = self._make_script()
 
         result = await executor.run(script)
@@ -236,7 +236,7 @@ class TestBackendSkillScriptExecutor:
 
     async def test_run_with_args(self):
         backend = MockSandboxBackend(ExecuteResponse(output="done", exit_code=0))
-        executor = BackendSkillScriptExecutor(backend=backend)
+        executor = BackendSkillScriptExecutor(backend=ensure_async(backend))
         script = self._make_script()
 
         result = await executor.run(script, args={"input": "data.csv", "verbose": True})
@@ -246,7 +246,7 @@ class TestBackendSkillScriptExecutor:
 
     async def test_run_with_bool_false_skipped(self):
         backend = MockSandboxBackend(ExecuteResponse(output="ok", exit_code=0))
-        executor = BackendSkillScriptExecutor(backend=backend)
+        executor = BackendSkillScriptExecutor(backend=ensure_async(backend))
         script = self._make_script()
 
         await executor.run(script, args={"debug": False})
@@ -254,7 +254,7 @@ class TestBackendSkillScriptExecutor:
 
     async def test_run_with_none_value_skipped(self):
         backend = MockSandboxBackend(ExecuteResponse(output="ok", exit_code=0))
-        executor = BackendSkillScriptExecutor(backend=backend)
+        executor = BackendSkillScriptExecutor(backend=ensure_async(backend))
         script = self._make_script()
 
         await executor.run(script, args={"optional": None})
@@ -262,7 +262,7 @@ class TestBackendSkillScriptExecutor:
 
     async def test_run_with_list_args(self):
         backend = MockSandboxBackend(ExecuteResponse(output="ok", exit_code=0))
-        executor = BackendSkillScriptExecutor(backend=backend)
+        executor = BackendSkillScriptExecutor(backend=ensure_async(backend))
         script = self._make_script()
 
         await executor.run(script, args={"file": ["a.txt", "b.txt"]})
@@ -270,7 +270,7 @@ class TestBackendSkillScriptExecutor:
 
     async def test_run_nonzero_exit(self):
         backend = MockSandboxBackend(ExecuteResponse(output="error msg", exit_code=1))
-        executor = BackendSkillScriptExecutor(backend=backend)
+        executor = BackendSkillScriptExecutor(backend=ensure_async(backend))
         script = self._make_script()
 
         result = await executor.run(script)
@@ -280,7 +280,7 @@ class TestBackendSkillScriptExecutor:
         backend = MockSandboxBackend(
             ExecuteResponse(output="partial output", exit_code=0, truncated=True)
         )
-        executor = BackendSkillScriptExecutor(backend=backend)
+        executor = BackendSkillScriptExecutor(backend=ensure_async(backend))
         script = self._make_script()
 
         result = await executor.run(script)
@@ -288,7 +288,7 @@ class TestBackendSkillScriptExecutor:
 
     async def test_run_empty_output(self):
         backend = MockSandboxBackend(ExecuteResponse(output="", exit_code=0))
-        executor = BackendSkillScriptExecutor(backend=backend)
+        executor = BackendSkillScriptExecutor(backend=ensure_async(backend))
         script = self._make_script()
 
         result = await executor.run(script)
@@ -297,7 +297,7 @@ class TestBackendSkillScriptExecutor:
     async def test_run_shell_injection_escaped(self):
         """Verify shell metacharacters in args are escaped (issue #31)."""
         backend = MockSandboxBackend(ExecuteResponse(output="safe", exit_code=0))
-        executor = BackendSkillScriptExecutor(backend=backend)
+        executor = BackendSkillScriptExecutor(backend=ensure_async(backend))
         script = self._make_script()
 
         await executor.run(script, args={"filename": "$(whoami)"})
@@ -307,7 +307,7 @@ class TestBackendSkillScriptExecutor:
 
     async def test_run_no_uri_raises(self):
         backend = MockSandboxBackend()
-        executor = BackendSkillScriptExecutor(backend=backend)
+        executor = BackendSkillScriptExecutor(backend=ensure_async(backend))
         script = self._make_script(uri=None)
         script.uri = None
 
@@ -317,7 +317,7 @@ class TestBackendSkillScriptExecutor:
     async def test_run_backend_exception_raises(self):
         backend = MockSandboxBackend()
         backend.execute = MagicMock(side_effect=RuntimeError("connection lost"))  # type: ignore[method-assign]
-        executor = BackendSkillScriptExecutor(backend=backend)
+        executor = BackendSkillScriptExecutor(backend=ensure_async(backend))
         script = self._make_script()
 
         with pytest.raises(SkillScriptExecutionError, match="Failed to execute"):
@@ -329,7 +329,7 @@ class TestBackendSkillScript:
 
     async def test_run_delegates_to_executor(self):
         backend = MockSandboxBackend(ExecuteResponse(output="executed", exit_code=0))
-        executor = BackendSkillScriptExecutor(backend=backend)
+        executor = BackendSkillScriptExecutor(backend=ensure_async(backend))
         script = BackendSkillScript(
             name="run.py",
             uri="/skills/test/run.py",
@@ -340,7 +340,7 @@ class TestBackendSkillScript:
 
     async def test_run_no_uri_raises(self):
         backend = MockSandboxBackend()
-        executor = BackendSkillScriptExecutor(backend=backend)
+        executor = BackendSkillScriptExecutor(backend=ensure_async(backend))
         script = BackendSkillScript(
             name="run.py",
             uri="/placeholder",  # satisfy __post_init__
@@ -406,7 +406,7 @@ class TestDiscovery:
         backend.write("/skills/test/data.json", '{"key": "val"}')
         backend.write("/skills/test/sub/template.txt", "template content")
 
-        resources = _discover_backend_resources(backend, "/skills/test")
+        resources = _discover_backend_resources(backend, ensure_async(backend), "/skills/test")
 
         names = [r.name for r in resources]
         assert "readme.md" in names or any("readme" in n for n in names)
@@ -416,14 +416,14 @@ class TestDiscovery:
 
     def test_discover_resources_empty_dir(self):
         backend = StateBackend()
-        resources = _discover_backend_resources(backend, "/skills/empty")
+        resources = _discover_backend_resources(backend, ensure_async(backend), "/skills/empty")
         assert resources == []
 
     def test_discover_resources_glob_error_handled(self):
         """If glob_info throws, resources are still collected for other extensions."""
         backend = MagicMock()
         backend.glob_info.side_effect = RuntimeError("glob failed")
-        resources = _discover_backend_resources(backend, "/skills/test")
+        resources = _discover_backend_resources(backend, ensure_async(backend), "/skills/test")
         assert resources == []
 
     def test_discover_scripts(self):
@@ -632,18 +632,18 @@ class TestBackendSkillsDirectory:
 
     def test_unexpected_error_wraps_in_validation_error(self):
         backend = StateBackend()
-        # Write a valid-looking SKILL.md but make read_bytes fail
+        # Write a valid-looking SKILL.md but make _read_bytes fail
         backend.write("/skills/test/SKILL.md", "---\nname: test\n---\nContent")
 
-        # Patch read_bytes to fail after glob succeeds
-        original_read = backend.read_bytes
+        # Patch _read_bytes to fail after glob succeeds
+        original_read = backend._read_bytes
 
         def failing_read(path: str) -> bytes:
             if "SKILL.md" in path:
                 raise OSError("disk error")
             return original_read(path)  # type: ignore[no-any-return]
 
-        backend.read_bytes = failing_read
+        backend._read_bytes = failing_read
 
         with pytest.raises(SkillValidationError, match="Failed to load skill"):
             BackendSkillsDirectory(backend=backend, path="/skills")
@@ -743,7 +743,7 @@ class TestCoverageEdgeCases:
         resource = BackendSkillResource(
             name="config.yaml",
             uri="/skills/test/config.yaml",
-            backend=backend,
+            backend=ensure_async(backend),
         )
         # Without pyyaml, should return raw text
         result = await resource.load(ctx=None)

--- a/tests/test_skills_backend.py
+++ b/tests/test_skills_backend.py
@@ -189,9 +189,9 @@ class TestBackendSkillResource:
 
     async def test_load_backend_error_raises(self):
         """If read_bytes raises, SkillResourceLoadError is raised."""
-        # _read_bytes is the sync read that AsyncBackendAdapter delegates to.
+        # read_bytes is the sync read that AsyncBackendAdapter delegates to.
         failing_backend = MagicMock()
-        failing_backend._read_bytes.side_effect = OSError("disk error")
+        failing_backend.read_bytes.side_effect = OSError("disk error")
 
         resource = BackendSkillResource(
             name="missing.txt",
@@ -633,18 +633,18 @@ class TestBackendSkillsDirectory:
 
     def test_unexpected_error_wraps_in_validation_error(self):
         backend = StateBackend()
-        # Write a valid-looking SKILL.md but make _read_bytes fail
+        # Write a valid-looking SKILL.md but make read_bytes fail
         backend.write("/skills/test/SKILL.md", "---\nname: test\n---\nContent")
 
-        # Patch _read_bytes to fail after glob succeeds
-        original_read = backend._read_bytes
+        # Patch read_bytes to fail after glob succeeds
+        original_read = backend.read_bytes
 
         def failing_read(path: str) -> bytes:
             if "SKILL.md" in path:
                 raise OSError("disk error")
             return original_read(path)  # type: ignore[no-any-return]
 
-        backend._read_bytes = failing_read
+        backend.read_bytes = failing_read
 
         with pytest.raises(SkillValidationError, match="Failed to load skill"):
             BackendSkillsDirectory(backend=backend, path="/skills")

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -188,7 +188,7 @@ class TestDeepAgentFromSpec:
             backend=backend,
             cost_tracking=False,
         )
-        assert deps.backend is backend
+        assert deps.backend.unwrap() is backend
 
     def test_from_spec_empty_dict(self) -> None:
         """Empty dict uses all defaults."""
@@ -218,7 +218,7 @@ class TestDeepAgentFromSpec:
             },
         )
         assert agent is not None
-        assert deps.backend is backend
+        assert deps.backend.unwrap() is backend
 
 
 class TestDeepAgentFromFile:

--- a/tests/test_tui_forking.py
+++ b/tests/test_tui_forking.py
@@ -1145,7 +1145,7 @@ class TestForkOpenDiffAllowList:
 class TestMergePickerOpenInEditor:
     """Test M - `MergePickerModal` exposes an Open-in-editor delegation point."""
 
-    def test_open_in_editor_delegates_to_callback(self, fork_app: DeepApp) -> None:
+    async def test_open_in_editor_delegates_to_callback(self, fork_app: DeepApp) -> None:
         from datetime import datetime, timezone
 
         from pydantic_deep.toolsets.forking.diff import build_diff_report
@@ -1165,12 +1165,12 @@ class TestMergePickerOpenInEditor:
                 last_activity_at=datetime.now(timezone.utc),
             )
         ]
-        report = build_diff_report("fork-x", [])
+        report = await build_diff_report("fork-x", [])
         modal = MergePickerModal(report, statuses, {"a": "id-a"}, on_open_in_editor=callback)
         modal.action_open_in_editor()
         assert seen == ["id-a"]
 
-    def test_open_in_editor_noop_without_callback(self, fork_app: DeepApp) -> None:
+    async def test_open_in_editor_noop_without_callback(self, fork_app: DeepApp) -> None:
         from datetime import datetime, timezone
 
         from pydantic_deep.toolsets.forking.diff import build_diff_report
@@ -1185,7 +1185,7 @@ class TestMergePickerOpenInEditor:
                 last_activity_at=datetime.now(timezone.utc),
             )
         ]
-        report = build_diff_report("fork-x", [])
+        report = await build_diff_report("fork-x", [])
         modal = MergePickerModal(report, statuses, {"a": "id-a"})
         # No callback set → action is a no-op, must not raise.
         modal.action_open_in_editor()


### PR DESCRIPTION
## Summary

- Converts all backend interactions from synchronous `BackendProtocol` calls to async `AsyncBackendProtocol`, enabling non-blocking I/O across the agent lifecycle
- `DeepAgentDeps.__post_init__` auto-wraps sync backends with `ensure_async()` so consumer code can always `await backend.X()`
- Updates hooks, forking internals, skills, context files, memory, eviction, and examples to use the async API

Closes #129

## Test plan

- [ ] Run `make test` — all existing tests pass with async backend calls
- [ ] Verify `DeepAgentDeps` auto-wraps sync `StateBackend` / `LocalBackend` transparently
- [ ] Confirm forking `BranchOverlay` correctly unwraps the async adapter for sync overlay operations
- [ ] Check that hooks using `AsyncSandboxProtocol.execute()` behave identically to the previous `asyncio.to_thread` path
- [ ] Validate skill discovery loads resources/scripts with the wrapped async backend