### PR TITLE
feat: expose init_timeout on MCPServerConfig for slow-starting servers

### DIFF
--- a/apps/cli/modals/mcp_view.py
+++ b/apps/cli/modals/mcp_view.py
@@ -379,9 +379,11 @@ class MCPViewModal(ModalScreen[None]):
             self._set_test_status(config.name, f"[red]· build error: {exc}[/red]")
             return
         # OAuth servers open a browser and wait for the user to authorize, so
-        # give the probe much longer than the default.
+        # give the probe much longer than the default. For the rest, a raised
+        # init_timeout must fit within the probe window — otherwise a slow
+        # server that connects fine at runtime would still fail the test here.
         is_oauth = config.auth is not None and config.auth.kind == "oauth"
-        timeout = 180.0 if is_oauth else 10.0
+        timeout = 180.0 if is_oauth else max(10.0, (config.init_timeout or 5.0) + 5.0)
         result: MCPProbeResult = await probe_mcp_server(server, timeout=timeout)
         if result.ok:
             self._set_test_status(config.name, f"[green]· ✓ {result.tool_count} tools[/green]")

--- a/pydantic_deep/mcp/config.py
+++ b/pydantic_deep/mcp/config.py
@@ -122,10 +122,19 @@ class MCPServerConfig:
     description: str = ""
     builtin: bool = False
     auth: MCPAuth | None = None
+    init_timeout: float | None = None
+    """Seconds to wait for the initial connection + ``initialize`` handshake.
+
+    ``None`` uses pydantic-ai's default (5s). Raise it for servers that are slow
+    to become ready (e.g. one that opens a database connection on startup),
+    which would otherwise fail with ``"Failed to initialize server session"``.
+    """
 
     def __post_init__(self) -> None:
         if not self.name:
             raise MCPConfigError("MCP server config requires a non-empty name")
+        if self.init_timeout is not None and self.init_timeout <= 0:
+            raise MCPConfigError(f"MCP server '{self.name}' init_timeout must be positive")
         if self.transport == "stdio":
             if not self.command:
                 raise MCPConfigError(f"stdio MCP server '{self.name}' requires a command")
@@ -163,4 +172,5 @@ class MCPServerConfig:
             description=data.get("description", ""),
             builtin=data.get("builtin", False),
             auth=MCPAuth.from_dict(auth_data) if auth_data is not None else None,
+            init_timeout=data.get("init_timeout"),
         )

