### PR TITLE
chore: release 0.3.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.29] - 2026-06-12
+
 ### Added
 
 - **Goal-completion loop — `/goal` (framework engine + CLI command)** (new `pydantic_deep/goal.py`, `apps/cli/goal.py`, wired into `apps/cli/screens/chat.py`). Set a completion condition and the agent keeps working toward it across turns without per-turn prompting — a port of Claude Code's [`/goal`](https://code.claude.com/docs/en/goal).
   - **Framework.** `pydantic_deep/goal.py` is a provider/UI-agnostic engine. `GoalEvaluator` asks a small, fast model (default Haiku, matching the periodic-reminder tier) whether the condition is satisfied — judging *only* from the conversation transcript, never running tools, exactly like Claude Code. It returns a `GoalEvaluation(met, reason, …token counts)`. `GoalState` holds session-scoped state (condition, turns, achieved, last reason, cumulative evaluator tokens) with a hard `max_turns` safety cap so a vague condition can't loop forever. Pure helpers — `parse_goal_command` (set / clear / status, with `clear`/`stop`/`off`/`reset`/`none`/`cancel` aliases and the 4,000-char condition cap), `parse_verdict` (lenient YES/NO parsing that defaults to *not met* on ambiguity so the loop never declares premature success), `build_goal_transcript` (compact transcript that keeps assistant text and tool results as the evidence the evaluator judges), `goal_continue_directive`, and `format_goal_status` — let any CLI or headless driver wire the behaviour. All exported from the top-level package.
   - **CLI.** New `/goal <condition>` command sets a goal and kicks the first turn immediately (the condition is the directive); `/goal` with no argument opens an input modal to type a condition (or, when a goal is already active, shows its status — condition, elapsed time, turns evaluated, evaluator tokens, latest reason); `/goal clear` (and aliases) drops it early, as does `/clear`. After each turn the stream worker evaluates the active goal off the saved history: when met it clears with a `✓ Goal achieved` toast, otherwise the evaluator's reason is surfaced and fed into a fresh turn. A `◎ goal` indicator shows on the status bar while a goal is active. Listed in `/help` and the command picker.
+
+### Changed
+
+- **Bumped vstorm-co packages** ([#145](https://github.com/vstorm-co/pydantic-deepagents/pull/145), Renovate) (`pyproject.toml`). `pydantic-ai-todo` to `>=0.2.5` — adds the `update_todo_statuses` batch tool and defaults `TodoItem.status` to `"pending"` (one fewer validation round-trip on plan creation). `pydantic-ai-backend` to `>=0.2.12` (`console` + `docker` extras).
 
 ## [0.3.28] - 2026-06-07
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-deep"
-version = "0.3.28"
+version = "0.3.29"
 description = "Batteries-included agent harness for Python — tool-calling, sandboxed execution, multi-agent teams, and unlimited context on Pydantic AI"
 readme = "README.md"
 keywords = [


### PR DESCRIPTION
Cuts **0.3.29** — version bump + CHANGELOG.

Bundles everything merged since 0.3.28:
- **Goal-completion loop `/goal`** (#132) — set a completion condition and the agent keeps working toward it across turns.
- **Dependency bump** (#145, Renovate) — `pydantic-ai-todo>=0.2.5` (batch `update_todo_statuses` + `TodoItem.status` defaulting to `pending`), `pydantic-ai-backend>=0.2.12`.

`pyproject.toml` version `0.3.28` → `0.3.29`; `[Unreleased]` promoted to `[0.3.29] - 2026-06-12`.