### PR TITLE
feat(deepresearch): add Sofya as a web tools MCP provider

### DIFF
--- a/apps/deepresearch/.env.example
+++ b/apps/deepresearch/.env.example
@@ -22,6 +22,9 @@ BRAVE_API_KEY=
 # Jina AI Reader — converts URLs to markdown (https://jina.ai/)
 JINA_API_KEY=
 
+# Sofya: all-in-one web tools (search, fetch, extract, research) (https://sofya.co)
+SOFYA_API_KEY=
+
 # Firecrawl — advanced web scraping (https://firecrawl.dev)
 FIRECRAWL_API_KEY=
 

--- a/apps/deepresearch/README.md
+++ b/apps/deepresearch/README.md
@@ -65,7 +65,7 @@ Open [http://localhost:8080](http://localhost:8080) in your browser.
 
 | Feature | Description |
 |---------|-------------|
-| **Web Search** | Tavily, Brave Search, Jina URL reader, Firecrawl |
+| **Web Search** | Tavily, Brave Search, Jina URL reader, Firecrawl, Sofya |
 | **Browser Automation** | Playwright MCP for JS-heavy pages |
 | **File Operations** | Read, write, edit, glob, grep in isolated Docker sandbox |
 | **Code Execution** | Python with pandas, numpy, matplotlib, scikit-learn pre-installed |
@@ -89,6 +89,7 @@ Open [http://localhost:8080](http://localhost:8080) in your browser.
 | `TAVILY_API_KEY` | Recommended | Tavily AI search |
 | `BRAVE_API_KEY` | No | Brave Search |
 | `JINA_API_KEY` | No | Jina URL reader |
+| `SOFYA_API_KEY` | No | Sofya web search, fetch, extract, research |
 | `FIRECRAWL_API_KEY` | No | Firecrawl web scraper |
 | `PLAYWRIGHT_MCP` | No | Set to `1` to enable Playwright browser |
 | `EXCALIDRAW_ENABLED` | No | Set to `0` to disable Excalidraw (default: `1`) |
@@ -117,6 +118,10 @@ BRAVE_API_KEY=BSAxxxxx
 # Jina AI Reader (converts any URL to clean markdown)
 # Sign up at https://jina.ai — free tier available
 JINA_API_KEY=jina_xxxxx
+
+# Sofya (all-in-one: web search, fetch, extract, deep research)
+# Sign up with GitHub at https://sofya.co for free monthly credits
+SOFYA_API_KEY=ay_live_xxxxx
 ```
 
 ### Web Scraping — Firecrawl

--- a/apps/deepresearch/src/deepresearch/config.py
+++ b/apps/deepresearch/src/deepresearch/config.py
@@ -90,6 +90,19 @@ def create_mcp_servers() -> list[AbstractToolset]:
             )
         )
 
+    # Sofya: all-in-one web tools (search, fetch, AI extract, deep research)
+    # Requires SOFYA_API_KEY (free monthly credits at https://sofya.co)
+    sofya_key = os.getenv("SOFYA_API_KEY")
+    if sofya_key:
+        servers.append(
+            MCPServerStreamableHTTP(
+                url="https://mcp.sofya.co/mcp",
+                headers={"Authorization": f"Bearer {sofya_key}"},
+                tool_prefix="sofya",
+                max_retries=3,
+            )
+        )
+
     # Excalidraw — live canvas with real-time sync via mcp-excalidraw-server
     excalidraw_server_url = os.getenv("EXCALIDRAW_SERVER_URL", "http://host.docker.internal:3000")
     if os.getenv("EXCALIDRAW_ENABLED", "1") == "1" and _docker_available():


### PR DESCRIPTION
## Summary

Adds [Sofya](https://sofya.co) as a web tools provider for the DeepResearch app. Sofya is an all-in-one web API for agents that exposes web search, fetch to markdown, AI extract, and deep research with citations over a single streamable-HTTP MCP server. The deep research capability in particular is a natural fit for DeepResearch.

It slots in next to the existing providers (Tavily, Brave, Jina, Firecrawl) and is fully optional: it only activates when `SOFYA_API_KEY` is set, so nothing changes for users who do not configure it.

## Changes

- `apps/deepresearch/src/deepresearch/config.py`: register a Sofya streamable-HTTP MCP server in `create_mcp_servers()`, gated on `SOFYA_API_KEY`, mirroring the existing Jina provider. Tools are exposed under the `sofya` prefix.
- `apps/deepresearch/.env.example`: document `SOFYA_API_KEY`.
- `apps/deepresearch/README.md`: add Sofya to the features table, the environment variables table, and the Web Search setup section.

## Testing

This follows the exact pattern of the existing optional providers (Tavily, Brave, Jina, Firecrawl), which are config-only entries in `create_mcp_servers()` gated behind an env var and have no dedicated tests. The change does not touch the `pydantic_deep` core package, so the 100% coverage scope (`source = ["pydantic_deep"]`) is unaffected.

- [ ] New tests added for any new functionality (n/a: app-level provider config, mirrors existing providers, outside the core coverage scope)
- [x] Linting passes: `ruff format --check` and `ruff check` both clean repo-wide
- [x] Type checking unaffected: `pyright`/`mypy` target `pydantic_deep` and `tests`, not `apps/`
- [x] Spell check clean: `codespell` passes on the changed files
- [x] Verified `config.py` compiles and the Sofya block activates only when `SOFYA_API_KEY` is set

## Related Issues

None. Happy to open a tracking issue first if preferred.

## Notes for Reviewers

- The integration is one streamable-HTTP MCP server, so a single entry exposes all four Sofya tools (search, fetch, extract, research) to the agent.
- Sofya offers free monthly credits when you sign up with GitHub, so reviewers can try it end to end without a paid plan.