### PR TITLE
feat(cli): support OpenAI-compatible local endpoints

### DIFF
--- a/apps/cli/agent.py
+++ b/apps/cli/agent.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic_ai_backends import LocalBackend
 
 from apps.cli.config import CliConfig, load_config
-from apps.cli.providers import OPENAI_COMPATIBLE_PREFIX
+from apps.cli.providers import OPENAI_COMPATIBLE_API_KEY_ENV, OPENAI_COMPATIBLE_PREFIX
 from apps.cli.reminder import _build_reminder_config
 from pydantic_deep.agent import create_deep_agent
 from pydantic_deep.deps import DeepAgentDeps
@@ -17,6 +18,9 @@ from pydantic_deep.features.forking.capability import LiveForkCapability
 from pydantic_deep.features.hooks import Hook, HookEvent, HookInput, HookResult
 from pydantic_deep.features.message_queue import MessageQueue
 from pydantic_deep.prompts import build_system_prompt
+
+if TYPE_CHECKING:
+    from pydantic_ai.models.openai import OpenAIChatModel
 
 
 def _detect_fork_test_command(backend: Any) -> str | None:
@@ -110,13 +114,15 @@ def _make_shell_allow_list_hook(allow_list: list[str]) -> Hook:
     )
 
 
-def _resolve_openai_compatible_model(model_str: str, config: CliConfig) -> Any:
+def _resolve_openai_compatible_model(model_str: str, config: CliConfig) -> OpenAIChatModel:
     """Turn an `openai-compatible:<name>` model string into an `OpenAIChatModel`.
 
     Local servers (llama.cpp, LM Studio, vLLM, …) speak the OpenAI wire format but
     need a `base_url`, which a plain model string can't carry — so the CLI stores
-    the URL in `config.base_url` and marks the model with a sentinel prefix. Most
-    local servers ignore the API key, so a noop stand-in is used when none is set.
+    the URL in `config.base_url` and marks the model with a sentinel prefix. The
+    API key comes from the keystore (`OPENAI_COMPATIBLE_API_KEY`), never from
+    `config.toml`; most local servers ignore it, so a noop stand-in is used when
+    none is set.
     """
     from pydantic_ai.models.openai import OpenAIChatModel
     from pydantic_ai.providers.openai import OpenAIProvider
@@ -127,7 +133,8 @@ def _resolve_openai_compatible_model(model_str: str, config: CliConfig) -> Any:
             "Run /provider, pick OpenAI-compatible, and enter the server URL."
         )
     name = model_str[len(OPENAI_COMPATIBLE_PREFIX) :] or "local-model"
-    provider = OpenAIProvider(base_url=config.base_url, api_key=config.local_api_key or "sk-noop")
+    api_key = os.environ.get(OPENAI_COMPATIBLE_API_KEY_ENV) or "sk-noop"
+    provider = OpenAIProvider(base_url=config.base_url, api_key=api_key)
     return OpenAIChatModel(name, provider=provider)
 
 
@@ -468,7 +475,7 @@ def create_cli_agent(  # noqa: C901
         except Exception:
             mcp_servers = []
 
-    model_for_agent: Any = effective_model
+    model_for_agent: str | OpenAIChatModel = effective_model
     if isinstance(effective_model, str) and effective_model.startswith(OPENAI_COMPATIBLE_PREFIX):
         model_for_agent = _resolve_openai_compatible_model(effective_model, config)
 
@@ -542,10 +549,10 @@ def create_cli_agent(  # noqa: C901
             reminder_mode,
             config,
             on_reminder,
-            # Inherit the runtime model, not config.model (the TOML default,
-            # which may be a different provider than `-m` — e.g. Anthropic while
-            # running on Vertex, which then crashes with no ANTHROPIC_API_KEY).
-            reminder_model or config.reminder_model or effective_model,
+            # Inherit the resolved runtime model, not config.model (a different
+            # provider than `-m` would crash on a missing key; the raw
+            # `openai-compatible:...` string would break the LLM reminder generator).
+            reminder_model or config.reminder_model or model_for_agent,
         ),
     )
 

--- a/apps/cli/agent.py
+++ b/apps/cli/agent.py
@@ -8,7 +8,8 @@ from typing import Any, Literal
 
 from pydantic_ai_backends import LocalBackend
 
-from apps.cli.config import load_config
+from apps.cli.config import CliConfig, load_config
+from apps.cli.providers import OPENAI_COMPATIBLE_PREFIX
 from apps.cli.reminder import _build_reminder_config
 from pydantic_deep.agent import create_deep_agent
 from pydantic_deep.deps import DeepAgentDeps
@@ -107,6 +108,27 @@ def _make_shell_allow_list_hook(allow_list: list[str]) -> Hook:
         handler=_check_command,
         matcher=r"^execute$",
     )
