### PR TITLE
docs: label ecosystem table stars column

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,8 +516,8 @@ make all    # lint + typecheck + test
 
 **pydantic-deepagents** is part of a broader open-source ecosystem for production AI agents:
 
-| Project | Description | |
-|---------|-------------|---|
+| Project | Description | Stars |
+|---------|-------------|-------|
 | **[full-stack-ai-agent-template](https://github.com/vstorm-co/full-stack-ai-agent-template)** | Zero to production AI app in 30 minutes. FastAPI + Next.js 15, 6 AI frameworks (incl. pydantic-deep), RAG pipeline, 75+ config options. | [![Stars](https://img.shields.io/github/stars/vstorm-co/full-stack-ai-agent-template?style=flat&logo=github&color=yellow)](https://github.com/vstorm-co/full-stack-ai-agent-template) |
 | **[pydantic-ai-shields](https://github.com/vstorm-co/pydantic-ai-shields)** | Drop-in guardrails for Pydantic AI agents. 5 infra + 5 content shields. | [![Stars](https://img.shields.io/github/stars/vstorm-co/pydantic-ai-shields?style=flat&logo=github&color=yellow)](https://github.com/vstorm-co/pydantic-ai-shields) |
 | **[pydantic-ai-subagents](https://github.com/vstorm-co/pydantic-ai-subagents)** | Declarative multi-agent orchestration with token tracking. | [![Stars](https://img.shields.io/github/stars/vstorm-co/pydantic-ai-subagents?style=flat&logo=github&color=yellow)](https://github.com/vstorm-co/pydantic-ai-subagents) |


### PR DESCRIPTION
## Summary
- Name the third column in the Vstorm OSS Ecosystem table as `Stars`
- Keep the existing badge links unchanged while making the table header clearer

## Testing
- Documentation-only change; not run
