### PR TITLE
fix: stop early-breaking verbose stream so tool calls execute

### DIFF
--- a/apps/cli/run.py
+++ b/apps/cli/run.py
@@ -15,7 +15,6 @@ from typing import Any
 from pydantic_ai import Agent
 from pydantic_ai._agent_graph import End, UserPromptNode
 from pydantic_ai.messages import (
-    FinalResultEvent,
     FunctionToolCallEvent,
     FunctionToolResultEvent,
     PartDeltaEvent,
@@ -165,11 +164,8 @@ async def execute_headless(  # noqa: C901
             deps.backend.stop()
 
 
-async def _run_verbose(  # noqa: C901
-    agent: Any, task: str, deps: Any, run_kwargs: dict[str, Any]
-) -> Any:
+async def _run_verbose(agent: Any, task: str, deps: Any, run_kwargs: dict[str, Any]) -> Any:
     """Run agent with verbose progress on stderr."""
-
     _log = lambda msg: print(msg, file=sys.stderr, flush=True)  # noqa: E731
     start = _time.monotonic()
 
@@ -191,8 +187,6 @@ async def _run_verbose(  # noqa: C901
                                 thinking_chars += len(event.delta.content_delta or "")
                             elif isinstance(event.delta, TextPartDelta):
                                 text_chars += len(event.delta.content_delta or "")
-                        elif isinstance(event, FinalResultEvent):
-                            break
                     if thinking_chars:
                         t = _time.monotonic() - start
                         _log(f"[{t:6.1f}s]   thinking: {thinking_chars} chars")


### PR DESCRIPTION
## Summary

`--verbose` mode (`pydantic-deep run ... --verbose`) was exiting early and never
applying any fixes — it printed a short text summary but never ran the tool calls
(e.g. `edit_file`). Root cause: `_run_verbose` in `apps/cli/run.py` broke out of the
model-request stream on `FinalResultEvent` and abandoned it mid-flight while still
inside the `async with node.stream(...)` block. This truncated the model turn, so the
agent never reached its tool-call nodes. The two working implementations in this repo
(`apps/cli/screens/chat.py` and `apps/deepresearch/.../app.py`) break on that event
*and then drain the rest* of the stream — `run.py` skipped the drain. Fix: let the
model-request stream iterate to natural completion so the turn finishes and tool calls
run, matching the non-verbose path.

## Changes

- Removed the early `break` on `FinalResultEvent` in `_run_verbose` so the
  model-request stream is fully consumed and the agent proceeds to its tool-call nodes.
- Removed the now-unused `FinalResultEvent` import and the now-unused `# noqa: C901`
  directive on `_run_verbose` (complexity dropped below threshold).

## Testing

- [ ] New tests added for any new functionality (required — `make test` enforces 100% coverage)
- [x] All tests pass locally: `make test` *(ran `tests/test_cli_run.py` — 24 passed)*
- [x] Linting passes: `make lint`
- [x] Type checking passes: `make typecheck` *(only 2 pre-existing errors in untouched code: `backend.stop`, `End` import)*
- [ ] Security scan passes: `make security`
- [ ] Full check suite passes: `make all`

## Related Issues

Fixes #147