+
+
+def _resolve_openai_compatible_model(model_str: str, config: CliConfig) -> Any:
+    """Turn an `openai-compatible:<name>` model string into an `OpenAIChatModel`.
+
+    Local servers (llama.cpp, LM Studio, vLLM, …) speak the OpenAI wire format but
+    need a `base_url`, which a plain model string can't carry — so the CLI stores
+    the URL in `config.base_url` and marks the model with a sentinel prefix. Most
+    local servers ignore the API key, so a noop stand-in is used when none is set.
+    """
+    from pydantic_ai.models.openai import OpenAIChatModel
+    from pydantic_ai.providers.openai import OpenAIProvider
+
+    if not config.base_url:
+        raise ValueError(
+            "No base_url configured for the OpenAI-compatible endpoint. "
+            "Run /provider, pick OpenAI-compatible, and enter the server URL."
+        )
+    name = model_str[len(OPENAI_COMPATIBLE_PREFIX) :] or "local-model"
+    provider = OpenAIProvider(base_url=config.base_url, api_key=config.local_api_key or "sk-noop")
+    return OpenAIChatModel(name, provider=provider)
 
 
 def create_cli_agent(  # noqa: C901
@@ -446,8 +468,12 @@ def create_cli_agent(  # noqa: C901
         except Exception:
             mcp_servers = []
 
+    model_for_agent: Any = effective_model
+    if isinstance(effective_model, str) and effective_model.startswith(OPENAI_COMPATIBLE_PREFIX):
+        model_for_agent = _resolve_openai_compatible_model(effective_model, config)
+
     agent = create_deep_agent(
-        model=effective_model,
+        model=model_for_agent,
         fallback_model=fallback_model or config.fallback_model or None,
         instructions=instructions,
         backend=effective_backend,

--- a/apps/cli/agent.py
+++ b/apps/cli/agent.py
@@ -2,15 +2,14 @@
 
 from __future__ import annotations
 
-import os
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic_ai_backends import LocalBackend
 
-from apps.cli.config import CliConfig, load_config
-from apps.cli.providers import OPENAI_COMPATIBLE_API_KEY_ENV, OPENAI_COMPATIBLE_PREFIX
+from apps.cli.config import load_config
+from apps.cli.model_resolve import resolve_cli_model
 from apps.cli.reminder import _build_reminder_config
 from pydantic_deep.agent import create_deep_agent
 from pydantic_deep.deps import DeepAgentDeps
@@ -20,7 +19,7 @@ from pydantic_deep.features.message_queue import MessageQueue
 from pydantic_deep.prompts import build_system_prompt
 
 if TYPE_CHECKING:
-    from pydantic_ai.models.openai import OpenAIChatModel
+    from pydantic_ai.models import Model
 
 
 def _detect_fork_test_command(backend: Any) -> str | None:
@@ -114,33 +113,9 @@ def _make_shell_allow_list_hook(allow_list: list[str]) -> Hook:
     )
 
 
-def _resolve_openai_compatible_model(model_str: str, config: CliConfig) -> OpenAIChatModel:
-    """Turn an `openai-compatible:<name>` model string into an `OpenAIChatModel`.
-
-    Local servers (llama.cpp, LM Studio, vLLM, …) speak the OpenAI wire format but
-    need a `base_url`, which a plain model string can't carry — so the CLI stores
-    the URL in `config.base_url` and marks the model with a sentinel prefix. The
-    API key comes from the keystore (`OPENAI_COMPATIBLE_API_KEY`), never from
-    `config.toml`; most local servers ignore it, so a noop stand-in is used when
-    none is set.
-    """
-    from pydantic_ai.models.openai import OpenAIChatModel
-    from pydantic_ai.providers.openai import OpenAIProvider
-
-    if not config.base_url:
-        raise ValueError(
-            "No base_url configured for the OpenAI-compatible endpoint. "
-            "Run /provider, pick OpenAI-compatible, and enter the server URL."
-        )
-    name = model_str[len(OPENAI_COMPATIBLE_PREFIX) :] or "local-model"
-    api_key = os.environ.get(OPENAI_COMPATIBLE_API_KEY_ENV) or "sk-noop"
-    provider = OpenAIProvider(base_url=config.base_url, api_key=api_key)
-    return OpenAIChatModel(name, provider=provider)
-
-
 def create_cli_agent(  # noqa: C901
-    model: str | None = None,
-    fallback_model: str | None = None,
+    model: str | Model | None = None,
+    fallback_model: str | Model | None = None,
     working_dir: str | None = None,
     shell_allow_list: list[str] | None = None,
     on_cost_update: Any | None = None,
@@ -475,13 +450,16 @@ def create_cli_agent(  # noqa: C901
         except Exception:
             mcp_servers = []
 
-    model_for_agent: str | OpenAIChatModel = effective_model
-    if isinstance(effective_model, str) and effective_model.startswith(OPENAI_COMPATIBLE_PREFIX):
-        model_for_agent = _resolve_openai_compatible_model(effective_model, config)
+    # Both go through the resolver: the `openai-compatible:` sentinel is a CLI
+    # concept pydantic-ai can't infer, and a local endpoint is as valid a
+    # fallback as it is a primary.
+    model_for_agent = resolve_cli_model(effective_model, config)
+    raw_fallback = fallback_model or config.fallback_model or None
+    fallback_for_agent = resolve_cli_model(raw_fallback, config) if raw_fallback else None
 
     agent = create_deep_agent(
         model=model_for_agent,
-        fallback_model=fallback_model or config.fallback_model or None,
+        fallback_model=fallback_for_agent,
         instructions=instructions,
         backend=effective_backend,
         skill_directories=skill_dirs if effective_skills else None,

--- a/apps/cli/app.py
+++ b/apps/cli/app.py
@@ -405,6 +405,13 @@ class DeepApp(App):
         """If the current model's provider key isn't set, pick one that is."""
         from apps.cli.providers import PROVIDERS
 
+        # Keyless providers (Ollama, OpenAI-compatible) are a deliberate local
+        # choice with no key to check — keep them, and before the keyed loop so
+        # "openai-compatible:…" isn't caught by the "openai" prefix.
+        for p in PROVIDERS:
+            if not p.env_var and current.startswith(p.id):
+                return current
+
         # Keyed providers only — a model name starts with its provider id.
         keyed = [p for p in PROVIDERS if p.env_var]
 

--- a/apps/cli/commands.py
+++ b/apps/cli/commands.py
@@ -764,13 +764,26 @@ async def _cmd_help(app: DeepApp, arg: str) -> None:
 
 async def _cmd_provider(app: DeepApp, arg: str) -> None:
     from apps.cli.providers import PROVIDER_DEFAULT_MODELS as _PROVIDER_DEFAULT_MODELS
-    from apps.cli.screens.onboarding import _PROVIDERS, ApiKeyModal, ProviderPickerModal
+    from apps.cli.screens.onboarding import (
+        _PROVIDERS,
+        ApiKeyModal,
+        LocalEndpointModal,
+        ProviderPickerModal,
+    )
 
     async def _handle_provider(provider_id: str | None) -> None:
         if provider_id is None:
             return
         if provider_id == "ollama":
             app.reconfigure_agent(model="ollama:llama3.3")
+            return
+        if provider_id == "openai-compatible":
+
+            async def _handle_endpoint(model: str | None) -> None:
+                if model:
+                    app.reconfigure_agent(model=model)
+
+            app.push_screen(LocalEndpointModal(), _handle_endpoint)
             return
         for pid, name, env_var, url in _PROVIDERS:
             if pid == provider_id:

--- a/apps/cli/commands.py
+++ b/apps/cli/commands.py
@@ -676,18 +676,22 @@ async def _cmd_improve(app: DeepApp, arg: str) -> None:  # noqa: C901
             from apps.cli.config import get_sessions_dir
             from apps.cli.keystore import load_keys
             from apps.cli.modals.improve_review import ImproveReviewModal
+            from apps.cli.model_resolve import resolve_cli_model
             from pydantic_deep.features.improve.analyzer import ImprovementAnalyzer
 
             # Ensure API keys are available (improve creates its own agents)
             load_keys()
 
             # Use the same model as the current agent
-            model = app.model_name
-            if not model or model in ("test", "preview"):
+            model_str = app.model_name
+            if not model_str or model_str in ("test", "preview"):
                 from apps.cli.config import load_config
                 from pydantic_deep.models import DEFAULT_IMPROVE_MODEL
 
-                model = load_config().model or DEFAULT_IMPROVE_MODEL
+                model_str = load_config().model or DEFAULT_IMPROVE_MODEL
+            # `app.model_name` is the raw CLI string and may carry the
+            # local-endpoint sentinel, which pydantic-ai can't infer.
+            model = resolve_cli_model(model_str)
 
             def _on_progress(stage: str, current: int, total: int) -> None:
                 if stage == "discovering":
@@ -702,7 +706,7 @@ async def _cmd_improve(app: DeepApp, arg: str) -> None:  # noqa: C901
                 elif stage == "done":
                     pass  # Report will be shown in modal
 
-            log.info("Improve starting", model=model, days=days)
+            log.info("Improve starting", model=model_str, days=days)
             analyzer = ImprovementAnalyzer(
                 model=model,
                 sessions_dir=get_sessions_dir(),

--- a/apps/cli/config.py
+++ b/apps/cli/config.py
@@ -120,6 +120,12 @@ class CliConfig:
     """CLI configuration loaded from config.toml."""
 
     model: str = DEFAULT_MODEL
+    base_url: str = ""
+    """Base URL for an OpenAI-compatible local endpoint (llama.cpp / LM Studio /
+    vLLM). Only consulted when `model` carries the `openai-compatible:` prefix."""
+    local_api_key: str = ""
+    """API key for the local OpenAI-compatible endpoint. Most local servers ignore
+    it, so a noop key is substituted when this is empty."""
     working_dir: str | None = None
     shell_allow_list: list[str] = field(default_factory=list)
     theme: str = "default"

--- a/apps/cli/config.py
+++ b/apps/cli/config.py
@@ -123,9 +123,6 @@ class CliConfig:
     base_url: str = ""
     """Base URL for an OpenAI-compatible local endpoint (llama.cpp / LM Studio /
     vLLM). Only consulted when `model` carries the `openai-compatible:` prefix."""
-    local_api_key: str = ""
-    """API key for the local OpenAI-compatible endpoint. Most local servers ignore
-    it, so a noop key is substituted when this is empty."""
     working_dir: str | None = None
     shell_allow_list: list[str] = field(default_factory=list)
     theme: str = "default"

--- a/apps/cli/credentials.py
+++ b/apps/cli/credentials.py
@@ -144,6 +144,16 @@ CREDENTIALS: tuple[Credential, ...] = (
         "https://www.heroku.com/",
         provider_id="heroku",
     ),
+    # Deliberately no `provider_id`: this credential is optional (most local
+    # servers ignore it) and the provider needs a base URL, not a key, so it
+    # must not appear in the key-first onboarding list built by
+    # `onboarding_cli._provider_credentials`. It is listed here so `keys list`,
+    # `keys set` and `/keys` can see and change what `/provider` wrote.
+    Credential(
+        "OPENAI_COMPATIBLE_API_KEY",
+        "OpenAI-compatible endpoint (local)",
+        "Model providers",
+    ),
     # ── Vertex AI (Gemini via Google Cloud) ────────────────────────────
     Credential(
         "GOOGLE_GENAI_USE_VERTEXAI", "Use Vertex AI (true/false)", "Vertex AI", secret=False

--- a/apps/cli/goal.py
+++ b/apps/cli/goal.py
@@ -46,9 +46,16 @@ def get_goal_evaluator(app: DeepApp) -> GoalEvaluator:
         # Fall back to the main session model so an OpenRouter/Ollama/etc. user
         # isn't silently routed to a direct Anthropic model they have no key for
         # (mirrors `_resolve_reminder_model`). Otherwise every evaluation fails
-        # with "Evaluator error; continuing." and the goal never completes.
+        # with "Evaluator error; continuing." and the goal never completes — as
+        # it also would if the raw `openai-compatible:` sentinel reached
+        # pydantic-ai, hence the resolve step.
+        from apps.cli.model_resolve import resolve_cli_model
+
         model = model or getattr(app, "model_name", None) or getattr(app, "_model", None)
-        app._goal_evaluator = GoalEvaluator(model=model) if model else GoalEvaluator()
+        if model:
+            app._goal_evaluator = GoalEvaluator(model=resolve_cli_model(model))
+        else:
+            app._goal_evaluator = GoalEvaluator()
     return app._goal_evaluator
 
 

--- a/apps/cli/model_resolve.py
+++ b/apps/cli/model_resolve.py
@@ -1,0 +1,75 @@
+"""Turn a CLI model string into something pydantic-ai accepts.
+
+Almost every model string the CLI carries is a plain pydantic-ai identifier that
+`infer_model()` understands. One is not: `openai-compatible:<name>` is a
+CLI-only sentinel for a local OpenAI-wire-format server (llama.cpp, LM Studio,
+vLLM, …) whose endpoint URL can't fit in a model string and lives in
+`config.base_url` instead. Handing that sentinel straight to pydantic-ai raises
+`ValueError: Unknown provider: openai-compatible`.
+
+So every place that turns the CLI's model string into a pydantic-ai model goes
+through :func:`resolve_cli_model` — the agent factory, the reminder generator,
+the goal evaluator and `/improve`. Keeping the knowledge here rather than at
+each call site is the point: a new consumer that forgets the prefix is a bug
+that only shows up for local-endpoint users.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from apps.cli.config import CliConfig, load_config
+from apps.cli.providers import OPENAI_COMPATIBLE_API_KEY_ENV, OPENAI_COMPATIBLE_PREFIX
+
+if TYPE_CHECKING:
+    from pydantic_ai.models import Model
+    from pydantic_ai.models.openai import OpenAIChatModel
+
+#: Stand-in key for endpoints that don't check one. `OpenAIProvider` requires
+#: *some* key and would otherwise fall back to `OPENAI_API_KEY` — which must
+#: never be sent to an arbitrary local or self-hosted endpoint.
+_NOOP_API_KEY = "sk-noop"
+
+
+def resolve_openai_compatible_model(model_str: str, config: CliConfig) -> OpenAIChatModel:
+    """Build an `OpenAIChatModel` for an `openai-compatible:<name>` model string.
+
+    The name after the prefix is the model served by the endpoint; the endpoint
+    URL comes from `config.base_url`. The API key comes from the keystore
+    (`OPENAI_COMPATIBLE_API_KEY`), never from `config.toml`; most local servers
+    ignore it, so a noop stand-in is used when none is set.
+
+    Raises:
+        ValueError: If no `base_url` is configured.
+    """
+    from pydantic_ai.models.openai import OpenAIChatModel
+    from pydantic_ai.providers.openai import OpenAIProvider
+
+    if not config.base_url:
+        raise ValueError(
+            "No base_url configured for the OpenAI-compatible endpoint. "
+            "Run /provider, pick OpenAI-compatible, and enter the server URL."
+        )
+    name = model_str[len(OPENAI_COMPATIBLE_PREFIX) :] or "local-model"
+    api_key = os.environ.get(OPENAI_COMPATIBLE_API_KEY_ENV) or _NOOP_API_KEY
+    provider = OpenAIProvider(base_url=config.base_url, api_key=api_key)
+    return OpenAIChatModel(name, provider=provider)
+
+
+def resolve_cli_model(model: str | Model, config: CliConfig | None = None) -> str | Model:
+    """Return `model` unchanged, or a `Model` instance for the local-endpoint sentinel.
+
+    Args:
+        model: A CLI model string, or an already-built `Model` (which callers
+            pass around once one link in the chain has resolved it) — those are
+            returned untouched.
+        config: Config to read `base_url` from. Loaded on demand when omitted,
+            so callers that don't already hold a config don't have to build one.
+    """
+    if not isinstance(model, str) or not model.startswith(OPENAI_COMPATIBLE_PREFIX):
+        return model
+    return resolve_openai_compatible_model(model, config if config is not None else load_config())
+
+
+__all__ = ["resolve_cli_model", "resolve_openai_compatible_model"]

--- a/apps/cli/providers.py
+++ b/apps/cli/providers.py
@@ -60,7 +60,18 @@ PROVIDERS: tuple[ProviderInfo, ...] = (
         "google-gla:gemini-2.5-pro",
     ),
     ProviderInfo("ollama", "Ollama (local, free)", "", "", "ollama:llama3.3"),
+    ProviderInfo(
+        "openai-compatible",
+        "OpenAI-compatible (local: llama.cpp / LM Studio / vLLM)",
+        "",
+        "",
+        "openai-compatible:local-model",
+    ),
 )
+
+#: Model-string prefix marking an OpenAI-compatible local endpoint. The part
+#: after the prefix is the model name; the endpoint URL lives in `config.base_url`.
+OPENAI_COMPATIBLE_PREFIX = "openai-compatible:"
 
 #: Provider id → default model, derived from :data:`PROVIDERS`.
 PROVIDER_DEFAULT_MODELS: dict[str, str] = {p.id: p.default_model for p in PROVIDERS}

--- a/apps/cli/providers.py
+++ b/apps/cli/providers.py
@@ -73,5 +73,8 @@ PROVIDERS: tuple[ProviderInfo, ...] = (
 #: after the prefix is the model name; the endpoint URL lives in `config.base_url`.
 OPENAI_COMPATIBLE_PREFIX = "openai-compatible:"
 
+#: Keystore key for the OpenAI-compatible endpoint's API key (kept out of config.toml).
+OPENAI_COMPATIBLE_API_KEY_ENV = "OPENAI_COMPATIBLE_API_KEY"
+
 #: Provider id → default model, derived from :data:`PROVIDERS`.
 PROVIDER_DEFAULT_MODELS: dict[str, str] = {p.id: p.default_model for p in PROVIDERS}

--- a/apps/cli/reminder.py
+++ b/apps/cli/reminder.py
@@ -6,6 +6,8 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
+    from pydantic_ai.models import Model
+
     from apps.cli.app import DeepApp
 
 _REMINDER_LABELS: dict[str, str] = {
@@ -21,7 +23,7 @@ def _build_reminder_config(
     reminder_mode: Literal["off", "first", "context", "llm"] | None,
     config: Any,
     on_reminder: Callable[[int, str], None] | None = None,
-    reminder_model: str | None = None,
+    reminder_model: str | Model | None = None,
 ) -> Any:
     """Build a PeriodicReminderConfig (or None) from CLI/config args."""
     enabled = periodic_reminder if periodic_reminder is not None else config.periodic_reminder

--- a/apps/cli/reminder.py
+++ b/apps/cli/reminder.py
@@ -39,26 +39,34 @@ def _build_reminder_config(
 
     cfg = make_config_for_mode(mode)
     if mode == "llm":
+        from apps.cli.model_resolve import resolve_cli_model
+
         model = reminder_model or getattr(config, "reminder_model", None) or config.model
-        cfg.generator = LLMReminderGenerator(model=model)
+        # Already-resolved models pass straight through; a raw `config.model`
+        # may still carry the local-endpoint sentinel.
+        cfg.generator = LLMReminderGenerator(model=resolve_cli_model(model, config))
     cfg.on_reminder = on_reminder
     return cfg
 
 
-def _resolve_reminder_model(app: DeepApp) -> str | None:
+def _resolve_reminder_model(app: DeepApp) -> str | Model | None:
     """Resolve the LLM reminder model: configured `reminder_model` or main model.
 
     Mirrors :func:`_build_reminder_config` so live-switching to `"llm"` mode
     uses the same model as the startup configuration instead of the generator
-    default.
+    default — including the resolution step, since `app.model_name` holds the
+    raw CLI string and may carry the local-endpoint sentinel prefix.
     """
+    from apps.cli.model_resolve import resolve_cli_model
+
     try:
         from apps.cli.config import load_config
 
         reminder_model = load_config().reminder_model
     except Exception:  # pragma: no cover - defensive: bad config shouldn't break switching
         reminder_model = None
-    return reminder_model or getattr(app, "model_name", None) or getattr(app, "_model", None)
+    model = reminder_model or getattr(app, "model_name", None) or getattr(app, "_model", None)
+    return resolve_cli_model(model) if model else None
 
 
 def _apply_reminder_mode(app: DeepApp, mode: str) -> None:

--- a/apps/cli/screens/onboarding.py
+++ b/apps/cli/screens/onboarding.py
@@ -30,7 +30,11 @@ def _check_provider_status() -> list[tuple[str, str, str, bool]]:
 
     result: list[tuple[str, str, str, bool]] = []
     for provider_id, name, env_var, _url in _PROVIDERS:
-        has_key = bool(os.environ.get(env_var)) if env_var else provider_id == "ollama"
+        has_key = (
+            bool(os.environ.get(env_var))
+            if env_var
+            else provider_id in ("ollama", "openai-compatible")
+        )
         result.append((provider_id, name, env_var, has_key))
     return result
 
@@ -172,6 +176,82 @@ class ApiKeyModal(ModalScreen[str | None]):
 
     def on_input_submitted(self, _event: Input.Submitted) -> None:
         self._save_and_dismiss()
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
+class LocalEndpointModal(ModalScreen[str | None]):
+    """Configure an OpenAI-compatible local endpoint (llama.cpp / LM Studio / vLLM).
+
+    Persists the base URL, optional model name and optional API key to the config
+    file, then dismisses with the `openai-compatible:<name>` model string so the
+    caller can reconfigure the agent.
+    """
+
+    DEFAULT_CSS = """
+    LocalEndpointModal {
+        align: center middle;
+    }
+    LocalEndpointModal > #local-container {
+        width: 72;
+        height: auto;
+        border: tall $primary;
+        background: $surface;
+        padding: 1 2;
+    }
+    LocalEndpointModal > #local-container > Input {
+        margin: 1 0;
+    }
+    LocalEndpointModal > #local-container > #local-actions {
+        margin: 1 0 0 0;
+    }
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="local-container"):
+            yield Static("[bold]Configure OpenAI-compatible endpoint[/bold]\n")
+            yield Static("Base URL (required):")
+            yield Input(placeholder="http://localhost:8080/v1", id="local-url")
+            yield Static("Model name:")
+            yield Input(placeholder="local-model", id="local-model")
+            yield Static("API key (optional — most local servers ignore it):")
+            yield Input(placeholder="leave blank if unused", password=True, id="local-key")
+            yield Static(
+                "\n[dim]Saved to .pydantic-deep/config.toml. Tool-calling & structured "
+                "output need a model served with a proper chat/tool template.[/dim]"
+            )
+            with Vertical(id="local-actions"):
+                yield Button("Connect", variant="primary", id="btn-connect")
+                yield Button("Cancel", variant="default", id="btn-cancel")
+
+    def on_mount(self) -> None:
+        self.query_one("#local-url", Input).focus()
+
+    def _save_and_dismiss(self) -> None:
+        from apps.cli.config import DEFAULT_CONFIG_PATH, set_config_value
+        from apps.cli.providers import OPENAI_COMPATIBLE_PREFIX
+
+        base_url = self.query_one("#local-url", Input).value.strip()
+        if not base_url:
+            self.app.notify("Please enter a base URL", severity="warning")
+            return
+        name = self.query_one("#local-model", Input).value.strip() or "local-model"
+        api_key = self.query_one("#local-key", Input).value.strip()
+
+        set_config_value(DEFAULT_CONFIG_PATH, "base_url", base_url)
+        set_config_value(DEFAULT_CONFIG_PATH, "local_api_key", api_key)
+        self.dismiss(f"{OPENAI_COMPATIBLE_PREFIX}{name}")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn-connect":
+            self._save_and_dismiss()
+        elif event.button.id == "btn-cancel":
+            self.dismiss(None)
 
     def action_cancel(self) -> None:
         self.dismiss(None)

--- a/apps/cli/screens/onboarding.py
+++ b/apps/cli/screens/onboarding.py
@@ -222,8 +222,9 @@ class LocalEndpointModal(ModalScreen[str | None]):
             yield Static("API key (optional — most local servers ignore it):")
             yield Input(placeholder="leave blank if unused", password=True, id="local-key")
             yield Static(
-                "\n[dim]Saved to .pydantic-deep/config.toml. Tool-calling & structured "
-                "output need a model served with a proper chat/tool template.[/dim]"
+                "\n[dim]URL saved to config.toml; the key goes to the keystore. "
+                "Tool-calling & structured output need a model served with a proper "
+                "chat/tool template.[/dim]"
             )
             with Vertical(id="local-actions"):
                 yield Button("Connect", variant="primary", id="btn-connect")
@@ -234,7 +235,7 @@ class LocalEndpointModal(ModalScreen[str | None]):
 
     def _save_and_dismiss(self) -> None:
         from apps.cli.config import DEFAULT_CONFIG_PATH, set_config_value
-        from apps.cli.providers import OPENAI_COMPATIBLE_PREFIX
+        from apps.cli.providers import OPENAI_COMPATIBLE_API_KEY_ENV, OPENAI_COMPATIBLE_PREFIX
 
         base_url = self.query_one("#local-url", Input).value.strip()
         if not base_url:
@@ -244,7 +245,9 @@ class LocalEndpointModal(ModalScreen[str | None]):
         api_key = self.query_one("#local-key", Input).value.strip()
 
         set_config_value(DEFAULT_CONFIG_PATH, "base_url", base_url)
-        set_config_value(DEFAULT_CONFIG_PATH, "local_api_key", api_key)
+        # Key is a secret — keystore, not config.toml (which lives in the project tree).
+        if api_key:
+            save_key(OPENAI_COMPATIBLE_API_KEY_ENV, api_key)
         self.dismiss(f"{OPENAI_COMPATIBLE_PREFIX}{name}")
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
@@ -252,6 +255,9 @@ class LocalEndpointModal(ModalScreen[str | None]):
             self._save_and_dismiss()
         elif event.button.id == "btn-cancel":
             self.dismiss(None)
+
+    def on_input_submitted(self, _event: Input.Submitted) -> None:
+        self._save_and_dismiss()
 
     def action_cancel(self) -> None:
         self.dismiss(None)

--- a/apps/cli/screens/onboarding.py
+++ b/apps/cli/screens/onboarding.py
@@ -30,11 +30,9 @@ def _check_provider_status() -> list[tuple[str, str, str, bool]]:
 
     result: list[tuple[str, str, str, bool]] = []
     for provider_id, name, env_var, _url in _PROVIDERS:
-        has_key = (
-            bool(os.environ.get(env_var))
-            if env_var
-            else provider_id in ("ollama", "openai-compatible")
-        )
+        # No env var means a keyless provider (Ollama, a local OpenAI-compatible
+        # endpoint): there is nothing to check, so it is always ready.
+        has_key = bool(os.environ.get(env_var)) if env_var else True
         result.append((provider_id, name, env_var, has_key))
     return result
 
@@ -240,6 +238,12 @@ class LocalEndpointModal(ModalScreen[str | None]):
         base_url = self.query_one("#local-url", Input).value.strip()
         if not base_url:
             self.app.notify("Please enter a base URL", severity="warning")
+            return
+        if not base_url.startswith(("http://", "https://")):
+            # A scheme-less URL (e.g. the `localhost:8080` a llama.cpp log prints)
+            # builds a provider fine and only fails on the first message, with an
+            # httpx protocol error that reads like an agent bug. Catch it here.
+            self.app.notify("Base URL must start with http:// or https://", severity="warning")
             return
         name = self.query_one("#local-model", Input).value.strip() or "local-model"
         api_key = self.query_one("#local-key", Input).value.strip()

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -49,7 +49,7 @@ Switch models, providers, themes, and feature toggles.
 | Command | What it does |
 | --- | --- |
 | `/model` | Change the active model (then optionally pick a fallback) |
-| `/provider` | Configure an AI provider and its API key |
+| `/provider` | Configure an AI provider and its API key (incl. Ollama and OpenAI-compatible local endpoints) |
 | `/settings` | Open settings — toggle features, model, theme |
 | `/theme [name]` | Switch color theme; with no name, lists the available themes |
 

--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -81,10 +81,9 @@ Two ways to run against a local model:
 ```toml
 model = "openai-compatible:qwen2.5"   # name after the prefix is the served model
 base_url = "http://localhost:8080/v1"
-local_api_key = ""                     # most local servers ignore it
 ```
 
-`base_url` is only consulted when `model` carries the `openai-compatible:` prefix, so switching to any other model via `/model` leaves it untouched.
+`base_url` is only consulted when `model` carries the `openai-compatible:` prefix, so switching to any other model via `/model` leaves it untouched. If the endpoint needs an API key (e.g. a remote LM Studio or a keyed vLLM deployment), it's stored in the keystore under `OPENAI_COMPATIBLE_API_KEY` — never in `config.toml` — so the project tree never carries the secret. Most local servers ignore the key, so you can leave it blank.
 
 !!! warning "Tool-calling needs a capable model"
     Deep agents lean on tool-calling and structured output. A local model only handles this well when it's served with a proper chat/tool template — small models without one will fail or loop. This is a model limitation, not a CLI one.

--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -71,6 +71,24 @@ fallback_model = "openrouter:anthropic/claude-haiku-4-5"
 
 `fallback_model` is used automatically when the primary model fails on a rate limit or 5xx. Set both from the `/model` picker.
 
+#### Local models
+
+Two ways to run against a local model:
+
+- **Ollama** — pick it in `/provider`, or set a model string with the `ollama:` prefix (e.g. `model = "ollama:llama3.3"`). Ollama must be listening on its default `localhost:11434`.
+- **OpenAI-compatible servers** (llama.cpp / LM Studio / vLLM / text-generation-webui) — these expose an OpenAI-style HTTP endpoint but need a `base_url`, which a plain model string can't carry. Run `/provider`, choose **OpenAI-compatible**, and enter the server URL. The CLI stores it as:
+
+```toml
+model = "openai-compatible:qwen2.5"   # name after the prefix is the served model
+base_url = "http://localhost:8080/v1"
+local_api_key = ""                     # most local servers ignore it
+```
+
+`base_url` is only consulted when `model` carries the `openai-compatible:` prefix, so switching to any other model via `/model` leaves it untouched.
+
+!!! warning "Tool-calling needs a capable model"
+    Deep agents lean on tool-calling and structured output. A local model only handles this well when it's served with a proper chat/tool template — small models without one will fail or loop. This is a model limitation, not a CLI one.
+
 !!! info "Override per launch"
     `PYDANTIC_DEEP_MODEL`, `PYDANTIC_DEEP_THEME`, `PYDANTIC_DEEP_WORKING_DIR`,
     and `PYDANTIC_DEEP_CHARSET` override the file for a single run — handy for

--- a/docs/cli/settings.md
+++ b/docs/cli/settings.md
@@ -83,7 +83,9 @@ model = "openai-compatible:qwen2.5"   # name after the prefix is the served mode
 base_url = "http://localhost:8080/v1"
 ```
 
-`base_url` is only consulted when `model` carries the `openai-compatible:` prefix, so switching to any other model via `/model` leaves it untouched. If the endpoint needs an API key (e.g. a remote LM Studio or a keyed vLLM deployment), it's stored in the keystore under `OPENAI_COMPATIBLE_API_KEY` — never in `config.toml` — so the project tree never carries the secret. Most local servers ignore the key, so you can leave it blank.
+`base_url` is only consulted when `model` carries the `openai-compatible:` prefix, so switching to any other model via `/model` leaves it untouched. If the endpoint needs an API key (e.g. a remote LM Studio or a keyed vLLM deployment), it's stored in the keystore under `OPENAI_COMPATIBLE_API_KEY` — never in `config.toml` — so the project tree never carries the secret. Most local servers ignore the key, so you can leave it blank; when you do set one, it shows up in `/keys` and `pydantic-deep keys list` like any other credential. Your `OPENAI_API_KEY` is never sent to a local endpoint, even when it's set.
+
+The prefix is a CLI-level marker, not something pydantic-ai understands, so everything that spins up its own small model off the session model — the LLM reminder generator, the `/goal` evaluator, `/improve`, and a `fallback_model` — resolves it the same way. Pointing all of those at your local server is the default; nothing quietly falls back to a cloud model.
 
 !!! warning "Tool-calling needs a capable model"
     Deep agents lean on tool-calling and structured output. A local model only handles this well when it's served with a proper chat/tool template — small models without one will fail or loop. This is a model limitation, not a CLI one.

--- a/pydantic_deep/features/improve/analyzer.py
+++ b/pydantic_deep/features/improve/analyzer.py
@@ -13,13 +13,16 @@ import time
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic_deep.features.improve.extractor import SessionExtractor
 from pydantic_deep.features.improve.synthesizer import InsightSynthesizer
 from pydantic_deep.features.improve.types import ImprovementReport, ProposedChange, SessionInsights
 from pydantic_deep.features.memory import DEFAULT_MEMORY_DIR, get_memory_path
 from pydantic_deep.models import DEFAULT_IMPROVE_MODEL
+
+if TYPE_CHECKING:
+    from pydantic_ai.models import Model
 
 # Default MEMORY.md path, aligned with the memory toolset's default location
 # (`get_memory_path(DEFAULT_MEMORY_DIR, "main")`) so that improve writes
@@ -86,7 +89,7 @@ class ImprovementAnalyzer:
 
     def __init__(
         self,
-        model: str = DEFAULT_IMPROVE_MODEL,
+        model: str | Model = DEFAULT_IMPROVE_MODEL,
         sessions_dir: Path | None = None,
         working_dir: Path | None = None,
         on_progress: ProgressCallback | None = None,
@@ -95,7 +98,8 @@ class ImprovementAnalyzer:
         """Initialize the analyzer.
 
         Args:
-            model: Model identifier for extraction and synthesis agents.
+            model: Model identifier (or `Model` instance) for the
+                extraction and synthesis agents.
             sessions_dir: Directory containing session folders with messages.json.
                 Defaults to `~/.pydantic-deep/sessions`.
             working_dir: Working directory where context files live.

--- a/pydantic_deep/features/improve/extractor.py
+++ b/pydantic_deep/features/improve/extractor.py
@@ -9,12 +9,15 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic_ai import Agent
 
 from pydantic_deep.features.improve.prompts import CHUNK_MERGE_PROMPT, EXTRACTION_PROMPT
 from pydantic_deep.features.improve.types import SessionInsights
+
+if TYPE_CHECKING:
+    from pydantic_ai.models import Model
 
 DEFAULT_MAX_TOKENS_PER_CHUNK: int = 140_000
 """Default maximum tokens per chunk (leaves room for system prompt)."""
@@ -43,14 +46,14 @@ class SessionExtractor:
 
     def __init__(
         self,
-        model: str,
+        model: str | Model,
         max_tokens_per_chunk: int = DEFAULT_MAX_TOKENS_PER_CHUNK,
         overlap_messages: int = DEFAULT_OVERLAP_MESSAGES,
     ) -> None:
         """Initialize the extractor.
 
         Args:
-            model: Model identifier for the extraction agent
+            model: Model identifier (or `Model` instance) for the extraction agent
                 (e.g., `"openrouter:anthropic/claude-sonnet-4"`).
             max_tokens_per_chunk: Max estimated tokens per chunk.
             overlap_messages: Number of messages to overlap between chunks.

--- a/pydantic_deep/features/improve/synthesizer.py
+++ b/pydantic_deep/features/improve/synthesizer.py
@@ -7,7 +7,7 @@ and current context files into minimal, high-confidence proposed changes.
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 from pydantic_ai import Agent
@@ -15,6 +15,9 @@ from pydantic_ai import Agent
 from pydantic_deep.features.improve.prompts import SYNTHESIS_PROMPT
 from pydantic_deep.features.improve.types import ProposedChange, SessionInsights
 from pydantic_deep.models import DEFAULT_IMPROVE_MODEL
+
+if TYPE_CHECKING:
+    from pydantic_ai.models import Model
 
 MAX_TOOL_SEQUENCE_CHARS = 8000
 """Per-session cap on raw tool-sequence text in the synthesis prompt."""
@@ -33,11 +36,11 @@ class InsightSynthesizer:
     files and produces a list of proposed changes to context files.
     """
 
-    def __init__(self, model: str = DEFAULT_IMPROVE_MODEL) -> None:
+    def __init__(self, model: str | Model = DEFAULT_IMPROVE_MODEL) -> None:
         """Initialize the synthesizer.
 
         Args:
-            model: Model identifier for the synthesis agent.
+            model: Model identifier (or `Model` instance) for the synthesis agent.
         """
         self._model = model
 

--- a/pydantic_deep/features/improve/toolset.py
+++ b/pydantic_deep/features/improve/toolset.py
@@ -10,7 +10,7 @@ import contextlib
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic_ai import RunContext
 from pydantic_ai.toolsets import FunctionToolset
@@ -18,6 +18,9 @@ from pydantic_ai.toolsets import FunctionToolset
 from pydantic_deep.features.improve.analyzer import ImprovementAnalyzer
 from pydantic_deep.features.improve.types import ImprovementReport
 from pydantic_deep.models import DEFAULT_IMPROVE_MODEL
+
+if TYPE_CHECKING:
+    from pydantic_ai.models import Model
 
 # Tool description constants
 
@@ -147,7 +150,7 @@ class ImproveToolset(FunctionToolset[Any]):
         self,
         sessions_dir: Path | None = None,
         working_dir: Path | None = None,
-        model: str = DEFAULT_IMPROVE_MODEL,
+        model: str | Model = DEFAULT_IMPROVE_MODEL,
         context_files: dict[str, str] | None = None,
     ) -> None:
         """Initialize the improve toolset.
@@ -155,7 +158,8 @@ class ImproveToolset(FunctionToolset[Any]):
         Args:
             sessions_dir: Directory containing session folders with messages.json.
             working_dir: Working directory where context files live.
-            model: Model identifier for the extraction/synthesis agents.
+            model: Model identifier (or `Model` instance) for the
+                extraction/synthesis agents.
             context_files: Mapping of logical context file names to paths
                 relative to working_dir. See
                 :data:`~pydantic_deep.improve.analyzer.DEFAULT_CONTEXT_FILES`.

--- a/pydantic_deep/features/periodic_reminder/capability.py
+++ b/pydantic_deep/features/periodic_reminder/capability.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field, replace
-from typing import Any, Literal, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.capabilities import AbstractCapability
@@ -34,6 +34,9 @@ from pydantic_ai.messages import ModelMessage, ModelRequest, UserPromptPart
 
 from pydantic_deep.deps import DeepAgentDeps
 from pydantic_deep.models import DEFAULT_REMINDER_MODEL
+
+if TYPE_CHECKING:
+    from pydantic_ai.models import Model
 
 logger = logging.getLogger(__name__)
 
@@ -119,12 +122,12 @@ class LLMReminderGenerator:
     and asks a cheap model to produce a single-sentence stay-on-task nudge.
 
     Args:
-        model: pydantic-ai model string (default: claude-haiku).
+        model: pydantic-ai model string or `Model` instance (default: claude-haiku).
         max_context_messages: Number of recent messages included in the
             compact transcript to save tokens.
     """
 
-    model: str = DEFAULT_REMINDER_MODEL
+    model: str | Model = DEFAULT_REMINDER_MODEL
     max_context_messages: int = 10
 
     _agent: Agent[None, str] | None = field(default=None, init=False, repr=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,10 @@ dev = [
     "griffe>=1.15.0",
 ]
 lint = [
-    "ruff>=0.8.0",
+    # Capped below 0.16: that release started formatting code blocks inside
+    # Markdown, which reformats 49 docs/skill files the repo never linted.
+    # Lift the cap in a dedicated commit that reformats them.
+    "ruff>=0.8.0,<0.16",
     "pyright>=1.1.0",
     "mypy>=1.0.0",
     "bandit>=1.8.0",

--- a/tests/test_cli_local_models.py
+++ b/tests/test_cli_local_models.py
@@ -43,8 +43,15 @@ class TestResolveOpenAICompatibleModel:
         with pytest.raises(ValueError, match="No base_url"):
             _resolve_openai_compatible_model("openai-compatible:x", CliConfig())
 
-    def test_custom_api_key_accepted(self) -> None:
-        cfg = CliConfig(base_url="http://localhost:1234/v1", local_api_key="lm-studio")
+    def test_api_key_read_from_keystore_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "lm-studio")
+        cfg = CliConfig(base_url="http://localhost:1234/v1")
+        model = _resolve_openai_compatible_model("openai-compatible:phi", cfg)
+        assert isinstance(model, OpenAIChatModel)
+
+    def test_no_api_key_still_builds_with_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENAI_COMPATIBLE_API_KEY", raising=False)
+        cfg = CliConfig(base_url="http://localhost:1234/v1")
         model = _resolve_openai_compatible_model("openai-compatible:phi", cfg)
         assert isinstance(model, OpenAIChatModel)
 
@@ -125,6 +132,11 @@ class TestLocalEndpointModal:
             "apps.cli.config.set_config_value",
             lambda _p, k, v: saved.append((k, v)),
         )
+        keys: list[tuple[str, str]] = []
+        monkeypatch.setattr(
+            "apps.cli.screens.onboarding.save_key",
+            lambda k, v: keys.append((k, v)),
+        )
         result: list[str | None] = []
         modal = LocalEndpointModal()
         async with app.run_test(size=(120, 40)) as pilot:
@@ -137,7 +149,8 @@ class TestLocalEndpointModal:
             await pilot.pause()
         assert result == ["openai-compatible:qwen2.5"]
         assert ("base_url", "http://localhost:8080/v1") in saved
-        assert ("local_api_key", "secret") in saved
+        assert keys == [("OPENAI_COMPATIBLE_API_KEY", "secret")]
+        assert not any(k == "local_api_key" for k, _v in saved)
 
     async def test_blank_model_name_defaults(
         self, app: DeepApp, monkeypatch: pytest.MonkeyPatch
@@ -172,6 +185,25 @@ class TestLocalEndpointModal:
             modal.action_cancel()
             await pilot.pause()
         assert result == [None]
+
+    async def test_enter_submits_from_any_field(
+        self, app: DeepApp, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from textual.widgets import Input
+
+        from apps.cli.screens.onboarding import LocalEndpointModal
+
+        monkeypatch.setattr("apps.cli.config.set_config_value", lambda _p, _k, _v: None)
+        result: list[str | None] = []
+        modal = LocalEndpointModal()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await app.push_screen(modal, lambda r: result.append(r))
+            await pilot.pause()
+            url_input = modal.query_one("#local-url", Input)
+            url_input.value = "http://localhost:8080/v1"
+            modal.on_input_submitted(Input.Submitted(url_input, url_input.value))
+            await pilot.pause()
+        assert result == ["openai-compatible:local-model"]
 
 
 class TestProviderCommandRouting:
@@ -233,3 +265,57 @@ class TestOnboardingStatus:
 
         status = {pid: has_key for pid, _n, _e, has_key in _check_provider_status()}
         assert status["openai-compatible"] is True
+
+
+class TestPickAvailableModel:
+    """A keyless local model must survive an implicit reconfigure, not get
+    swapped for a cloud default."""
+
+    def test_openai_compatible_kept_without_openai_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from apps.cli.app import DeepApp
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant")
+        assert (
+            DeepApp._pick_available_model("openai-compatible:qwen2.5")
+            == "openai-compatible:qwen2.5"
+        )
+
+    def test_ollama_kept_with_only_cloud_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from apps.cli.app import DeepApp
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant")
+        assert DeepApp._pick_available_model("ollama:llama3.3") == "ollama:llama3.3"
+
+    def test_keyed_model_without_key_still_falls_back(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from apps.cli.app import DeepApp
+
+        for var in ("ANTHROPIC_API_KEY", "OPENROUTER_API_KEY", "GOOGLE_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+        assert DeepApp._pick_available_model("anthropic:claude-sonnet-4-6").startswith("openai")
+
+
+class TestReminderModelWiring:
+    """The LLM reminder generator must receive the resolved model, not the raw
+    `openai-compatible:...` string."""
+
+    def test_build_reminder_config_accepts_model_instance(self) -> None:
+        from apps.cli.reminder import _build_reminder_config
+        from pydantic_deep.features.periodic_reminder import LLMReminderGenerator
+
+        cfg = CliConfig(base_url="http://localhost:8080/v1")
+        model = _resolve_openai_compatible_model("openai-compatible:qwen2.5", cfg)
+        reminder_cfg = _build_reminder_config(
+            periodic_reminder=True,
+            reminder_mode="llm",
+            config=cfg,
+            reminder_model=model,
+        )
+        assert isinstance(reminder_cfg.generator, LLMReminderGenerator)
+        assert reminder_cfg.generator.model is model

--- a/tests/test_cli_local_models.py
+++ b/tests/test_cli_local_models.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 from pydantic_ai.models.openai import OpenAIChatModel
 
 from apps.cli.agent import _resolve_openai_compatible_model, create_cli_agent
+from apps.cli.app import DeepApp
 from apps.cli.config import CliConfig
 from apps.cli.providers import OPENAI_COMPATIBLE_PREFIX, PROVIDER_DEFAULT_MODELS, PROVIDERS
 
@@ -108,13 +110,11 @@ class TestCreateCliAgentLocalModel:
 
 class TestLocalEndpointModal:
     @pytest.fixture
-    def app(self):
-        from apps.cli.app import DeepApp
-
+    def app(self) -> DeepApp:
         return DeepApp(model="test", version="0.0.0")
 
     async def test_connect_persists_and_dismisses_with_model_string(
-        self, app, monkeypatch: pytest.MonkeyPatch
+        self, app: DeepApp, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from textual.widgets import Input
 
@@ -126,63 +126,66 @@ class TestLocalEndpointModal:
             lambda _p, k, v: saved.append((k, v)),
         )
         result: list[str | None] = []
+        modal = LocalEndpointModal()
         async with app.run_test(size=(120, 40)) as pilot:
-            await app.push_screen(LocalEndpointModal(), lambda r: result.append(r))
+            await app.push_screen(modal, lambda r: result.append(r))
             await pilot.pause()
-            app.screen.query_one("#local-url", Input).value = "http://localhost:8080/v1"
-            app.screen.query_one("#local-model", Input).value = "qwen2.5"
-            app.screen.query_one("#local-key", Input).value = "secret"
-            app.screen._save_and_dismiss()
+            modal.query_one("#local-url", Input).value = "http://localhost:8080/v1"
+            modal.query_one("#local-model", Input).value = "qwen2.5"
+            modal.query_one("#local-key", Input).value = "secret"
+            modal._save_and_dismiss()
             await pilot.pause()
         assert result == ["openai-compatible:qwen2.5"]
         assert ("base_url", "http://localhost:8080/v1") in saved
         assert ("local_api_key", "secret") in saved
 
-    async def test_blank_model_name_defaults(self, app, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_blank_model_name_defaults(
+        self, app: DeepApp, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         from textual.widgets import Input
 
         from apps.cli.screens.onboarding import LocalEndpointModal
 
         monkeypatch.setattr("apps.cli.config.set_config_value", lambda _p, _k, _v: None)
         result: list[str | None] = []
+        modal = LocalEndpointModal()
         async with app.run_test(size=(120, 40)) as pilot:
-            await app.push_screen(LocalEndpointModal(), lambda r: result.append(r))
+            await app.push_screen(modal, lambda r: result.append(r))
             await pilot.pause()
-            app.screen.query_one("#local-url", Input).value = "http://localhost:8080/v1"
-            app.screen._save_and_dismiss()
+            modal.query_one("#local-url", Input).value = "http://localhost:8080/v1"
+            modal._save_and_dismiss()
             await pilot.pause()
         assert result == ["openai-compatible:local-model"]
 
-    async def test_blank_url_warns_and_stays_open(self, app) -> None:
+    async def test_blank_url_warns_and_stays_open(self, app: DeepApp) -> None:
         from apps.cli.screens.onboarding import LocalEndpointModal
 
         result: list[str | None] = []
+        modal = LocalEndpointModal()
         async with app.run_test(size=(120, 40)) as pilot:
-            await app.push_screen(LocalEndpointModal(), lambda r: result.append(r))
+            await app.push_screen(modal, lambda r: result.append(r))
             await pilot.pause()
-            app.screen._save_and_dismiss()
+            modal._save_and_dismiss()
             await pilot.pause()
             # Modal did not dismiss — no callback fired yet.
             assert result == []
-            app.screen.action_cancel()
+            modal.action_cancel()
             await pilot.pause()
         assert result == [None]
 
 
 class TestProviderCommandRouting:
     @pytest.fixture
-    def app(self):
-        from apps.cli.app import DeepApp
-
+    def app(self) -> DeepApp:
         return DeepApp(model="test", version="0.0.0")
 
     async def test_openai_compatible_opens_local_endpoint_modal(
-        self, app, monkeypatch: pytest.MonkeyPatch
+        self, app: DeepApp, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from apps.cli.commands import _cmd_provider
         from apps.cli.screens.onboarding import LocalEndpointModal, ProviderPickerModal
 
-        pushes: list[tuple[object, object]] = []
+        pushes: list[tuple[Any, Any]] = []
         reconfigured: list[str] = []
         monkeypatch.setattr(app, "reconfigure_agent", lambda model=None: reconfigured.append(model))
         async with app.run_test(size=(120, 40)) as pilot:
@@ -203,12 +206,12 @@ class TestProviderCommandRouting:
         assert reconfigured == ["openai-compatible:qwen2.5"]
 
     async def test_openai_compatible_cancel_does_not_reconfigure(
-        self, app, monkeypatch: pytest.MonkeyPatch
+        self, app: DeepApp, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from apps.cli.commands import _cmd_provider
         from apps.cli.screens.onboarding import LocalEndpointModal
 
-        pushes: list[tuple[object, object]] = []
+        pushes: list[tuple[Any, Any]] = []
         reconfigured: list[str] = []
         monkeypatch.setattr(app, "reconfigure_agent", lambda model=None: reconfigured.append(model))
         async with app.run_test(size=(120, 40)) as pilot:

--- a/tests/test_cli_local_models.py
+++ b/tests/test_cli_local_models.py
@@ -1,0 +1,232 @@
+"""Tests for OpenAI-compatible local model support in the CLI (issue #175)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic_ai.models.openai import OpenAIChatModel
+
+from apps.cli.agent import _resolve_openai_compatible_model, create_cli_agent
+from apps.cli.config import CliConfig
+from apps.cli.providers import OPENAI_COMPATIBLE_PREFIX, PROVIDER_DEFAULT_MODELS, PROVIDERS
+
+
+class TestProviderTable:
+    def test_openai_compatible_entry_present(self) -> None:
+        entry = next(p for p in PROVIDERS if p.id == "openai-compatible")
+        assert entry.env_var == ""  # keyless
+        assert entry.default_model.startswith(OPENAI_COMPATIBLE_PREFIX)
+
+    def test_default_models_includes_openai_compatible(self) -> None:
+        assert PROVIDER_DEFAULT_MODELS["openai-compatible"].startswith(OPENAI_COMPATIBLE_PREFIX)
+
+    def test_prefix_constant(self) -> None:
+        assert OPENAI_COMPATIBLE_PREFIX == "openai-compatible:"
+
+
+class TestResolveOpenAICompatibleModel:
+    def test_happy_path_builds_openai_chat_model(self) -> None:
+        cfg = CliConfig(base_url="http://localhost:8080/v1")
+        model = _resolve_openai_compatible_model("openai-compatible:qwen2.5", cfg)
+        assert isinstance(model, OpenAIChatModel)
+        assert model.model_name == "qwen2.5"
+
+    def test_empty_name_defaults_to_local_model(self) -> None:
+        cfg = CliConfig(base_url="http://localhost:8080/v1")
+        model = _resolve_openai_compatible_model("openai-compatible:", cfg)
+        assert model.model_name == "local-model"
+
+    def test_missing_base_url_raises(self) -> None:
+        with pytest.raises(ValueError, match="No base_url"):
+            _resolve_openai_compatible_model("openai-compatible:x", CliConfig())
+
+    def test_custom_api_key_accepted(self) -> None:
+        cfg = CliConfig(base_url="http://localhost:1234/v1", local_api_key="lm-studio")
+        model = _resolve_openai_compatible_model("openai-compatible:phi", cfg)
+        assert isinstance(model, OpenAIChatModel)
+
+
+class _StopBuild(Exception):
+    """Short-circuits create_cli_agent right after the model is resolved."""
+
+
+class TestCreateCliAgentLocalModel:
+    def _write_config(self, tmp_path: Path, body: str) -> Path:
+        cfg = tmp_path / "config.toml"
+        cfg.write_text(body)
+        return cfg
+
+    def _capture_model_arg(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        model: str,
+        tmp_path: Path,
+        config_body: str,
+    ) -> object:
+        import apps.cli.agent as agent_mod
+
+        captured: dict[str, object] = {}
+
+        def spy(*_args: object, **kwargs: object) -> object:
+            captured["model"] = kwargs.get("model")
+            raise _StopBuild
+
+        monkeypatch.setattr(agent_mod, "create_deep_agent", spy)
+        with pytest.raises(_StopBuild):
+            create_cli_agent(
+                model=model,
+                working_dir=str(tmp_path),
+                config_path=self._write_config(tmp_path, config_body),
+            )
+        return captured["model"]
+
+    def test_prefix_model_is_converted_to_instance(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        model = self._capture_model_arg(
+            monkeypatch,
+            model="openai-compatible:qwen2.5",
+            tmp_path=tmp_path,
+            config_body='base_url = "http://localhost:8080/v1"\n',
+        )
+        assert isinstance(model, OpenAIChatModel)
+        assert model.model_name == "qwen2.5"
+
+    def test_plain_string_model_not_converted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        model = self._capture_model_arg(
+            monkeypatch,
+            model="anthropic:claude-sonnet-4-6",
+            tmp_path=tmp_path,
+            config_body="",
+        )
+        assert model == "anthropic:claude-sonnet-4-6"
+
+
+class TestLocalEndpointModal:
+    @pytest.fixture
+    def app(self):
+        from apps.cli.app import DeepApp
+
+        return DeepApp(model="test", version="0.0.0")
+
+    async def test_connect_persists_and_dismisses_with_model_string(
+        self, app, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from textual.widgets import Input
+
+        from apps.cli.screens.onboarding import LocalEndpointModal
+
+        saved: list[tuple[str, str]] = []
+        monkeypatch.setattr(
+            "apps.cli.config.set_config_value",
+            lambda _p, k, v: saved.append((k, v)),
+        )
+        result: list[str | None] = []
+        async with app.run_test(size=(120, 40)) as pilot:
+            await app.push_screen(LocalEndpointModal(), lambda r: result.append(r))
+            await pilot.pause()
+            app.screen.query_one("#local-url", Input).value = "http://localhost:8080/v1"
+            app.screen.query_one("#local-model", Input).value = "qwen2.5"
+            app.screen.query_one("#local-key", Input).value = "secret"
+            app.screen._save_and_dismiss()
+            await pilot.pause()
+        assert result == ["openai-compatible:qwen2.5"]
+        assert ("base_url", "http://localhost:8080/v1") in saved
+        assert ("local_api_key", "secret") in saved
+
+    async def test_blank_model_name_defaults(self, app, monkeypatch: pytest.MonkeyPatch) -> None:
+        from textual.widgets import Input
+
+        from apps.cli.screens.onboarding import LocalEndpointModal
+
+        monkeypatch.setattr("apps.cli.config.set_config_value", lambda _p, _k, _v: None)
+        result: list[str | None] = []
+        async with app.run_test(size=(120, 40)) as pilot:
+            await app.push_screen(LocalEndpointModal(), lambda r: result.append(r))
+            await pilot.pause()
+            app.screen.query_one("#local-url", Input).value = "http://localhost:8080/v1"
+            app.screen._save_and_dismiss()
+            await pilot.pause()
+        assert result == ["openai-compatible:local-model"]
+
+    async def test_blank_url_warns_and_stays_open(self, app) -> None:
+        from apps.cli.screens.onboarding import LocalEndpointModal
+
+        result: list[str | None] = []
+        async with app.run_test(size=(120, 40)) as pilot:
+            await app.push_screen(LocalEndpointModal(), lambda r: result.append(r))
+            await pilot.pause()
+            app.screen._save_and_dismiss()
+            await pilot.pause()
+            # Modal did not dismiss — no callback fired yet.
+            assert result == []
+            app.screen.action_cancel()
+            await pilot.pause()
+        assert result == [None]
+
+
+class TestProviderCommandRouting:
+    @pytest.fixture
+    def app(self):
+        from apps.cli.app import DeepApp
+
+        return DeepApp(model="test", version="0.0.0")
+
+    async def test_openai_compatible_opens_local_endpoint_modal(
+        self, app, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from apps.cli.commands import _cmd_provider
+        from apps.cli.screens.onboarding import LocalEndpointModal, ProviderPickerModal
+
+        pushes: list[tuple[object, object]] = []
+        reconfigured: list[str] = []
+        monkeypatch.setattr(app, "reconfigure_agent", lambda model=None: reconfigured.append(model))
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            # Patch after mount so the app's own initial screen push isn't captured.
+            monkeypatch.setattr(
+                app, "push_screen", lambda screen, cb=None: pushes.append((screen, cb))
+            )
+            await _cmd_provider(app, "")
+            # First push: the provider picker. Drive its callback.
+            screen0, cb0 = pushes[0]
+            assert isinstance(screen0, ProviderPickerModal)
+            await cb0("openai-compatible")
+            # Second push: the local-endpoint modal. Drive its callback.
+            screen1, cb1 = pushes[1]
+            assert isinstance(screen1, LocalEndpointModal)
+            await cb1("openai-compatible:qwen2.5")
+        assert reconfigured == ["openai-compatible:qwen2.5"]
+
+    async def test_openai_compatible_cancel_does_not_reconfigure(
+        self, app, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from apps.cli.commands import _cmd_provider
+        from apps.cli.screens.onboarding import LocalEndpointModal
+
+        pushes: list[tuple[object, object]] = []
+        reconfigured: list[str] = []
+        monkeypatch.setattr(app, "reconfigure_agent", lambda model=None: reconfigured.append(model))
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            monkeypatch.setattr(
+                app, "push_screen", lambda screen, cb=None: pushes.append((screen, cb))
+            )
+            await _cmd_provider(app, "")
+            await pushes[0][1]("openai-compatible")
+            screen1, cb1 = pushes[1]
+            assert isinstance(screen1, LocalEndpointModal)
+            await cb1(None)  # user cancelled the endpoint modal
+        assert reconfigured == []
+
+
+class TestOnboardingStatus:
+    def test_openai_compatible_reported_ready(self) -> None:
+        from apps.cli.screens.onboarding import _check_provider_status
+
+        status = {pid: has_key for pid, _n, _e, has_key in _check_provider_status()}
+        assert status["openai-compatible"] is True

--- a/tests/test_cli_local_models.py
+++ b/tests/test_cli_local_models.py
@@ -8,10 +8,21 @@ from typing import Any
 import pytest
 from pydantic_ai.models.openai import OpenAIChatModel
 
-from apps.cli.agent import _resolve_openai_compatible_model, create_cli_agent
+from apps.cli.agent import create_cli_agent
 from apps.cli.app import DeepApp
 from apps.cli.config import CliConfig
+from apps.cli.model_resolve import resolve_cli_model, resolve_openai_compatible_model
 from apps.cli.providers import OPENAI_COMPATIBLE_PREFIX, PROVIDER_DEFAULT_MODELS, PROVIDERS
+
+
+def _patch_load_config(monkeypatch: pytest.MonkeyPatch, config: CliConfig) -> None:
+    """Pin the config every on-demand `load_config()` call sees.
+
+    `model_resolve` binds the name at import time, so patching only
+    `apps.cli.config.load_config` would miss it.
+    """
+    monkeypatch.setattr("apps.cli.config.load_config", lambda *_a, **_k: config)
+    monkeypatch.setattr("apps.cli.model_resolve.load_config", lambda *_a, **_k: config)
 
 
 class TestProviderTable:
@@ -30,30 +41,58 @@ class TestProviderTable:
 class TestResolveOpenAICompatibleModel:
     def test_happy_path_builds_openai_chat_model(self) -> None:
         cfg = CliConfig(base_url="http://localhost:8080/v1")
-        model = _resolve_openai_compatible_model("openai-compatible:qwen2.5", cfg)
+        model = resolve_openai_compatible_model("openai-compatible:qwen2.5", cfg)
         assert isinstance(model, OpenAIChatModel)
         assert model.model_name == "qwen2.5"
+        # The whole point of the feature: the configured endpoint is what the
+        # client talks to.
+        assert str(model.base_url) == "http://localhost:8080/v1/"
 
     def test_empty_name_defaults_to_local_model(self) -> None:
         cfg = CliConfig(base_url="http://localhost:8080/v1")
-        model = _resolve_openai_compatible_model("openai-compatible:", cfg)
+        model = resolve_openai_compatible_model("openai-compatible:", cfg)
         assert model.model_name == "local-model"
 
     def test_missing_base_url_raises(self) -> None:
         with pytest.raises(ValueError, match="No base_url"):
-            _resolve_openai_compatible_model("openai-compatible:x", CliConfig())
+            resolve_openai_compatible_model("openai-compatible:x", CliConfig())
 
     def test_api_key_read_from_keystore_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("OPENAI_COMPATIBLE_API_KEY", "lm-studio")
         cfg = CliConfig(base_url="http://localhost:1234/v1")
-        model = _resolve_openai_compatible_model("openai-compatible:phi", cfg)
-        assert isinstance(model, OpenAIChatModel)
+        model = resolve_openai_compatible_model("openai-compatible:phi", cfg)
+        assert model.client.api_key == "lm-studio"
 
-    def test_no_api_key_still_builds_with_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_no_api_key_uses_noop_never_the_openai_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.delenv("OPENAI_COMPATIBLE_API_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-the-users-real-openai-key")
         cfg = CliConfig(base_url="http://localhost:1234/v1")
-        model = _resolve_openai_compatible_model("openai-compatible:phi", cfg)
+        model = resolve_openai_compatible_model("openai-compatible:phi", cfg)
+        # `OpenAIProvider` would fall back to OPENAI_API_KEY if we passed none;
+        # the user's real key must never be sent to an arbitrary endpoint.
+        assert model.client.api_key == "sk-noop"
+
+
+class TestResolveCliModel:
+    def test_plain_model_string_passes_through(self) -> None:
+        assert resolve_cli_model("anthropic:claude-sonnet-4-6") == "anthropic:claude-sonnet-4-6"
+
+    def test_ollama_is_not_treated_as_local_endpoint(self) -> None:
+        assert resolve_cli_model("ollama:llama3.3") == "ollama:llama3.3"
+
+    def test_sentinel_is_converted(self) -> None:
+        cfg = CliConfig(base_url="http://localhost:8080/v1")
+        model = resolve_cli_model("openai-compatible:qwen2.5", cfg)
         assert isinstance(model, OpenAIChatModel)
+        assert model.model_name == "qwen2.5"
+
+    def test_config_is_loaded_on_demand_when_omitted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_load_config(monkeypatch, CliConfig(base_url="http://localhost:9999/v1"))
+        model = resolve_cli_model("openai-compatible:phi")
+        assert isinstance(model, OpenAIChatModel)
+        assert str(model.base_url) == "http://localhost:9999/v1/"
 
 
 class _StopBuild(Exception):
@@ -66,20 +105,20 @@ class TestCreateCliAgentLocalModel:
         cfg.write_text(body)
         return cfg
 
-    def _capture_model_arg(
+    def _capture_agent_kwargs(
         self,
         monkeypatch: pytest.MonkeyPatch,
         *,
         model: str,
         tmp_path: Path,
         config_body: str,
-    ) -> object:
+    ) -> dict[str, object]:
         import apps.cli.agent as agent_mod
 
         captured: dict[str, object] = {}
 
         def spy(*_args: object, **kwargs: object) -> object:
-            captured["model"] = kwargs.get("model")
+            captured.update(kwargs)
             raise _StopBuild
 
         monkeypatch.setattr(agent_mod, "create_deep_agent", spy)
@@ -89,30 +128,58 @@ class TestCreateCliAgentLocalModel:
                 working_dir=str(tmp_path),
                 config_path=self._write_config(tmp_path, config_body),
             )
-        return captured["model"]
+        return captured
 
     def test_prefix_model_is_converted_to_instance(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        model = self._capture_model_arg(
+        kwargs = self._capture_agent_kwargs(
             monkeypatch,
             model="openai-compatible:qwen2.5",
             tmp_path=tmp_path,
             config_body='base_url = "http://localhost:8080/v1"\n',
         )
+        model = kwargs["model"]
         assert isinstance(model, OpenAIChatModel)
         assert model.model_name == "qwen2.5"
 
     def test_plain_string_model_not_converted(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        model = self._capture_model_arg(
+        kwargs = self._capture_agent_kwargs(
             monkeypatch,
             model="anthropic:claude-sonnet-4-6",
             tmp_path=tmp_path,
             config_body="",
         )
-        assert model == "anthropic:claude-sonnet-4-6"
+        assert kwargs["model"] == "anthropic:claude-sonnet-4-6"
+
+    def test_prefix_fallback_model_is_converted_too(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A local endpoint is as valid a fallback as it is a primary — passing
+        the raw sentinel through would crash in `infer_model`."""
+        kwargs = self._capture_agent_kwargs(
+            monkeypatch,
+            model="anthropic:claude-sonnet-4-6",
+            tmp_path=tmp_path,
+            config_body=(
+                'base_url = "http://localhost:8080/v1"\n'
+                'fallback_model = "openai-compatible:qwen2.5"\n'
+            ),
+        )
+        fallback = kwargs["fallback_model"]
+        assert isinstance(fallback, OpenAIChatModel)
+        assert fallback.model_name == "qwen2.5"
+
+    def test_no_fallback_stays_none(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        kwargs = self._capture_agent_kwargs(
+            monkeypatch,
+            model="anthropic:claude-sonnet-4-6",
+            tmp_path=tmp_path,
+            config_body="",
+        )
+        assert kwargs["fallback_model"] is None
 
 
 class TestLocalEndpointModal:
@@ -169,6 +236,26 @@ class TestLocalEndpointModal:
             modal._save_and_dismiss()
             await pilot.pause()
         assert result == ["openai-compatible:local-model"]
+
+    async def test_schemeless_url_warns_and_stays_open(self, app: DeepApp) -> None:
+        """`localhost:8080/v1` is what a llama.cpp log prints; without a scheme
+        it only fails on the first message, deep inside httpx."""
+        from textual.widgets import Input
+
+        from apps.cli.screens.onboarding import LocalEndpointModal
+
+        result: list[str | None] = []
+        modal = LocalEndpointModal()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await app.push_screen(modal, lambda r: result.append(r))
+            await pilot.pause()
+            modal.query_one("#local-url", Input).value = "localhost:8080/v1"
+            modal._save_and_dismiss()
+            await pilot.pause()
+            assert result == []
+            modal.action_cancel()
+            await pilot.pause()
+        assert result == [None]
 
     async def test_blank_url_warns_and_stays_open(self, app: DeepApp) -> None:
         from apps.cli.screens.onboarding import LocalEndpointModal
@@ -303,14 +390,14 @@ class TestPickAvailableModel:
 
 class TestReminderModelWiring:
     """The LLM reminder generator must receive the resolved model, not the raw
-    `openai-compatible:...` string."""
+    `openai-compatible:...` string — at startup *and* on the live mode switch."""
 
     def test_build_reminder_config_accepts_model_instance(self) -> None:
         from apps.cli.reminder import _build_reminder_config
         from pydantic_deep.features.periodic_reminder import LLMReminderGenerator
 
         cfg = CliConfig(base_url="http://localhost:8080/v1")
-        model = _resolve_openai_compatible_model("openai-compatible:qwen2.5", cfg)
+        model = resolve_openai_compatible_model("openai-compatible:qwen2.5", cfg)
         reminder_cfg = _build_reminder_config(
             periodic_reminder=True,
             reminder_mode="llm",
@@ -319,3 +406,65 @@ class TestReminderModelWiring:
         )
         assert isinstance(reminder_cfg.generator, LLMReminderGenerator)
         assert reminder_cfg.generator.model is model
+
+    def test_build_reminder_config_resolves_a_raw_sentinel(self) -> None:
+        from apps.cli.reminder import _build_reminder_config
+        from pydantic_deep.features.periodic_reminder import LLMReminderGenerator
+
+        cfg = CliConfig(model="openai-compatible:qwen2.5", base_url="http://localhost:8080/v1")
+        reminder_cfg = _build_reminder_config(
+            periodic_reminder=True, reminder_mode="llm", config=cfg
+        )
+        assert isinstance(reminder_cfg.generator, LLMReminderGenerator)
+        assert isinstance(reminder_cfg.generator.model, OpenAIChatModel)
+
+    def test_live_switch_resolves_the_apps_model_name(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`/remind llm` rebuilds the generator from `app.model_name`, which
+        holds the raw CLI string."""
+        from apps.cli.reminder import _resolve_reminder_model
+
+        _patch_load_config(monkeypatch, CliConfig(base_url="http://localhost:8080/v1"))
+        app = DeepApp(model="openai-compatible:qwen2.5", version="0.0.0")
+        model = _resolve_reminder_model(app)
+        assert isinstance(model, OpenAIChatModel)
+        assert model.model_name == "qwen2.5"
+
+    def test_live_switch_leaves_a_normal_model_alone(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from apps.cli.reminder import _resolve_reminder_model
+
+        _patch_load_config(monkeypatch, CliConfig())
+        app = DeepApp(model="anthropic:claude-sonnet-4-6", version="0.0.0")
+        assert _resolve_reminder_model(app) == "anthropic:claude-sonnet-4-6"
+
+
+class TestGoalEvaluatorWiring:
+    def test_goal_evaluator_gets_the_resolved_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Without this the evaluator fails on every turn with
+        "Evaluator error; continuing." and the goal never completes."""
+        from apps.cli.goal import get_goal_evaluator
+
+        _patch_load_config(monkeypatch, CliConfig(base_url="http://localhost:8080/v1"))
+        app = DeepApp(model="openai-compatible:qwen2.5", version="0.0.0")
+        evaluator = get_goal_evaluator(app)
+        assert isinstance(evaluator.model, OpenAIChatModel)
+        assert evaluator.model.model_name == "qwen2.5"
+
+
+class TestCredentialRegistration:
+    def test_local_endpoint_key_is_manageable(self) -> None:
+        """`/provider` writes this key, so `keys list` / `keys set` / `/keys`
+        must be able to see and change it."""
+        from apps.cli.credentials import CREDENTIALS, find_credential
+
+        cred = find_credential("OPENAI_COMPATIBLE_API_KEY")
+        assert cred is not None
+        assert cred in CREDENTIALS
+
+    def test_local_endpoint_key_is_not_a_first_run_provider(self) -> None:
+        """It must stay out of the key-first onboarding list: the provider needs
+        a base URL, and picking it there would set a model with no endpoint."""
+        from apps.cli.onboarding_cli import _provider_credentials
+
+        assert all(c.env_var != "OPENAI_COMPATIBLE_API_KEY" for c in _provider_credentials())


### PR DESCRIPTION
## Changes

### Summary

Let the CLI target any OpenAI-compatible local endpoint (llama.cpp, LM Studio, vLLM, text-generation-webui) by supplying a `base_url`. Previously only Ollama worked from the CLI, because it has a provider prefix pydantic-ai recognizes; other local servers need an `OpenAIChatModel` built with a custom `base_url`, which a plain model string couldn't carry.

### Business Context

Requested in #175. The author wants llama.cpp specifically (explicitly not Ollama). llama.cpp's `llama-server` already speaks the OpenAI wire format, so no new engine is needed — the only gap was a way to set the endpoint URL from the CLI.

### Changes

- **config** — add `base_url` and `local_api_key` fields to `CliConfig`.
- **providers** — add an `openai-compatible` provider entry and an `OPENAI_COMPATIBLE_PREFIX` sentinel.
- **agent** — `_resolve_openai_compatible_model()` turns an `openai-compatible:<name>` model string into an `OpenAIChatModel` pointed at `config.base_url` (noop API key when unset); wired into `create_cli_agent` so only prefixed models take the branch, everything else is untouched.
- **onboarding** — new `LocalEndpointModal` (base URL + model name + optional key); keyless-local providers now report as ready in the picker.
- **commands** — `/provider` routes the OpenAI-compatible choice to the new modal.
- **docs** — "Local models" section in `cli/settings.md` plus a tool-calling caveat.

The sentinel prefix keeps `base_url` from interfering with normal provider switching: it's only consulted when the active model is `openai-compatible:…`, and the model string round-trips through the existing config persistence unchanged.

### Verification

`tests/test_cli_local_models.py` (15 tests) covers the resolver (happy path, missing-`base_url` guard, default name), the `create_cli_agent` conversion branch, the `LocalEndpointModal` (connect / blank-name default / blank-URL warning / cancel), the `/provider` routing, and the onboarding status.

```
$ uv run pytest tests/test_cli_local_models.py
collected 15 items
tests/test_cli_local_models.py ...............                           [100%]
============================== 15 passed in 1.66s ==============================
```

Broader CLI/TUI suite (`-k "cli or tui or provider or model_picker or onboard or config"`): **607 passed**, no regressions.

Config written by the `/provider` → OpenAI-compatible flow:

```toml
model = "openai-compatible:qwen2.5"
base_url = "http://localhost:8080/v1"
local_api_key = ""   # most local servers ignore it
```

> Note: dev tooling (`ruff`, `pyright`, `mypy`) wasn't installed in the local env, so lint/typecheck ran via pre-commit only after `make install`. CI covers these gates.

### Linked Issues

Closes #175
