### PR TITLE
docs: add Xquik search tool example

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -62,6 +62,12 @@ uv run python examples/<example_name>.py
 </div>
 
 <div class="feature-card" markdown>
+<h3 markdown="span">:material-magnify: Xquik Search Tool</h3>
+<p>Connect a custom tool to Xquik's public X post search API.</p>
+<a href="xquik-search/">View Example →</a>
+</div>
+
+<div class="feature-card" markdown>
 <h3 markdown="span">:material-upload: File Uploads</h3>
 <p>Upload files for agent processing with run_with_files() or deps.upload_file().</p>
 <a href="file-uploads/">View Example →</a>

--- a/docs/examples/xquik-search.md
+++ b/docs/examples/xquik-search.md
@@ -1,0 +1,74 @@
+# Xquik Search Tool
+
+Connect a deep agent to Xquik's public X post search endpoint with one custom
+tool.
+
+## Source Code
+
+:material-file-code: `examples/xquik_search.py`
+
+## Overview
+
+This example demonstrates:
+
+- Calling an authenticated HTTP API from a custom tool
+- Returning structured X post search results to the agent
+- Keeping third-party tools opt-in with environment variables
+- Letting the agent summarize public X posts with the built-in tool loop
+
+## Tool Function
+
+```python
+async def search_x_posts(
+    ctx: RunContext[DeepAgentDeps],
+    query: str,
+    limit: int = 10,
+    cursor: str | None = None,
+) -> str:
+    """Search public X posts with Xquik.
+
+    Args:
+        query: Keyword, X search query, Tweet ID, or X status URL.
+        limit: Maximum posts to return, from 1 to 50.
+        cursor: Optional pagination cursor from a previous response.
+    """
+    result = await asyncio.to_thread(_fetch_xquik_posts, query, limit, cursor)
+    return json.dumps(result, ensure_ascii=False)
+```
+
+The helper reads `XQUIK_API_KEY`, calls
+`https://xquik.com/api/v1/x/tweets/search`, and returns a JSON string with
+`tweets`, `has_more`, and `next_cursor`.
+
+## Running the Example
+
+```bash
+export ANTHROPIC_API_KEY=your-model-api-key
+export XQUIK_API_KEY=your-xquik-api-key
+uv run python examples/xquik_search.py
+```
+
+Use `PYDANTIC_DEEP_MODEL` to choose another supported model:
+
+```bash
+export PYDANTIC_DEEP_MODEL=openai:gpt-4o
+```
+
+## Key Concepts
+
+The tool is just a typed async function passed to `create_deep_agent()`:
+
+```python
+agent = create_deep_agent(
+    model=os.environ.get("PYDANTIC_DEEP_MODEL", "anthropic:claude-sonnet-4-6"),
+    instructions="Use search_x_posts when a task needs current public X posts.",
+    tools=[search_x_posts],
+)
+```
+
+No Xquik dependency is loaded by default. The tool only runs when you register it
+and provide `XQUIK_API_KEY`.
+
+!!! tip "Paginate"
+    If the response includes `has_more: true`, call `search_x_posts` again with
+    the returned `next_cursor`.

--- a/examples/xquik_search.py
+++ b/examples/xquik_search.py
@@ -1,0 +1,114 @@
+"""Example adding an Xquik search tool to a deep agent.
+
+This example demonstrates:
+- Calling an authenticated HTTP API from a custom tool
+- Returning structured X post search results to the agent
+- Keeping third-party tools opt-in through environment variables
+"""
+
+import asyncio
+import json
+import os
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from pydantic_ai import RunContext
+
+from pydantic_deep import DeepAgentDeps, StateBackend, create_deep_agent
+
+XQUIK_SEARCH_URL = "https://xquik.com/api/v1/x/tweets/search"
+
+
+def _clamp_limit(limit: int) -> int:
+    return max(1, min(limit, 50))
+
+
+def _fetch_xquik_posts(query: str, limit: int, cursor: str | None) -> dict[str, Any]:
+    params = {
+        "q": query,
+        "limit": str(_clamp_limit(limit)),
+    }
+    if cursor:
+        params["cursor"] = cursor
+
+    api_key = os.environ.get("XQUIK_API_KEY")
+    if not api_key:
+        return {
+            "ok": False,
+            "error": "Set XQUIK_API_KEY before calling search_x_posts.",
+        }
+
+    request = Request(
+        f"{XQUIK_SEARCH_URL}?{urlencode(params)}",
+        headers={
+            "Accept": "application/json",
+            "X-API-Key": api_key,
+        },
+    )
+
+    try:
+        with urlopen(request, timeout=30) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except HTTPError as exc:
+        return {
+            "ok": False,
+            "status": exc.code,
+            "error": exc.reason,
+        }
+    except (OSError, URLError, json.JSONDecodeError) as exc:
+        return {
+            "ok": False,
+            "error": str(exc),
+        }
+
+    return {
+        "ok": True,
+        "tweets": payload.get("tweets", []),
+        "has_more": payload.get("has_more", False),
+        "next_cursor": payload.get("next_cursor"),
+    }
+
+
+async def search_x_posts(
+    ctx: RunContext[DeepAgentDeps],
+    query: str,
+    limit: int = 10,
+    cursor: str | None = None,
+) -> str:
+    """Search public X posts with Xquik.
+
+    Args:
+        query: Keyword, X search query, Tweet ID, or X status URL.
+        limit: Maximum posts to return, from 1 to 50.
+        cursor: Optional pagination cursor from a previous response.
+    """
+    result = await asyncio.to_thread(_fetch_xquik_posts, query, limit, cursor)
+    return json.dumps(result, ensure_ascii=False)
+
+
+async def main():
+    agent = create_deep_agent(
+        model=os.environ.get("PYDANTIC_DEEP_MODEL", "anthropic:claude-sonnet-4-6"),
+        instructions="""
+        You are a research assistant.
+        Use search_x_posts when a task needs current public X posts.
+        Summarize patterns, include post URLs when available, and say when no results return.
+        """,
+        tools=[search_x_posts],
+    )
+
+    deps = DeepAgentDeps(backend=StateBackend())
+
+    result = await agent.run(
+        "Find recent public X posts about open source AI agents and summarize the themes.",
+        deps=deps,
+    )
+
+    print("Agent output:")
+    print(result.output)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -303,6 +303,7 @@ nav:
     - Agent Features:
       - examples/subagents.md
       - examples/custom-tools.md
+      - examples/xquik-search.md
       - examples/skills.md
       - examples/file-uploads.md
       - examples/thinking.md


### PR DESCRIPTION
Summary
- Add a runnable `examples/xquik_search.py` custom-tool example.
- Add docs for registering the Xquik search tool through `create_deep_agent(tools=[...])`.
- Add the example to the examples index and MkDocs navigation.

Validation
- `python3 -m py_compile examples/xquik_search.py`
- `uv run --with ruff ruff check examples/xquik_search.py`
- `uv run --with ruff ruff format --check examples/xquik_search.py`
- `git diff --check`
- `uv run --group docs mkdocs build --strict`
