### PR TITLE
feat: expose MCP resources & skill:// skills to the model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **MCP resources and `skill://` skills are now visible to the model** ([#180](https://github.com/vstorm-co/pydantic-deepagents/pull/180), closes [#178](https://github.com/vstorm-co/pydantic-deepagents/issues/178)) (`pydantic_deep/mcp/resources.py`, `pydantic_deep/mcp/registry.py`, `pydantic_deep/mcp/config.py`, `pydantic_deep/mcp/loader.py`). pydantic-ai surfaces only an MCP server's *tools*, so a server publishing skills through FastMCP's `SkillsDirectoryProvider` was unreachable from a delegated agent unless the app hand-rolled a bridge. Set `include_resources` / `include_skills` on an `MCPServerConfig` (or in the `mcpServers` JSON) and `MCPRegistry.build_active()` attaches a second toolset with `list_mcp_resources` / `read_mcp_resource` and, for skills, `list_mcp_skills` / `load_mcp_skill`. It binds to the same `MCPToolset`, so tools and resources share one connection and one resource cache. Both flags default to off.
+  - The resource tools are prefixed per server (the config's `tool_prefix`, else its name), so several servers can expose their resources in the same run — without a prefix their identical tool names collide and pydantic-ai fails the run.
+  - With `include_skills`, the server's skills are listed in the system prompt, so the model knows the guidance exists before it starts calling the server's operational tools.
+  - An unreachable server returns the failure as tool text rather than raising out of `agent.run()`, matching how `make_resilient` degrades the tools toolset.
+  - New export: `create_mcp_resources_toolset` (also `MCPResourceProvider`, `SKILL_URI_SCHEME`, `SKILL_DOC_NAME` from `pydantic_deep.mcp`).
+
 ## [0.3.37] - 2026-07-22
 
 A CLI paste fix and raised floors on the vstorm-co packages, bringing backend

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -17,6 +17,39 @@ them to an agent via the `mcp_servers` parameter of
     options:
       show_source: false
 
+## create_mcp_resources_toolset
+
+Most MCP servers are used for their tools, but a server can also publish
+*resources* — docs, templates, or FastMCP `skill://.../SKILL.md` skills. pydantic-ai
+surfaces only the tools to the model, so set `include_resources=True` (or
+`include_skills=True` for skills specifically) on an
+[`MCPServerConfig`][pydantic_deep.mcp.MCPServerConfig] and build with
+[`MCPRegistry.build_active`][pydantic_deep.mcp.MCPRegistry] to attach a second
+toolset that lets the model discover and read them:
+
+```python
+from pydantic_deep.mcp import MCPRegistry, MCPServerConfig
+
+registry = MCPRegistry([
+    MCPServerConfig(
+        name="service",
+        transport="http",
+        url="https://example.com/mcp/",
+        include_skills=True,  # exposes list_mcp_skills / load_mcp_skill
+    ),
+])
+mcp_servers = registry.build_active()  # tools toolset + resources toolset
+```
+
+The resources toolset adds `list_mcp_resources` / `read_mcp_resource`, plus
+`list_mcp_skills` / `load_mcp_skill` when `include_skills` is set. It binds to the
+same underlying `MCPToolset`, so tools and resources share one connection. Use
+`create_mcp_resources_toolset` directly to wrap a server you built yourself.
+
+::: pydantic_deep.mcp.create_mcp_resources_toolset
+    options:
+      show_source: false
+
 ## builtin_mcp_servers
 
 ::: pydantic_deep.mcp.builtin_mcp_servers

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -43,8 +43,23 @@ mcp_servers = registry.build_active()  # tools toolset + resources toolset
 
 The resources toolset adds `list_mcp_resources` / `read_mcp_resource`, plus
 `list_mcp_skills` / `load_mcp_skill` when `include_skills` is set. It binds to the
-same underlying `MCPToolset`, so tools and resources share one connection. Use
-`create_mcp_resources_toolset` directly to wrap a server you built yourself.
+same underlying `MCPToolset`, so tools and resources share one connection.
+
+Every server's tools carry a prefix, so the example above registers
+`service_list_mcp_skills`, `service_load_mcp_skill` and so on. The prefix is the
+server's `tool_prefix` when set, otherwise its name — without it, two servers
+exposing their resources would register identical tool names and pydantic-ai
+would reject the collision and fail the run.
+
+With `include_skills` the toolset also lists the server's skills in the system
+prompt, so the model knows the guidance exists before it reaches for the server's
+operational tools rather than having to go looking for it.
+
+A server that is unreachable degrades the same way its tools do: these tools
+return the error as text instead of raising out of `agent.run()`.
+
+Use `create_mcp_resources_toolset` directly to wrap a server you built yourself —
+pass `tool_prefix` if more than one server will expose its resources.
 
 ::: pydantic_deep.mcp.create_mcp_resources_toolset
     options:

--- a/pydantic_deep/__init__.py
+++ b/pydantic_deep/__init__.py
@@ -271,6 +271,7 @@ from pydantic_deep.mcp import (
     auth_satisfied,
     build_mcp_server,
     builtin_mcp_servers,
+    create_mcp_resources_toolset,
     parse_mcp_servers,
     probe_mcp_server,
 )
@@ -329,6 +330,7 @@ __all__ = [
     "MCPConfigError",
     "MCPNotInstalledError",
     "build_mcp_server",
+    "create_mcp_resources_toolset",
     "probe_mcp_server",
     "auth_satisfied",
     "builtin_mcp_servers",

--- a/pydantic_deep/mcp/__init__.py
+++ b/pydantic_deep/mcp/__init__.py
@@ -28,6 +28,11 @@ from pydantic_deep.mcp.registry import (
     make_resilient,
     probe_mcp_server,
 )
+from pydantic_deep.mcp.resources import (
+    SKILL_URI_SCHEME,
+    MCPResourceProvider,
+    create_mcp_resources_toolset,
+)
 
 __all__ = [
     "MCPAuth",
@@ -44,6 +49,9 @@ __all__ = [
     "build_mcp_server",
     "make_resilient",
     "probe_mcp_server",
+    "create_mcp_resources_toolset",
+    "MCPResourceProvider",
+    "SKILL_URI_SCHEME",
     "builtin_mcp_servers",
     "BUILTIN_MCP_NAMES",
     "parse_mcp_servers",

--- a/pydantic_deep/mcp/__init__.py
+++ b/pydantic_deep/mcp/__init__.py
@@ -29,6 +29,7 @@ from pydantic_deep.mcp.registry import (
     probe_mcp_server,
 )
 from pydantic_deep.mcp.resources import (
+    SKILL_DOC_NAME,
     SKILL_URI_SCHEME,
     MCPResourceProvider,
     create_mcp_resources_toolset,
@@ -52,6 +53,7 @@ __all__ = [
     "create_mcp_resources_toolset",
     "MCPResourceProvider",
     "SKILL_URI_SCHEME",
+    "SKILL_DOC_NAME",
     "builtin_mcp_servers",
     "BUILTIN_MCP_NAMES",
     "parse_mcp_servers",

--- a/pydantic_deep/mcp/config.py
+++ b/pydantic_deep/mcp/config.py
@@ -129,6 +129,12 @@ class MCPServerConfig:
     to become ready (e.g. one that opens a database connection on startup),
     which would otherwise fail with ``"Failed to initialize server session"``.
     """
+    include_resources: bool = False
+    """Expose the server's MCP resources to the model via `list_mcp_resources` /
+    `read_mcp_resource`. Off by default — most servers are used for tools only."""
+    include_skills: bool = False
+    """Expose the server's ``skill://.../SKILL.md`` resources via `list_mcp_skills`
+    / `load_mcp_skill` (and enables resource reading). See issue #178."""
 
     def __post_init__(self) -> None:
         if not self.name:
@@ -173,4 +179,6 @@ class MCPServerConfig:
             builtin=data.get("builtin", False),
             auth=MCPAuth.from_dict(auth_data) if auth_data is not None else None,
             init_timeout=data.get("init_timeout"),
+            include_resources=data.get("include_resources", False),
+            include_skills=data.get("include_skills", False),
         )

--- a/pydantic_deep/mcp/loader.py
+++ b/pydantic_deep/mcp/loader.py
@@ -81,6 +81,8 @@ def parse_mcp_servers(
                     args=[_expand(a) for a in entry.get("args", [])],
                     env={k: _expand(v) for k, v in entry.get("env", {}).items()},
                     enabled=enabled,
+                    include_resources=bool(entry.get("include_resources", False)),
+                    include_skills=bool(entry.get("include_skills", False)),
                 )
             elif entry.get("url") and transport_type != "ws":
                 transport: MCPTransport = "sse" if transport_type == "sse" else "http"
@@ -90,6 +92,8 @@ def parse_mcp_servers(
                     url=_expand(entry["url"]),
                     headers={k: _expand(v) for k, v in entry.get("headers", {}).items()},
                     enabled=enabled,
+                    include_resources=bool(entry.get("include_resources", False)),
+                    include_skills=bool(entry.get("include_skills", False)),
                 )
             else:
                 logger.warning(

--- a/pydantic_deep/mcp/registry.py
+++ b/pydantic_deep/mcp/registry.py
@@ -110,42 +110,23 @@ def auth_satisfied(config: MCPServerConfig, resolver: SecretResolver | None = No
     return bool(resolver(auth.secret_key))
 
 
-def build_mcp_server(
+def _build_raw_mcp_toolset(
     config: MCPServerConfig,
     resolver: SecretResolver | None = None,
     *,
     oauth_token_storage: Any | None = None,
 ) -> AbstractToolset[Any]:
-    """Build a connected pydantic-ai MCP toolset from a config.
+    """Build the bare ``MCPToolset`` for a config (before any prefix wrapping).
 
-    Resolves the auth secret (if any) and injects it as an HTTP header (for
-    ``bearer``/``header`` auth) or a subprocess env var (for ``env`` auth).
-    Wraps the toolset in a ``PrefixedToolset`` when ``tool_prefix`` is set.
-    When ``config.init_timeout`` is set it is forwarded to the ``MCPToolset``,
-    raising the connect/``initialize`` deadline above pydantic-ai's 5s default
-    for servers that are slow to become ready.
-
-    For ``stdio`` servers, the subprocess receives ``config.env`` (plus any
-    ``env``-kind auth var) layered on top of the MCP SDK's *safe default*
-    environment (``PATH``, ``HOME``, …) — the parent process's full environment
-    is intentionally **not** inherited, so secrets like API keys are never
-    leaked to a third-party server. Add anything else a server needs (proxies,
-    ``NODE_EXTRA_CA_CERTS``, …) explicitly via ``config.env``.
-
-    Args:
-        oauth_token_storage: A persistent ``AsyncKeyValue`` store for OAuth
-            tokens (e.g. a disk-backed store). When provided for an ``oauth``
-            server, the token survives restarts and is shared between the
-            connection test and the agent (FastMCP keys tokens by server URL).
-            When ``None``, FastMCP uses in-memory storage (token re-auth per
-            client/restart).
+    Split out from :func:`build_mcp_server` so a resources toolset can bind to the
+    same underlying ``MCPToolset`` instance and share its connection/cache.
 
     Raises:
         MCPNotInstalledError: if the ``mcp`` optional dependency is missing.
     """
     resolver = resolver or _default_resolver
     try:
-        MCPToolset, PrefixedToolset, StdioTransport = _load_mcp_classes()
+        MCPToolset, _PrefixedToolset, StdioTransport = _load_mcp_classes()
     except ImportError as exc:
         raise MCPNotInstalledError(MCP_INSTALL_HINT) from exc
 
@@ -195,9 +176,59 @@ def build_mcp_server(
         url = cast(str, config.url)
         toolset = MCPToolset(url, headers=headers or None, id=config.name, **extra)
 
-    if config.tool_prefix:
-        toolset = PrefixedToolset(toolset, config.tool_prefix)
     return cast("AbstractToolset[Any]", toolset)
+
+
+def _apply_tool_prefix(
+    toolset: AbstractToolset[Any], config: MCPServerConfig
+) -> AbstractToolset[Any]:
+    """Wrap ``toolset`` in a ``PrefixedToolset`` when ``config.tool_prefix`` is set."""
+    if not config.tool_prefix:
+        return toolset
+    _MCPToolset, PrefixedToolset, _StdioTransport = _load_mcp_classes()
+    return cast("AbstractToolset[Any]", PrefixedToolset(toolset, config.tool_prefix))
+
+
+def build_mcp_server(
+    config: MCPServerConfig,
+    resolver: SecretResolver | None = None,
+    *,
+    oauth_token_storage: Any | None = None,
+) -> AbstractToolset[Any]:
+    """Build a connected pydantic-ai MCP toolset from a config.
+
+    Resolves the auth secret (if any) and injects it as an HTTP header (for
+    ``bearer``/``header`` auth) or a subprocess env var (for ``env`` auth).
+    Wraps the toolset in a ``PrefixedToolset`` when ``tool_prefix`` is set.
+    When ``config.init_timeout`` is set it is forwarded to the ``MCPToolset``,
+    raising the connect/``initialize`` deadline above pydantic-ai's 5s default
+    for servers that are slow to become ready.
+
+    Only the server's *tools* are built here. To also expose its resources or
+    ``skill://`` skills to the model, set ``include_resources`` / ``include_skills``
+    on the config and build via :meth:`MCPRegistry.build_active`.
+
+    For ``stdio`` servers, the subprocess receives ``config.env`` (plus any
+    ``env``-kind auth var) layered on top of the MCP SDK's *safe default*
+    environment (``PATH``, ``HOME``, …) — the parent process's full environment
+    is intentionally **not** inherited, so secrets like API keys are never
+    leaked to a third-party server. Add anything else a server needs (proxies,
+    ``NODE_EXTRA_CA_CERTS``, …) explicitly via ``config.env``.
+
+    Args:
+        oauth_token_storage: A persistent ``AsyncKeyValue`` store for OAuth
+            tokens (e.g. a disk-backed store). When provided for an ``oauth``
+            server, the token survives restarts and is shared between the
+            connection test and the agent (FastMCP keys tokens by server URL).
+            When ``None``, FastMCP uses in-memory storage (token re-auth per
+            client/restart).
+
+    Raises:
+        MCPNotInstalledError: if the ``mcp`` optional dependency is missing.
+    """
+    resolver = resolver or _default_resolver
+    raw = _build_raw_mcp_toolset(config, resolver, oauth_token_storage=oauth_token_storage)
+    return _apply_tool_prefix(raw, config)
 
 
 async def _connect_and_list(server: Any) -> list[str]:
@@ -375,9 +406,29 @@ class MCPRegistry:
         which turns out to be unreachable at runtime contributes no tools rather
         than failing the entire agent run. ``on_degraded(name, reason)`` is
         forwarded to each wrapper.
+
+        A server with ``include_resources`` / ``include_skills`` set contributes a
+        second toolset exposing its MCP resources (and ``skill://`` skills) to the
+        model. It binds to the same underlying ``MCPToolset`` so tools and
+        resources share one connection.
         """
         servers: list[AbstractToolset[Any]] = []
         for config in self._configs.values():
-            if self.status(config) == "ready":
-                servers.append(make_resilient(self.build(config), config.name, on_degraded))
+            if self.status(config) != "ready":
+                continue
+            raw = _build_raw_mcp_toolset(
+                config, self._resolver, oauth_token_storage=self._oauth_token_storage
+            )
+            servers.append(
+                make_resilient(_apply_tool_prefix(raw, config), config.name, on_degraded)
+            )
+            if config.include_resources or config.include_skills:
+                from pydantic_deep.mcp.resources import create_mcp_resources_toolset
+
+                resources = create_mcp_resources_toolset(
+                    cast("Any", raw),
+                    server_name=config.name,
+                    include_skills=config.include_skills,
+                )
+                servers.append(make_resilient(resources, config.name, on_degraded))
         return servers

--- a/pydantic_deep/mcp/registry.py
+++ b/pydantic_deep/mcp/registry.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from pydantic_deep.mcp.config import _SECRET_AUTH_KINDS, MCPServerConfig
+from pydantic_deep.mcp.resources import create_mcp_resources_toolset
 
 
 def _stdio_log_file(name: str) -> Path:
@@ -187,6 +188,17 @@ def _apply_tool_prefix(
         return toolset
     _MCPToolset, PrefixedToolset, _StdioTransport = _load_mcp_classes()
     return cast("AbstractToolset[Any]", PrefixedToolset(toolset, config.tool_prefix))
+
+
+def _resources_tool_prefix(config: MCPServerConfig) -> str:
+    """Tool-name prefix for a server's resource tools.
+
+    Every server's resources toolset registers the same four tool names, so two
+    servers exposing their resources would collide and pydantic-ai fails the whole
+    run on the duplicate. Prefixing with the server name (sanitised to what tool
+    names allow) keeps them distinct and tells the model which server it is reading.
+    """
+    return config.tool_prefix or re.sub(r"[^A-Za-z0-9_-]", "_", config.name)
 
 
 def build_mcp_server(
@@ -410,7 +422,8 @@ class MCPRegistry:
         A server with ``include_resources`` / ``include_skills`` set contributes a
         second toolset exposing its MCP resources (and ``skill://`` skills) to the
         model. It binds to the same underlying ``MCPToolset`` so tools and
-        resources share one connection.
+        resources share one connection, and its tools are prefixed per server so
+        several such servers can be active at once.
         """
         servers: list[AbstractToolset[Any]] = []
         for config in self._configs.values():
@@ -423,12 +436,11 @@ class MCPRegistry:
                 make_resilient(_apply_tool_prefix(raw, config), config.name, on_degraded)
             )
             if config.include_resources or config.include_skills:
-                from pydantic_deep.mcp.resources import create_mcp_resources_toolset
-
                 resources = create_mcp_resources_toolset(
                     cast("Any", raw),
                     server_name=config.name,
                     include_skills=config.include_skills,
+                    tool_prefix=_resources_tool_prefix(config),
                 )
                 servers.append(make_resilient(resources, config.name, on_degraded))
         return servers

--- a/pydantic_deep/mcp/resources.py
+++ b/pydantic_deep/mcp/resources.py
@@ -1,0 +1,188 @@
+"""Expose an MCP server's resources — and ``skill://`` resources in particular — to the model.
+
+An MCP server can publish *resources* (docs, templates, FastMCP skills) next to its
+tools, but pydantic-ai only surfaces the tools to the model. A server that correctly
+advertises ``skill://.../SKILL.md`` via FastMCP's ``SkillsDirectoryProvider`` is
+therefore invisible to a delegated agent unless the application reimplements a bridge
+by hand (see issue #178).
+
+:func:`create_mcp_resources_toolset` closes that gap: given anything that can
+``list_resources()`` / ``read_resource(uri)`` (pydantic-ai's ``MCPToolset`` does), it
+returns a small ``FunctionToolset`` exposing model-visible tools to discover and read
+those resources, with first-class handling for ``SKILL.md`` skill resources.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+from urllib.parse import urlsplit
+
+from pydantic_ai._run_context import RunContext
+from pydantic_ai.messages import BinaryContent
+from pydantic_ai.toolsets import FunctionToolset
+
+__all__ = [
+    "MCPResourceProvider",
+    "SKILL_URI_SCHEME",
+    "SKILL_DOC_NAME",
+    "create_mcp_resources_toolset",
+]
+
+#: URI scheme FastMCP uses for skill resources, e.g. ``skill://service-mcp/SKILL.md``.
+SKILL_URI_SCHEME = "skill"
+
+#: Filename that marks a skill's entry document within a ``skill://`` resource.
+SKILL_DOC_NAME = "SKILL.md"
+
+
+@runtime_checkable
+class MCPResourceProvider(Protocol):
+    """The slice of ``MCPToolset`` this toolset needs — list and read resources."""
+
+    async def list_resources(self) -> list[Any]: ...
+
+    async def read_resource(self, uri: str) -> Any: ...
+
+
+def _uri_str(resource: Any) -> str:
+    uri = getattr(resource, "uri", None)
+    return str(uri) if uri is not None else ""
+
+
+def _is_skill_doc_uri(uri: str) -> bool:
+    parts = urlsplit(uri)
+    return parts.scheme == SKILL_URI_SCHEME and parts.path.rsplit("/", 1)[-1] == SKILL_DOC_NAME
+
+
+def _skill_id_from_uri(uri: str) -> str:
+    """``skill://service-mcp/SKILL.md`` → ``service-mcp``."""
+    parts = urlsplit(uri)
+    return parts.netloc or parts.path.strip("/").split("/", 1)[0]
+
+
+def _coerce_text(content: Any) -> str:
+    """Flatten ``read_resource``'s ``str | BinaryContent | list[...]`` into text.
+
+    Binary parts can't be inlined, so they're rendered as a short placeholder note
+    rather than dropped silently.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, BinaryContent):
+        return f"[binary content: {content.media_type}, {len(content.data)} bytes]"
+    if isinstance(content, list):
+        return "\n".join(_coerce_text(part) for part in content)
+    return str(content)
+
+
+def _resource_summary(resource: Any) -> dict[str, str]:
+    return {
+        "uri": _uri_str(resource),
+        "name": getattr(resource, "name", "") or "",
+        "description": getattr(resource, "description", "") or "",
+        "mime_type": getattr(resource, "mime_type", None)
+        or getattr(resource, "mimeType", "")
+        or "",
+    }
+
+
+LIST_RESOURCES_DESCRIPTION = """\
+List the resources published by this MCP server (docs, templates, skills).
+
+Resources are read-only data the server exposes alongside its tools. Returns each \
+resource's uri, name, description and mime type. Read one with `read_mcp_resource`."""
+
+READ_RESOURCE_DESCRIPTION = """\
+Read the contents of an MCP resource by its exact uri (from `list_mcp_resources`).
+
+Returns the resource text. Binary resources are summarised as a short placeholder."""
+
+LIST_SKILLS_DESCRIPTION = """\
+List the skills this MCP server publishes as `skill://.../SKILL.md` resources.
+
+Skills carry operational guidance and tool-usage patterns for the server. Load one \
+with `load_mcp_skill` before using the server's operational tools."""
+
+LOAD_SKILL_DESCRIPTION = """\
+Load an MCP server skill's `SKILL.md` guidance by skill id or full uri.
+
+Read the returned guidance before using the server's operational tools — it explains \
+how the server expects them to be used."""
+
+
+def create_mcp_resources_toolset(
+    provider: MCPResourceProvider,
+    *,
+    server_name: str,
+    id: str | None = None,
+    include_skills: bool = True,
+) -> FunctionToolset:
+    """Build a toolset that exposes an MCP server's resources to the model.
+
+    Args:
+        provider: The connected MCP server (anything with ``list_resources`` /
+            ``read_resource``). ``MCPToolset`` manages its own connection, so the
+            tools work whether or not the toolset is currently entered.
+        server_name: Server identifier, used in the toolset id and skill error text.
+        id: Explicit toolset id (defaults to ``mcp-resources-<server_name>``).
+        include_skills: Also register `list_mcp_skills` / `load_mcp_skill` for
+            ``skill://`` resources.
+
+    Returns:
+        A ``FunctionToolset`` with `list_mcp_resources`, `read_mcp_resource`, and
+        (when ``include_skills``) the two skill tools.
+    """
+    toolset = FunctionToolset(id=id or f"mcp-resources-{server_name}")
+
+    @toolset.tool(description=LIST_RESOURCES_DESCRIPTION)
+    async def list_mcp_resources(  # pyright: ignore[reportUnusedFunction]
+        _ctx: RunContext[Any],
+    ) -> list[dict[str, str]]:
+        return [_resource_summary(r) for r in await provider.list_resources()]
+
+    @toolset.tool(description=READ_RESOURCE_DESCRIPTION)
+    async def read_mcp_resource(  # pyright: ignore[reportUnusedFunction]
+        _ctx: RunContext[Any],
+        uri: str,
+    ) -> str:
+        return _coerce_text(await provider.read_resource(uri))
+
+    if include_skills:
+
+        @toolset.tool(description=LIST_SKILLS_DESCRIPTION)
+        async def list_mcp_skills(  # pyright: ignore[reportUnusedFunction]
+            _ctx: RunContext[Any],
+        ) -> list[dict[str, str]]:
+            skills: list[dict[str, str]] = []
+            for resource in await provider.list_resources():
+                uri = _uri_str(resource)
+                if _is_skill_doc_uri(uri):
+                    skills.append(
+                        {
+                            "skill": _skill_id_from_uri(uri),
+                            "uri": uri,
+                            "description": getattr(resource, "description", "") or "",
+                        }
+                    )
+            return skills
+
+        @toolset.tool(description=LOAD_SKILL_DESCRIPTION)
+        async def load_mcp_skill(  # pyright: ignore[reportUnusedFunction]
+            _ctx: RunContext[Any],
+            skill: str,
+        ) -> str:
+            resources = await provider.list_resources()
+            skill_uris = [_uri_str(r) for r in resources if _is_skill_doc_uri(_uri_str(r))]
+            target = next(
+                (u for u in skill_uris if skill in (u, _skill_id_from_uri(u))),
+                None,
+            )
+            if target is None:
+                available = ", ".join(sorted(_skill_id_from_uri(u) for u in skill_uris)) or "none"
+                return (
+                    f"Error: MCP skill {skill!r} not found on server {server_name!r}. "
+                    f"Available: {available}"
+                )
+            return _coerce_text(await provider.read_resource(target))
+
+    return toolset

--- a/pydantic_deep/mcp/resources.py
+++ b/pydantic_deep/mcp/resources.py
@@ -9,12 +9,14 @@ by hand (see issue #178).
 :func:`create_mcp_resources_toolset` closes that gap: given anything that can
 ``list_resources()`` / ``read_resource(uri)`` (pydantic-ai's ``MCPToolset`` does), it
 returns a small ``FunctionToolset`` exposing model-visible tools to discover and read
-those resources, with first-class handling for ``SKILL.md`` skill resources.
+those resources, with first-class handling for ``SKILL.md`` skill resources. When the
+server publishes skills, the toolset also announces them in the system prompt, so the
+model knows the guidance exists before it reaches for the server's operational tools.
 """
 
 from __future__ import annotations
 
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol
 from urllib.parse import urlsplit
 
 from pydantic_ai._run_context import RunContext
@@ -34,8 +36,12 @@ SKILL_URI_SCHEME = "skill"
 #: Filename that marks a skill's entry document within a ``skill://`` resource.
 SKILL_DOC_NAME = "SKILL.md"
 
+LIST_RESOURCES_TOOL = "list_mcp_resources"
+READ_RESOURCE_TOOL = "read_mcp_resource"
+LIST_SKILLS_TOOL = "list_mcp_skills"
+LOAD_SKILL_TOOL = "load_mcp_skill"
 
-@runtime_checkable
+
 class MCPResourceProvider(Protocol):
     """The slice of ``MCPToolset`` this toolset needs — list and read resources."""
 
@@ -60,6 +66,10 @@ def _skill_id_from_uri(uri: str) -> str:
     return parts.netloc or parts.path.strip("/").split("/", 1)[0]
 
 
+def _prefixed(name: str, tool_prefix: str | None) -> str:
+    return f"{tool_prefix}_{name}" if tool_prefix else name
+
+
 def _coerce_text(content: Any) -> str:
     """Flatten ``read_resource``'s ``str | BinaryContent | list[...]`` into text.
 
@@ -69,7 +79,11 @@ def _coerce_text(content: Any) -> str:
     if isinstance(content, str):
         return content
     if isinstance(content, BinaryContent):
-        return f"[binary content: {content.media_type}, {len(content.data)} bytes]"
+        # BinaryContent's fields are invisible to pyright but present at runtime
+        # (upstream type-info gap); mypy's pydantic plugin sees them.
+        media_type = content.media_type  # type: ignore[attr-defined, unused-ignore]
+        size = len(content.data)  # type: ignore[attr-defined, unused-ignore]
+        return f"[binary content: {media_type}, {size} bytes]"
     if isinstance(content, list):
         return "\n".join(_coerce_text(part) for part in content)
     return str(content)
@@ -86,28 +100,136 @@ def _resource_summary(resource: Any) -> dict[str, str]:
     }
 
 
+def _skill_summary(resource: Any) -> dict[str, str]:
+    uri = _uri_str(resource)
+    return {
+        "skill": _skill_id_from_uri(uri),
+        "uri": uri,
+        "description": getattr(resource, "description", "") or "",
+    }
+
+
 LIST_RESOURCES_DESCRIPTION = """\
-List the resources published by this MCP server (docs, templates, skills).
+List the resources published by the `{server}` MCP server (docs, templates, skills).
 
 Resources are read-only data the server exposes alongside its tools. Returns each \
-resource's uri, name, description and mime type. Read one with `read_mcp_resource`."""
+resource's uri, name, description and mime type. Read one with `{read_resource}`."""
 
 READ_RESOURCE_DESCRIPTION = """\
-Read the contents of an MCP resource by its exact uri (from `list_mcp_resources`).
+Read a resource on the `{server}` MCP server by its exact uri (from `{list_resources}`).
 
 Returns the resource text. Binary resources are summarised as a short placeholder."""
 
 LIST_SKILLS_DESCRIPTION = """\
-List the skills this MCP server publishes as `skill://.../SKILL.md` resources.
+List the skills the `{server}` MCP server publishes as `skill://.../SKILL.md` resources.
 
 Skills carry operational guidance and tool-usage patterns for the server. Load one \
-with `load_mcp_skill` before using the server's operational tools."""
+with `{load_skill}` before using the server's operational tools."""
 
 LOAD_SKILL_DESCRIPTION = """\
-Load an MCP server skill's `SKILL.md` guidance by skill id or full uri.
+Load a skill's `SKILL.md` guidance from the `{server}` MCP server, by skill id or uri.
 
 Read the returned guidance before using the server's operational tools — it explains \
 how the server expects them to be used."""
+
+SKILLS_INSTRUCTIONS = """\
+The `{server}` MCP server publishes skills carrying operational guidance for its tools:
+
+{skills}
+
+Load the relevant one with `{load_skill}` before using that server's tools."""
+
+
+# An unreachable server must not abort the run: `make_resilient` guards listing a
+# toolset's tools, not calling them, so failures below are handed back to the model
+# as text instead of propagating out of `agent.run()`.
+async def _list_resources(
+    provider: MCPResourceProvider, server_name: str
+) -> tuple[list[Any], str | None]:
+    try:
+        return list(await provider.list_resources()), None
+    except Exception as exc:
+        return [], f"Error: could not list resources on MCP server {server_name!r}: {exc}"
+
+
+async def _read_resource(provider: MCPResourceProvider, server_name: str, uri: str) -> str:
+    try:
+        return _coerce_text(await provider.read_resource(uri))
+    except Exception as exc:
+        return f"Error: could not read {uri!r} from MCP server {server_name!r}: {exc}"
+
+
+async def _list_skills(
+    provider: MCPResourceProvider, server_name: str
+) -> tuple[list[dict[str, str]], str | None]:
+    resources, error = await _list_resources(provider, server_name)
+    if error is not None:
+        return [], error
+    return [_skill_summary(r) for r in resources if _is_skill_doc_uri(_uri_str(r))], None
+
+
+def _register_skill_tools(
+    toolset: FunctionToolset[Any],
+    provider: MCPResourceProvider,
+    server_name: str,
+    *,
+    list_skills_tool: str,
+    load_skill_tool: str,
+) -> None:
+    """Register the `skill://` tools and announce the server's skills up front."""
+
+    @toolset.tool(
+        name=list_skills_tool,
+        description=LIST_SKILLS_DESCRIPTION.format(server=server_name, load_skill=load_skill_tool),
+    )
+    async def list_mcp_skills(  # pyright: ignore[reportUnusedFunction]
+        _ctx: RunContext[Any],
+    ) -> list[dict[str, str]] | str:
+        skills, error = await _list_skills(provider, server_name)
+        return error if error is not None else skills
+
+    @toolset.tool(
+        name=load_skill_tool,
+        description=LOAD_SKILL_DESCRIPTION.format(server=server_name),
+    )
+    async def load_mcp_skill(  # pyright: ignore[reportUnusedFunction]
+        _ctx: RunContext[Any],
+        skill: str,
+    ) -> str:
+        skills, error = await _list_skills(provider, server_name)
+        if error is not None:
+            return error
+        target = next((s["uri"] for s in skills if skill in (s["uri"], s["skill"])), None)
+        if target is None:
+            available = ", ".join(sorted(s["skill"] for s in skills)) or "none"
+            return (
+                f"Error: MCP skill {skill!r} not found on server {server_name!r}. "
+                f"Available: {available}"
+            )
+        return await _read_resource(provider, server_name, target)
+
+    @toolset.instructions
+    async def skills_instructions(  # pyright: ignore[reportUnusedFunction]
+        _ctx: RunContext[Any],
+    ) -> str:
+        """Announce the server's skills so the model knows they exist up front.
+
+        Issue #178 asks for the guidance to reach the model *before* it starts using
+        the server's operational tools; a tool description alone only helps if the
+        model happens to go looking. An empty string leaves the system prompt
+        untouched, which is what we want when the server publishes no skills or
+        can't be reached.
+        """
+        skills, error = await _list_skills(provider, server_name)
+        if error is not None or not skills:
+            return ""
+        listing = "\n".join(
+            f"- `{s['skill']}`" + (f" \u2014 {s['description']}" if s["description"] else "")
+            for s in skills
+        )
+        return SKILLS_INSTRUCTIONS.format(
+            server=server_name, skills=listing, load_skill=load_skill_tool
+        )
 
 
 def create_mcp_resources_toolset(
@@ -116,73 +238,67 @@ def create_mcp_resources_toolset(
     server_name: str,
     id: str | None = None,
     include_skills: bool = True,
-) -> FunctionToolset:
+    tool_prefix: str | None = None,
+) -> FunctionToolset[Any]:
     """Build a toolset that exposes an MCP server's resources to the model.
 
     Args:
         provider: The connected MCP server (anything with ``list_resources`` /
             ``read_resource``). ``MCPToolset`` manages its own connection, so the
             tools work whether or not the toolset is currently entered.
-        server_name: Server identifier, used in the toolset id and skill error text.
+        server_name: Server identifier, used in the toolset id, the tool descriptions
+            and the skill error text.
         id: Explicit toolset id (defaults to ``mcp-resources-<server_name>``).
         include_skills: Also register `list_mcp_skills` / `load_mcp_skill` for
-            ``skill://`` resources.
+            ``skill://`` resources, and announce the server's skills in the system
+            prompt so the model knows they exist before using the server's tools.
+        tool_prefix: Prepended to every tool name as ``<prefix>_<name>``. Needed when
+            more than one server exposes its resources — the tool names are otherwise
+            identical and pydantic-ai rejects the collision, failing the whole run.
+            :meth:`MCPRegistry.build_active` always passes one.
 
     Returns:
         A ``FunctionToolset`` with `list_mcp_resources`, `read_mcp_resource`, and
         (when ``include_skills``) the two skill tools.
     """
-    toolset = FunctionToolset(id=id or f"mcp-resources-{server_name}")
+    list_resources_tool = _prefixed(LIST_RESOURCES_TOOL, tool_prefix)
+    read_resource_tool = _prefixed(READ_RESOURCE_TOOL, tool_prefix)
 
-    @toolset.tool(description=LIST_RESOURCES_DESCRIPTION)
+    toolset = FunctionToolset[Any](id=id or f"mcp-resources-{server_name}")
+
+    @toolset.tool(
+        name=list_resources_tool,
+        description=LIST_RESOURCES_DESCRIPTION.format(
+            server=server_name, read_resource=read_resource_tool
+        ),
+    )
     async def list_mcp_resources(  # pyright: ignore[reportUnusedFunction]
         _ctx: RunContext[Any],
-    ) -> list[dict[str, str]]:
-        return [_resource_summary(r) for r in await provider.list_resources()]
+    ) -> list[dict[str, str]] | str:
+        resources, error = await _list_resources(provider, server_name)
+        if error is not None:
+            return error
+        return [_resource_summary(r) for r in resources]
 
-    @toolset.tool(description=READ_RESOURCE_DESCRIPTION)
+    @toolset.tool(
+        name=read_resource_tool,
+        description=READ_RESOURCE_DESCRIPTION.format(
+            server=server_name, list_resources=list_resources_tool
+        ),
+    )
     async def read_mcp_resource(  # pyright: ignore[reportUnusedFunction]
         _ctx: RunContext[Any],
         uri: str,
     ) -> str:
-        return _coerce_text(await provider.read_resource(uri))
+        return await _read_resource(provider, server_name, uri)
 
     if include_skills:
-
-        @toolset.tool(description=LIST_SKILLS_DESCRIPTION)
-        async def list_mcp_skills(  # pyright: ignore[reportUnusedFunction]
-            _ctx: RunContext[Any],
-        ) -> list[dict[str, str]]:
-            skills: list[dict[str, str]] = []
-            for resource in await provider.list_resources():
-                uri = _uri_str(resource)
-                if _is_skill_doc_uri(uri):
-                    skills.append(
-                        {
-                            "skill": _skill_id_from_uri(uri),
-                            "uri": uri,
-                            "description": getattr(resource, "description", "") or "",
-                        }
-                    )
-            return skills
-
-        @toolset.tool(description=LOAD_SKILL_DESCRIPTION)
-        async def load_mcp_skill(  # pyright: ignore[reportUnusedFunction]
-            _ctx: RunContext[Any],
-            skill: str,
-        ) -> str:
-            resources = await provider.list_resources()
-            skill_uris = [_uri_str(r) for r in resources if _is_skill_doc_uri(_uri_str(r))]
-            target = next(
-                (u for u in skill_uris if skill in (u, _skill_id_from_uri(u))),
-                None,
-            )
-            if target is None:
-                available = ", ".join(sorted(_skill_id_from_uri(u) for u in skill_uris)) or "none"
-                return (
-                    f"Error: MCP skill {skill!r} not found on server {server_name!r}. "
-                    f"Available: {available}"
-                )
-            return _coerce_text(await provider.read_resource(target))
+        _register_skill_tools(
+            toolset,
+            provider,
+            server_name,
+            list_skills_tool=_prefixed(LIST_SKILLS_TOOL, tool_prefix),
+            load_skill_tool=_prefixed(LOAD_SKILL_TOOL, tool_prefix),
+        )
 
     return toolset

--- a/tests/test_mcp_resources.py
+++ b/tests/test_mcp_resources.py
@@ -1,0 +1,281 @@
+"""Tests for model-visible MCP resource/skill support (issue #178)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from pydantic_ai._run_context import RunContext
+from pydantic_ai.messages import BinaryContent
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.toolsets import FunctionToolset
+from pydantic_ai.usage import RunUsage
+
+from pydantic_deep.mcp.resources import (
+    SKILL_URI_SCHEME,
+    _coerce_text,
+    _is_skill_doc_uri,
+    _skill_id_from_uri,
+    create_mcp_resources_toolset,
+)
+
+
+@dataclass
+class _FakeResource:
+    uri: str
+    name: str = ""
+    description: str = ""
+    mime_type: str = ""
+
+
+@dataclass
+class _FakeProvider:
+    """Stand-in for a connected ``MCPToolset``."""
+
+    resources: list[_FakeResource] = field(default_factory=list)
+    contents: dict[str, Any] = field(default_factory=dict)
+    reads: list[str] = field(default_factory=list)
+
+    async def list_resources(self) -> list[_FakeResource]:
+        return self.resources
+
+    async def read_resource(self, uri: str) -> Any:
+        self.reads.append(uri)
+        return self.contents.get(uri, "")
+
+
+def _ctx() -> RunContext[Any]:
+    return RunContext[Any](
+        deps=None,
+        model=TestModel(),
+        usage=RunUsage(),
+        retry=0,
+        run_step=0,
+        tool_name=None,
+        tool_call_id=None,
+    )
+
+
+async def _call(toolset: FunctionToolset, name: str, args: dict[str, Any] | None = None) -> Any:
+    ctx = _ctx()
+    tools = await toolset.get_tools(ctx)
+    return await toolset.call_tool(name, args or {}, ctx, tools[name])
+
+
+class TestHelpers:
+    def test_is_skill_doc_uri(self) -> None:
+        assert _is_skill_doc_uri("skill://service-mcp/SKILL.md") is True
+        assert _is_skill_doc_uri("skill://service-mcp/_manifest") is False
+        assert _is_skill_doc_uri("file:///x/SKILL.md") is False
+
+    def test_skill_id_from_uri_netloc(self) -> None:
+        assert _skill_id_from_uri("skill://service-mcp/SKILL.md") == "service-mcp"
+
+    def test_skill_id_from_uri_path_only(self) -> None:
+        # No netloc → first path segment.
+        assert _skill_id_from_uri("skill:///alpha/SKILL.md") == "alpha"
+
+    def test_coerce_text_str(self) -> None:
+        assert _coerce_text("hello") == "hello"
+
+    def test_coerce_text_binary(self) -> None:
+        out = _coerce_text(BinaryContent(data=b"1234", media_type="image/png"))
+        assert "binary content" in out
+        assert "image/png" in out
+
+    def test_coerce_text_list_mixed(self) -> None:
+        out = _coerce_text(["a", BinaryContent(data=b"x", media_type="text/plain"), "b"])
+        assert out.startswith("a\n")
+        assert out.endswith("\nb")
+        assert "binary content" in out
+
+    def test_coerce_text_other(self) -> None:
+        assert _coerce_text(123) == "123"
+
+
+class TestResourceTools:
+    async def test_list_mcp_resources(self) -> None:
+        provider = _FakeProvider(
+            resources=[
+                _FakeResource(
+                    uri="skill://svc/SKILL.md",
+                    name="svc",
+                    description="d",
+                    mime_type="text/markdown",
+                ),
+                _FakeResource(uri="res://svc/data.json", name="data"),
+            ]
+        )
+        toolset = create_mcp_resources_toolset(provider, server_name="svc")
+        result = await _call(toolset, "list_mcp_resources")
+        assert result == [
+            {
+                "uri": "skill://svc/SKILL.md",
+                "name": "svc",
+                "description": "d",
+                "mime_type": "text/markdown",
+            },
+            {"uri": "res://svc/data.json", "name": "data", "description": "", "mime_type": ""},
+        ]
+
+    async def test_read_mcp_resource(self) -> None:
+        provider = _FakeProvider(contents={"skill://svc/SKILL.md": "# guidance"})
+        toolset = create_mcp_resources_toolset(provider, server_name="svc")
+        result = await _call(toolset, "read_mcp_resource", {"uri": "skill://svc/SKILL.md"})
+        assert result == "# guidance"
+        assert provider.reads == ["skill://svc/SKILL.md"]
+
+    async def test_mime_type_camel_case_fallback(self) -> None:
+        # A raw MCP SDK resource may expose `mimeType` rather than `mime_type`.
+        class _CamelResource:
+            uri = "res://svc/x"
+            name = "x"
+            description = ""
+            mimeType = "application/json"
+
+        toolset = create_mcp_resources_toolset(
+            _FakeProvider(resources=[_CamelResource()]),
+            server_name="svc",
+        )
+        result = await _call(toolset, "list_mcp_resources")
+        assert result[0]["mime_type"] == "application/json"
+
+
+class TestSkillTools:
+    def _provider(self) -> _FakeProvider:
+        return _FakeProvider(
+            resources=[
+                _FakeResource(uri="skill://svc/SKILL.md", description="Service guidance"),
+                _FakeResource(uri="skill://svc/_manifest"),
+                _FakeResource(uri="skill://other/SKILL.md"),
+                _FakeResource(uri="res://svc/data.json"),
+            ],
+            contents={"skill://svc/SKILL.md": "# svc skill"},
+        )
+
+    async def test_list_mcp_skills_filters_skill_docs(self) -> None:
+        toolset = create_mcp_resources_toolset(self._provider(), server_name="svc")
+        result = await _call(toolset, "list_mcp_skills")
+        assert result == [
+            {"skill": "svc", "uri": "skill://svc/SKILL.md", "description": "Service guidance"},
+            {"skill": "other", "uri": "skill://other/SKILL.md", "description": ""},
+        ]
+
+    async def test_load_mcp_skill_by_id(self) -> None:
+        toolset = create_mcp_resources_toolset(self._provider(), server_name="svc")
+        result = await _call(toolset, "load_mcp_skill", {"skill": "svc"})
+        assert result == "# svc skill"
+
+    async def test_load_mcp_skill_by_uri(self) -> None:
+        toolset = create_mcp_resources_toolset(self._provider(), server_name="svc")
+        result = await _call(toolset, "load_mcp_skill", {"skill": "skill://svc/SKILL.md"})
+        assert result == "# svc skill"
+
+    async def test_load_mcp_skill_not_found(self) -> None:
+        toolset = create_mcp_resources_toolset(self._provider(), server_name="svc")
+        result = await _call(toolset, "load_mcp_skill", {"skill": "missing"})
+        assert "not found" in result
+        assert "other" in result and "svc" in result
+
+    async def test_load_mcp_skill_not_found_none_available(self) -> None:
+        toolset = create_mcp_resources_toolset(_FakeProvider(), server_name="svc")
+        result = await _call(toolset, "load_mcp_skill", {"skill": "x"})
+        assert "Available: none" in result
+
+
+class TestToolRegistration:
+    async def test_include_skills_false_omits_skill_tools(self) -> None:
+        toolset = create_mcp_resources_toolset(
+            _FakeProvider(), server_name="svc", include_skills=False
+        )
+        tools = await toolset.get_tools(_ctx())
+        assert set(tools) == {"list_mcp_resources", "read_mcp_resource"}
+
+    async def test_include_skills_true_adds_skill_tools(self) -> None:
+        toolset = create_mcp_resources_toolset(_FakeProvider(), server_name="svc")
+        tools = await toolset.get_tools(_ctx())
+        assert set(tools) == {
+            "list_mcp_resources",
+            "read_mcp_resource",
+            "list_mcp_skills",
+            "load_mcp_skill",
+        }
+
+    def test_default_id(self) -> None:
+        toolset = create_mcp_resources_toolset(_FakeProvider(), server_name="svc")
+        assert toolset.id == "mcp-resources-svc"
+
+    def test_explicit_id(self) -> None:
+        toolset = create_mcp_resources_toolset(_FakeProvider(), server_name="svc", id="custom")
+        assert toolset.id == "custom"
+
+    def test_scheme_constant(self) -> None:
+        assert SKILL_URI_SCHEME == "skill"
+
+
+class TestConfigFlags:
+    def test_defaults_false(self) -> None:
+        from pydantic_deep.mcp import MCPServerConfig
+
+        cfg = MCPServerConfig(name="x", transport="http", url="http://x/mcp")
+        assert cfg.include_resources is False
+        assert cfg.include_skills is False
+
+    def test_roundtrip(self) -> None:
+        from pydantic_deep.mcp import MCPServerConfig
+
+        cfg = MCPServerConfig(
+            name="svc",
+            transport="http",
+            url="http://x/mcp",
+            include_resources=True,
+            include_skills=True,
+        )
+        assert MCPServerConfig.from_dict(cfg.to_dict()) == cfg
+
+    def test_loader_reads_flags_http(self) -> None:
+        from pydantic_deep.mcp import parse_mcp_servers
+
+        configs = parse_mcp_servers(
+            {"svc": {"type": "http", "url": "http://x/mcp", "include_skills": True}}
+        )
+        assert configs[0].include_skills is True
+        assert configs[0].include_resources is False
+
+    def test_loader_reads_flags_stdio(self) -> None:
+        from pydantic_deep.mcp import parse_mcp_servers
+
+        configs = parse_mcp_servers({"svc": {"command": "run", "include_resources": True}})
+        assert configs[0].include_resources is True
+
+
+class TestBuildActiveWiring:
+    def test_plain_server_yields_one_toolset(self) -> None:
+        from pydantic_deep.mcp import MCPRegistry, MCPServerConfig
+
+        reg = MCPRegistry(resolver=lambda _k: None)
+        reg.add(MCPServerConfig(name="x", transport="http", url="http://x/mcp"))
+        assert len(reg.build_active()) == 1
+
+    def test_skills_server_adds_resources_toolset(self) -> None:
+        from pydantic_deep.mcp import MCPRegistry, MCPServerConfig
+
+        reg = MCPRegistry(resolver=lambda _k: None)
+        reg.add(
+            MCPServerConfig(name="svc", transport="http", url="http://x/mcp", include_skills=True)
+        )
+        active = reg.build_active()
+        assert len(active) == 2
+        # The second toolset is the resources bridge bound to the same server.
+        assert active[1].wrapped.id == "mcp-resources-svc"  # type: ignore[attr-defined]
+
+    def test_resources_only_flag_also_adds_toolset(self) -> None:
+        from pydantic_deep.mcp import MCPRegistry, MCPServerConfig
+
+        reg = MCPRegistry(resolver=lambda _k: None)
+        reg.add(
+            MCPServerConfig(
+                name="svc", transport="http", url="http://x/mcp", include_resources=True
+            )
+        )
+        assert len(reg.build_active()) == 2

--- a/tests/test_mcp_resources.py
+++ b/tests/test_mcp_resources.py
@@ -8,7 +8,7 @@ from typing import Any
 from pydantic_ai._run_context import RunContext
 from pydantic_ai.messages import BinaryContent
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.toolsets import FunctionToolset
+from pydantic_ai.toolsets import CombinedToolset, FunctionToolset
 from pydantic_ai.usage import RunUsage
 
 from pydantic_deep.mcp.resources import (
@@ -42,6 +42,25 @@ class _FakeProvider:
     async def read_resource(self, uri: str) -> Any:
         self.reads.append(uri)
         return self.contents.get(uri, "")
+
+
+@dataclass
+class _UnreachableProvider(_FakeProvider):
+    """A server that can't be reached — every call raises."""
+
+    async def list_resources(self) -> list[_FakeResource]:
+        raise ConnectionError("server down")
+
+    async def read_resource(self, uri: str) -> Any:
+        raise ConnectionError("server down")
+
+
+@dataclass
+class _ReadFailsProvider(_FakeProvider):
+    """A server that lists fine but drops the connection on read."""
+
+    async def read_resource(self, uri: str) -> Any:
+        raise ConnectionError("read failed")
 
 
 def _ctx() -> RunContext[Any]:
@@ -183,6 +202,132 @@ class TestSkillTools:
         assert "Available: none" in result
 
 
+class TestUnreachableServer:
+    """A server that is down must degrade to an error string, never abort the run.
+
+    ``make_resilient`` only guards listing a toolset's tools, so an exception raised
+    inside one of these tools would propagate straight out of ``agent.run()``.
+    """
+
+    async def test_list_mcp_resources_reports_error(self) -> None:
+        toolset = create_mcp_resources_toolset(_UnreachableProvider(), server_name="svc")
+        result = await _call(toolset, "list_mcp_resources")
+        assert result == "Error: could not list resources on MCP server 'svc': server down"
+
+    async def test_read_mcp_resource_reports_error(self) -> None:
+        toolset = create_mcp_resources_toolset(_UnreachableProvider(), server_name="svc")
+        result = await _call(toolset, "read_mcp_resource", {"uri": "res://svc/x"})
+        assert result == "Error: could not read 'res://svc/x' from MCP server 'svc': server down"
+
+    async def test_list_mcp_skills_reports_error(self) -> None:
+        toolset = create_mcp_resources_toolset(_UnreachableProvider(), server_name="svc")
+        result = await _call(toolset, "list_mcp_skills")
+        assert "could not list resources" in result
+
+    async def test_load_mcp_skill_reports_list_error(self) -> None:
+        toolset = create_mcp_resources_toolset(_UnreachableProvider(), server_name="svc")
+        result = await _call(toolset, "load_mcp_skill", {"skill": "svc"})
+        assert "could not list resources" in result
+
+    async def test_load_mcp_skill_reports_read_error(self) -> None:
+        provider = _ReadFailsProvider(resources=[_FakeResource(uri="skill://svc/SKILL.md")])
+        toolset = create_mcp_resources_toolset(provider, server_name="svc")
+        result = await _call(toolset, "load_mcp_skill", {"skill": "svc"})
+        assert "could not read 'skill://svc/SKILL.md'" in result
+
+
+class TestSkillsInstructions:
+    """The skills must be announced up front, not only via a tool description."""
+
+    async def test_announces_skills_with_descriptions(self) -> None:
+        provider = _FakeProvider(
+            resources=[
+                _FakeResource(uri="skill://svc/SKILL.md", description="Service guidance"),
+                _FakeResource(uri="skill://other/SKILL.md"),
+                _FakeResource(uri="res://svc/data.json"),
+            ]
+        )
+        toolset = create_mcp_resources_toolset(provider, server_name="svc")
+        parts = await toolset.get_instructions(_ctx())
+        assert parts is not None
+        content = parts[0].content
+        assert "`svc` MCP server publishes skills" in content
+        assert "- `svc` — Service guidance" in content
+        assert "- `other`\n" in content
+        assert "data.json" not in content
+        assert "`load_mcp_skill`" in content
+
+    async def test_prefixed_instructions_name_the_prefixed_tool(self) -> None:
+        provider = _FakeProvider(resources=[_FakeResource(uri="skill://svc/SKILL.md")])
+        toolset = create_mcp_resources_toolset(provider, server_name="svc", tool_prefix="svc")
+        parts = await toolset.get_instructions(_ctx())
+        assert parts is not None
+        assert "`svc_load_mcp_skill`" in parts[0].content
+
+    async def test_no_skills_leaves_prompt_untouched(self) -> None:
+        toolset = create_mcp_resources_toolset(
+            _FakeProvider(resources=[_FakeResource(uri="res://svc/data.json")]),
+            server_name="svc",
+        )
+        assert await toolset.get_instructions(_ctx()) is None
+
+    async def test_unreachable_server_leaves_prompt_untouched(self) -> None:
+        toolset = create_mcp_resources_toolset(_UnreachableProvider(), server_name="svc")
+        assert await toolset.get_instructions(_ctx()) is None
+
+    async def test_include_skills_false_announces_nothing(self) -> None:
+        provider = _FakeProvider(resources=[_FakeResource(uri="skill://svc/SKILL.md")])
+        toolset = create_mcp_resources_toolset(provider, server_name="svc", include_skills=False)
+        assert await toolset.get_instructions(_ctx()) is None
+
+
+class TestToolPrefix:
+    async def test_prefix_renames_every_tool(self) -> None:
+        toolset = create_mcp_resources_toolset(
+            _FakeProvider(), server_name="svc", tool_prefix="svc"
+        )
+        tools = await toolset.get_tools(_ctx())
+        assert set(tools) == {
+            "svc_list_mcp_resources",
+            "svc_read_mcp_resource",
+            "svc_list_mcp_skills",
+            "svc_load_mcp_skill",
+        }
+
+    async def test_descriptions_reference_the_prefixed_names(self) -> None:
+        toolset = create_mcp_resources_toolset(
+            _FakeProvider(), server_name="svc", tool_prefix="svc"
+        )
+        tools = await toolset.get_tools(_ctx())
+        assert "`svc_read_mcp_resource`" in (
+            tools["svc_list_mcp_resources"].tool_def.description or ""
+        )
+        assert "`svc_load_mcp_skill`" in (tools["svc_list_mcp_skills"].tool_def.description or "")
+
+    async def test_prefixed_tools_still_call_through(self) -> None:
+        provider = _FakeProvider(contents={"res://svc/x": "body"})
+        toolset = create_mcp_resources_toolset(provider, server_name="svc", tool_prefix="svc")
+        result = await _call(toolset, "svc_read_mcp_resource", {"uri": "res://svc/x"})
+        assert result == "body"
+
+    async def test_two_servers_do_not_collide(self) -> None:
+        # Without a per-server prefix `CombinedToolset` raises `UserError` on the
+        # duplicate tool names and the whole agent run fails.
+        combined = CombinedToolset(
+            [
+                create_mcp_resources_toolset(
+                    _FakeProvider(), server_name="alpha", tool_prefix="alpha"
+                ),
+                create_mcp_resources_toolset(
+                    _FakeProvider(), server_name="beta", tool_prefix="beta"
+                ),
+            ]
+        )
+        tools = await combined.get_tools(_ctx())
+        assert "alpha_list_mcp_resources" in tools
+        assert "beta_list_mcp_resources" in tools
+
+
 class TestToolRegistration:
     async def test_include_skills_false_omits_skill_tools(self) -> None:
         toolset = create_mcp_resources_toolset(
@@ -269,7 +414,7 @@ class TestBuildActiveWiring:
         # The second toolset is the resources bridge bound to the same server.
         assert active[1].wrapped.id == "mcp-resources-svc"  # type: ignore[attr-defined]
 
-    def test_resources_only_flag_also_adds_toolset(self) -> None:
+    async def test_resources_only_flag_omits_the_skill_tools(self) -> None:
         from pydantic_deep.mcp import MCPRegistry, MCPServerConfig
 
         reg = MCPRegistry(resolver=lambda _k: None)
@@ -278,4 +423,52 @@ class TestBuildActiveWiring:
                 name="svc", transport="http", url="http://x/mcp", include_resources=True
             )
         )
-        assert len(reg.build_active()) == 2
+        active = reg.build_active()
+        assert len(active) == 2
+        tools = await active[1].get_tools(_ctx())
+        assert set(tools) == {"svc_list_mcp_resources", "svc_read_mcp_resource"}
+
+    async def test_tools_are_prefixed_with_the_server_name(self) -> None:
+        from pydantic_deep.mcp import MCPRegistry, MCPServerConfig
+
+        reg = MCPRegistry(resolver=lambda _k: None)
+        # A name that isn't a legal tool-name fragment is sanitised, not passed through.
+        reg.add(
+            MCPServerConfig(
+                name="svc one.2", transport="http", url="http://x/mcp", include_skills=True
+            )
+        )
+        tools = await reg.build_active()[1].get_tools(_ctx())
+        assert "svc_one_2_load_mcp_skill" in tools
+
+    async def test_explicit_tool_prefix_wins(self) -> None:
+        from pydantic_deep.mcp import MCPRegistry, MCPServerConfig
+
+        reg = MCPRegistry(resolver=lambda _k: None)
+        reg.add(
+            MCPServerConfig(
+                name="svc",
+                transport="http",
+                url="http://x/mcp",
+                tool_prefix="s",
+                include_skills=True,
+            )
+        )
+        tools = await reg.build_active()[1].get_tools(_ctx())
+        assert "s_load_mcp_skill" in tools
+
+    async def test_two_resource_servers_can_be_active_together(self) -> None:
+        from pydantic_deep.mcp import MCPRegistry, MCPServerConfig
+
+        reg = MCPRegistry(resolver=lambda _k: None)
+        for name in ("alpha", "beta"):
+            reg.add(
+                MCPServerConfig(
+                    name=name, transport="http", url=f"http://{name}/mcp", include_skills=True
+                )
+            )
+        active = reg.build_active()
+        assert len(active) == 4
+        resource_tools = await CombinedToolset([active[1], active[3]]).get_tools(_ctx())
+        assert "alpha_load_mcp_skill" in resource_tools
+        assert "beta_load_mcp_skill" in resource_tools


### PR DESCRIPTION
## Changes

### Summary

Let an MCP server's **resources** — docs, templates, and FastMCP `skill://.../SKILL.md` skills — be discovered and read by the model. pydantic-ai only surfaces a server's *tools*, so a server that correctly publishes skills via `SkillsDirectoryProvider` was invisible to a delegated agent unless the app hand-rolled a bridge.

### Business Context

Requested in #178. The author's MCP server exposes bundled skills as resources (`skill://service-mcp/SKILL.md`), readable programmatically via `MCPToolset.list_resources()` / `read_resource()` — but a delegated MCP subagent had no model-visible way to reach them. FastMCP skills are meant to carry operational guidance and tool-usage patterns, so without client-side support that guidance never reaches the model. This adds it once, in the framework, instead of every app reimplementing the same `FunctionToolset` workaround.

### Changes

- **`mcp/resources.py`** (new) — `create_mcp_resources_toolset(provider, …)` returns a `FunctionToolset` exposing `list_mcp_resources` / `read_mcp_resource`, plus `list_mcp_skills` / `load_mcp_skill` (by skill id or full uri) when `include_skills` is set. Binds to any `MCPResourceProvider` (structurally, an `MCPToolset`); since `list_resources`/`read_resource` manage their own connection, the tools work whether or not the toolset is currently entered.
- **`mcp/config.py`** — `MCPServerConfig` gains `include_resources` / `include_skills` (default off, round-trip through `to_dict`/`from_dict`).
- **`mcp/registry.py`** — split out `_build_raw_mcp_toolset` / `_apply_tool_prefix` (public `build_mcp_server` behaviour unchanged); `build_active` attaches the resources toolset bound to the **same** `MCPToolset`, so tools and resources share one connection. Each is `make_resilient`-wrapped as before.
- **`mcp/loader.py`** — the standard `mcpServers` JSON can carry the two flags.
- **exports** — `create_mcp_resources_toolset` / `MCPResourceProvider` / `SKILL_URI_SCHEME` from `pydantic_deep.mcp` and the top-level package.
- **docs** — "create_mcp_resources_toolset" section in `docs/api/mcp.md`; CHANGELOG entry.

The flags default off — most servers are used for tools only, and this keeps the resource-reading traffic opt-in per server.

### Verification

`tests/test_mcp_resources.py` (30 tests) covers the helpers (skill-uri detection, id parsing, text coercion of `str` / `BinaryContent` / `list`), all four tools against a fake provider, `include_skills` on/off registration, config round-trip, loader flags, and the `build_active` wiring (plain server → 1 toolset; `include_skills`/`include_resources` → 2, resources bound to the same server).

```
$ uv run pytest tests/test_mcp_resources.py -q
..............................                                           [100%]
30 passed in 0.10s
```

Full gate green: `make test` — **2744 passed, 100% coverage**; `ruff check` + `ruff format --check` clean; `mypy pydantic_deep tests` and `pyright` 0 errors.

Ergonomics match the shape requested in the issue:

```python
from pydantic_deep.mcp import MCPRegistry, MCPServerConfig

registry = MCPRegistry([
    MCPServerConfig(
        name="service",
        transport="http",
        url="https://example.com/mcp/",
        include_skills=True,
    ),
])
mcp_servers = registry.build_active()  # tools toolset + resources toolset
```

### Linked Issues

Closes #178 