### PR TITLE
fix(cli): prevent duplicate text paste

### DIFF
--- a/apps/cli/widgets/input_area.py
+++ b/apps/cli/widgets/input_area.py
@@ -247,7 +247,9 @@ class PromptInput(Input):
             self.post_message(MultilinePasteRequested(combined))
             event.stop()
             return
-        super()._on_paste(event)
+        # Let Textual continue dispatching the event to Input._on_paste.
+        # Calling it directly inserts the text once here and once again when
+        # MessagePump reaches the base-class handler.
 
     def on_key(self, event: Any) -> None:
         """Handle special keys for history and triggers."""

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -133,6 +133,20 @@ async def test_multiline_paste_preserves_structure(app: DeepApp) -> None:
         assert ml.text == "def f():\n    return 1\n"
 
 
+async def test_single_line_paste_is_inserted_once(app: DeepApp) -> None:
+    """Textual dispatches paste events through subclass and base handlers."""
+    from textual.events import Paste
+
+    from apps.cli.widgets.input_area import InputArea, PromptInput
+
+    async with app.run_test(size=(120, 35)) as pilot:
+        await pilot.pause()
+        prompt = app.screen.query_one(InputArea).query_one(PromptInput)
+        prompt.post_message(Paste("once"))
+        await pilot.pause()
+        assert prompt.value == "once"
+
+
 async def test_on_paste_routes_multiline(app: DeepApp) -> None:
     """PromptInput._on_paste hands multi-line pastes to multiline mode and lets
     a plain single-line paste fall through to the default insert behaviour."""


### PR DESCRIPTION
## Summary

Fixes #177. Single-line text pastes were inserted twice because `PromptInput` called Textual's base paste handler directly before normal event dispatch reached the same handler again.

## Changes

- Let Textual dispatch ordinary paste events to the base input handler once
- Add a regression test that posts a real paste event

## Testing

- [x] New tests added for any new functionality (required — `make test` enforces 100% coverage)
- [ ] All tests pass locally: `make test`
- [ ] Linting passes: `make lint`
- [ ] Type checking passes: `make typecheck`
- [ ] Security scan passes: `make security`
- [ ] Full check suite passes: `make all`

Focused CLI tests: 31 passed. Ruff check and format check passed for both changed files.

## Related Issues

Closes #177

## Notes for Reviewers

The regression fails as `onceonce` before the source fix and passes as `once` after it.
