### PR TITLE
fix: bump liteparse's lower bound to the first release containing the…

### DIFF
--- a/docs/advanced/liteparse.md
+++ b/docs/advanced/liteparse.md
@@ -57,14 +57,23 @@ You don't call these yourself — the agent does, when the task calls for it. As
 Parsing is powered by [LiteParse](https://github.com/run-llama/liteparse), a Node.js CLI that the Python wrapper drives via subprocess. So you need three things:
 
 - **Node.js >= 18** on the system.
-- **The LiteParse CLI** — `npm install -g @llamaindex/liteparse`.
+- **The LiteParse CLI** — `npm install -g @llamaindex/liteparse@^1.2.0`.
 - **The Python extra** — `pip install pydantic-deep[liteparse]`.
+
+!!! warning "Pin the CLI to the 1.x line"
+    The `2.x` CLI (and the matching Python `2.x` package) dropped the async API
+    the toolset drives, so a 2.x install silently degrades to `"Parse error"`
+    fallbacks. Pin both to `1.x`: the extra resolves the Python package to
+    `>=1.1.0,<2.0.0`, and you should install the CLI with an explicit
+    `@^1.2.0` (or any `1.x`). Don't rely on plain
+    `npm install -g @llamaindex/liteparse` — it pulls `latest` (2.x).
 
 !!! tip "First run auto-installs the CLI"
     If the CLI is missing but `npm` is on the `PATH`, LiteParse installs it for
-    you on first use (`install_if_not_available=True`, the default). Handy
-    locally, but for Docker and production, pre-install it in your image so the
-    first request isn't waiting on `npm`.
+    you on first use (`install_if_not_available=True`, the default). It installs
+    the **unpinned** `latest`, though — so pre-install a `1.x` CLI yourself
+    (locally and especially in Docker/production) rather than letting the first
+    request pull a 2.x that breaks parsing.
 
 ### Docker
 
@@ -76,8 +85,8 @@ RUN apt-get update && apt-get install -y curl && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs
 
-# LiteParse CLI, pre-installed so the first request is fast
-RUN npm install -g @llamaindex/liteparse
+# LiteParse CLI (1.x — 2.x dropped the async API), pre-installed so the first request is fast
+RUN npm install -g @llamaindex/liteparse@^1.2.0
 
 COPY . .
 RUN pip install pydantic-deep[liteparse]
@@ -142,7 +151,7 @@ The LiteParse repo ships [reference OCR servers](https://github.com/run-llama/li
 
 - `include_liteparse=True` hands your agent `parse_document` and `screenshot_document` — local document parsing, no cloud.
 - `parse_document` extracts text (with OCR) from PDF, DOCX, XLSX, PPTX, ODF, and images; `screenshot_document` renders PDFs and images to PNGs in the backend.
-- It needs Node.js >= 18, the `@llamaindex/liteparse` CLI, and the `pydantic-deep[liteparse]` extra — pre-install the CLI in Docker.
+- It needs Node.js >= 18, the `@llamaindex/liteparse@^1.2.0` CLI (1.x — 2.x dropped the async API), and the `pydantic-deep[liteparse]` extra — pre-install the CLI in Docker.
 - For OCR language, DPI, or a custom OCR server, build [`LiteparseToolset`][pydantic_deep.LiteparseToolset] directly instead of the flag.
 
 Where to go next:

--- a/docs/advanced/liteparse.md
+++ b/docs/advanced/liteparse.md
@@ -65,7 +65,7 @@ Parsing is powered by [LiteParse](https://github.com/run-llama/liteparse), a Nod
     the toolset drives, so a 2.x install silently degrades to `"Parse error"`
     fallbacks. Pin both to `1.x`: the extra resolves the Python package to
     `>=1.1.0,<2.0.0`, and you should install the CLI with an explicit
-    `@^1.2.0` (or any `1.x`). Don't rely on plain
+    `@^1.2.0`. Don't rely on plain
     `npm install -g @llamaindex/liteparse` — it pulls `latest` (2.x).
 
 !!! tip "First run auto-installs the CLI"

--- a/pydantic_deep/features/liteparse/toolset.py
+++ b/pydantic_deep/features/liteparse/toolset.py
@@ -5,7 +5,8 @@ LiteParse Node.js CLI via the `liteparse` Python package.
 
 Requirements:
     - Node.js >= 18 installed on the system
-    - LiteParse CLI: `npm install -g @llamaindex/liteparse`
+    - LiteParse CLI: `npm install -g @llamaindex/liteparse@^1.2.0`
+      (pin to 1.x — the 2.x CLI dropped the async API this toolset uses)
     - Python package: `pip install pydantic-deep[liteparse]`
 """
 
@@ -60,7 +61,7 @@ for _cli_err_module in ("liteparse", "liteparse.types"):
 _NOT_INSTALLED_MSG = (
     "LiteParse is not installed. "
     "Run: pip install pydantic-deep[liteparse] "
-    "and npm install -g @llamaindex/liteparse"
+    "and npm install -g @llamaindex/liteparse@^1.2.0"
 )
 
 PARSE_DOCUMENT_DESCRIPTION = """\
@@ -91,7 +92,9 @@ class LiteparseToolset(FunctionToolset[Any]):
 
     Requirements:
         - Node.js >= 18 on the system
-        - LiteParse CLI (auto-installed via npm on first use if `install_if_not_available=True`)
+        - LiteParse CLI: `npm install -g @llamaindex/liteparse@^1.2.0` — pre-install a 1.x
+          version; the auto-install on first use (`install_if_not_available=True`) pulls the
+          unpinned `latest`, which is an incompatible 2.x
         - `pip install pydantic-deep[liteparse]`
 
     Tools:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,8 +91,9 @@ browser = [
 # MCP (Model Context Protocol) client support — connect to MCP servers.
 # py-key-value-aio[disk] persists OAuth tokens (e.g. hosted Figma) across runs.
 mcp = ["pydantic-ai-slim[mcp]>=2.0.0", "py-key-value-aio[disk]>=0.4.5"]
-# Document parsing via LiteParse (requires Node.js >= 18)
-liteparse = ["liteparse>=1.1.0"]
+# Document parsing via LiteParse (requires Node.js >= 18).
+# Upper bound: 2.x dropped the async API (parse_async/screenshot_async) the toolset uses.
+liteparse = ["liteparse>=1.1.0,<2.0.0"]
 # ACP (Agent Client Protocol) support for editor integration
 acp = ["agent-client-protocol>=0.8.0"]
 # Logfire tracing support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ browser = [
 # py-key-value-aio[disk] persists OAuth tokens (e.g. hosted Figma) across runs.
 mcp = ["pydantic-ai-slim[mcp]>=2.0.0", "py-key-value-aio[disk]>=0.4.5"]
 # Document parsing via LiteParse (requires Node.js >= 18)
-liteparse = ["liteparse>=0.1.0"]
+liteparse = ["liteparse>=1.1.0"]
 # ACP (Agent Client Protocol) support for editor integration
 acp = ["agent-client-protocol>=0.8.0"]
 # Logfire tracing support


### PR DESCRIPTION
## Changes

### Summary

Bump the lower bound of the optional `liteparse` dependency from `>=0.1.0` to `>=1.1.0` — the first published release that contains the async API (`parse_async` / `screenshot_async`) that the LiteParse toolset calls.

### Business Context

Fixes #172. The report claimed the async functions weren't in any release; in fact they've shipped since liteparse `1.1.0`. The real defect is the constraint `liteparse>=0.1.0`, which references a nonexistent version and permits installing `1.0.0` — the last release *without* the async API. On `1.0.0`, `parser.parse_async(...)` raises `AttributeError`, gets swallowed by the toolset's generic `except Exception`, and surfaces as `"Parse error: ..."`, so parsing silently falls back to other methods.

### Changes

- `pyproject.toml`: `liteparse` extra pinned to `>=1.1.0`.

### Verification

Confirmed the async API's presence by inspecting the published PyPI wheels:

| liteparse | `parse_async` / `screenshot_async` |
|-----------|-----------------------------------|
| 1.0.0     | absent |
| 1.1.0+    | present |

Toolset tests pass against the resolved version (1.2.1):

​```
$ uv run pytest tests/test_liteparse.py -q
........................                                                 [100%]
24 passed, 2 warnings in 0.27s
​```

### Linked Issues

Closes #172