--- a/pydantic_deep/mcp/registry.py
+++ b/pydantic_deep/mcp/registry.py
@@ -121,6 +121,9 @@ def build_mcp_server(
     Resolves the auth secret (if any) and injects it as an HTTP header (for
     ``bearer``/``header`` auth) or a subprocess env var (for ``env`` auth).
     Wraps the toolset in a ``PrefixedToolset`` when ``tool_prefix`` is set.
+    When ``config.init_timeout`` is set it is forwarded to the ``MCPToolset``,
+    raising the connect/``initialize`` deadline above pydantic-ai's 5s default
+    for servers that are slow to become ready.
 
     For ``stdio`` servers, the subprocess receives ``config.env`` (plus any
     ``env``-kind auth var) layered on top of the MCP SDK's *safe default*
@@ -149,6 +152,10 @@ def build_mcp_server(
     headers = dict(config.headers)
     env = dict(config.env)
 
+    extra: dict[str, Any] = {}
+    if config.init_timeout is not None:
+        extra["init_timeout"] = config.init_timeout
+
     auth = config.auth
     if auth is not None and auth.kind in _SECRET_AUTH_KINDS:
         token = resolver(auth.secret_key)
@@ -168,7 +175,7 @@ def build_mcp_server(
             env=env or None,
             log_file=_stdio_log_file(config.name),
         )
-        toolset = MCPToolset(transport, id=config.name)
+        toolset = MCPToolset(transport, id=config.name, **extra)
     elif auth is not None and auth.kind == "oauth":  # http/sse interactive OAuth
         url = cast(str, config.url)
         # A persistent token store and/or a custom client name require a real
@@ -181,12 +188,12 @@ def build_mcp_server(
                 oauth_kwargs["token_storage"] = oauth_token_storage
             if auth.client_name:
                 oauth_kwargs["client_name"] = auth.client_name
-            toolset = MCPToolset(url, auth=OAuth(**oauth_kwargs), id=config.name)
+            toolset = MCPToolset(url, auth=OAuth(**oauth_kwargs), id=config.name, **extra)
         else:
-            toolset = MCPToolset(url, auth="oauth", id=config.name)
+            toolset = MCPToolset(url, auth="oauth", id=config.name, **extra)
     else:  # http / sse — FastMCP infers the transport from the URL
         url = cast(str, config.url)
-        toolset = MCPToolset(url, headers=headers or None, id=config.name)
+        toolset = MCPToolset(url, headers=headers or None, id=config.name, **extra)
 
     if config.tool_prefix:
         toolset = PrefixedToolset(toolset, config.tool_prefix)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -337,6 +337,61 @@ def test_build_raises_when_mcp_missing(monkeypatch: pytest.MonkeyPatch) -> None:
         build_mcp_server(cfg)
 
 
+def test_config_init_timeout_defaults_none() -> None:
+    assert MCPServerConfig(name="x", transport="stdio", command="run").init_timeout is None
+
+
+def test_config_init_timeout_roundtrip() -> None:
+    cfg = MCPServerConfig(name="db", transport="stdio", command="run", init_timeout=8.0)
+    assert MCPServerConfig.from_dict(cfg.to_dict()) == cfg
+
+
+def test_config_rejects_non_positive_init_timeout() -> None:
+    with pytest.raises(MCPConfigError):
+        MCPServerConfig(name="x", transport="stdio", command="run", init_timeout=0)
+    with pytest.raises(MCPConfigError):
+        MCPServerConfig(name="x", transport="stdio", command="run", init_timeout=-1)
+
+
+def _spy_mcp_classes(recorder: dict[str, Any]) -> tuple[Any, Any, Any]:
+    """Fake (MCPToolset, PrefixedToolset, StdioTransport) that records kwargs.
+
+    Lets the forwarding tests run without a working ``fastmcp`` client install.
+    """
+
+    class SpyStdioTransport:
+        def __init__(self, command: str, args: list[str], **kwargs: Any) -> None:
+            self.command = command
+            self.args = args
+
+    class SpyMCPToolset:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            recorder["args"] = args
+            recorder["kwargs"] = kwargs
+
+    class SpyPrefixedToolset:
+        def __init__(self, wrapped: Any, prefix: str) -> None:  # pragma: no cover
+            self.wrapped = wrapped
+
+    return SpyMCPToolset, SpyPrefixedToolset, SpyStdioTransport
+
+
+def test_build_forwards_init_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    rec: dict[str, Any] = {}
+    monkeypatch.setattr(registry_mod, "_load_mcp_classes", lambda: _spy_mcp_classes(rec))
+    cfg = MCPServerConfig(name="db", transport="stdio", command="run", init_timeout=8.0)
+    build_mcp_server(cfg)
+    assert rec["kwargs"]["init_timeout"] == 8.0
+
+
+def test_build_omits_init_timeout_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    rec: dict[str, Any] = {}
+    monkeypatch.setattr(registry_mod, "_load_mcp_classes", lambda: _spy_mcp_classes(rec))
+    cfg = MCPServerConfig(name="x", transport="http", url="http://x/mcp")
+    build_mcp_server(cfg)
+    assert "init_timeout" not in rec["kwargs"]
+
+
 # ── MCPRegistry ──────────────────────────────────────────────────────────
 
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -384,6 +384,14 @@ def test_build_forwards_init_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     assert rec["kwargs"]["init_timeout"] == 8.0
 
 
+def test_build_forwards_init_timeout_http(monkeypatch: pytest.MonkeyPatch) -> None:
+    rec: dict[str, Any] = {}
+    monkeypatch.setattr(registry_mod, "_load_mcp_classes", lambda: _spy_mcp_classes(rec))
+    cfg = MCPServerConfig(name="x", transport="http", url="http://x/mcp", init_timeout=8.0)
+    build_mcp_server(cfg)
+    assert rec["kwargs"]["init_timeout"] == 8.0
+
+
 def test_build_omits_init_timeout_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     rec: dict[str, Any] = {}
     monkeypatch.setattr(registry_mod, "_load_mcp_classes", lambda: _spy_mcp_classes(rec))


### PR DESCRIPTION
## Summary

Adds an optional `init_timeout` to `MCPServerConfig`, forwarded to `MCPToolset`
so servers that are slow to become ready don't fail their handshake.

pydantic-ai defaults the connect + `initialize` deadline to **5s**. A server
that does real work on startup (e.g. opening a database connection, ~8s) trips
this and fails with `"Failed to initialize server session"`. Re-wrapping a
pre-built toolset with a longer timeout isn't possible — `MCPToolset` rejects
`init_timeout` alongside a pre-built `fastmcp.Client`. Since `build_mcp_server`
always constructs the toolset from a transport/URL (never a pre-built client),
it can pass `init_timeout` cleanly through the official API.

Requested in #167.

## Changes

- **`pydantic_deep/mcp/config.py`** — new `MCPServerConfig.init_timeout: float | None`
  (default `None` = pydantic-ai's 5s). Validated as positive; round-trips through
  `to_dict`/`from_dict`, so the CLI persists it in `mcp.json`.
- **`pydantic_deep/mcp/registry.py`** — `build_mcp_server` forwards `init_timeout`
  to every `MCPToolset` construction (stdio, oauth, http/sse), but only when set,
  so an unset config keeps the upstream default.
- **`tests/test_mcp.py`** — default is `None`, round-trip, rejects non-positive
  values, and `init_timeout` is forwarded to `MCPToolset` when set / omitted when
  unset.

## Testing

- [x] `make test` — 2716 passed, **100% coverage** (branch)
- [x] `ruff format --check` + `ruff check` clean
- [x] `mypy pydantic_deep tests` clean; `pyright` 0 errors

## Related Issues

Refs #167
