### PR TITLE
fix: keep the todo system prompt static (#182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - An unreachable server returns the failure as tool text rather than raising out of `agent.run()`, matching how `make_resilient` degrades the tools toolset.
   - New export: `create_mcp_resources_toolset` (also `MCPResourceProvider`, `SKILL_URI_SCHEME`, `SKILL_DOC_NAME` from `pydantic_deep.mcp`).
 
+### Fixed
+
+- **Todo mutations no longer rewrite the system prompt** ([#182](https://github.com/vstorm-co/pydantic-deepagents/issues/182)) (`pydantic_deep/instructions.py`, `pydantic_deep/agent.py`, `pydantic_deep/spec.py`, `pydantic_deep/deps.py`). `create_deep_agent` doesn't use `TodoCapability` — it builds its own instruction providers — so the static-by-default prompt introduced in `pydantic-ai-todo` 0.2.7 never applied here: `make_todo_section` called `get_todo_system_prompt(proxy)`, which appends `## Current Todos` whenever the run has any. The instructions open the provider's prompt-cache prefix, so every `write_todos` / `update_todo_status` invalidated the whole cached prefix mid-run. The todo section is now the static `TODO_SYSTEM_PROMPT`, with the live list behind a new `include_current_todos=True` (also a `DeepAgentSpec` field), matching the upstream flag name. Reported by [@jb2197](https://github.com/jb2197).
+  - The instruction providers no longer touch the todo proxy at all, so `build_instruction_providers` drops its `todo_proxy` argument. `_TodoProxyBinder` re-binds the proxy in each tool's own `contextvars` context (issue [#148](https://github.com/vstorm-co/pydantic-deepagents/issues/148)), which was always the only binding the tools saw. The end-to-end `write_todos` persistence test covers this.
+  - The opt-in list is appended as its own section, so it composes with `tool_search=True` instead of being dropped by the lean todo section.
+  - `DeepAgentDeps.get_todo_prompt()` — until now unused by the library — is what renders that section, and now includes each todo's id (`- [ ] [id] content`, matching upstream) so the model can address a task with `update_todo_status` without re-reading the list.
+  - The 0.3.37 note below claimed pydantic-deep's prompt behavior was unaffected by the upstream default. It wasn't; this is that fix.
+
 ## [0.3.37] - 2026-07-22
 
 A CLI paste fix and raised floors on the vstorm-co packages, bringing backend

--- a/docs/api/agent.md
+++ b/docs/api/agent.md
@@ -45,6 +45,7 @@
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `include_todo` | `bool` | `True` | Include TodoToolset |
+| `include_current_todos` | `bool` | `False` | Inject the live todo list into the system prompt (invalidates the provider's prompt cache on every mutation) |
 | `include_filesystem` | `bool` | `True` | Include Console Toolset |
 | `include_subagents` | `bool` | `True` | Include SubAgentToolset |
 | `include_skills` | `bool` | `True` | Include SkillsToolset |

--- a/docs/c4/4a-deep-dive-agent-factory.md
+++ b/docs/c4/4a-deep-dive-agent-factory.md
@@ -48,6 +48,7 @@ The 70+ parameters are organized into these logical groups:
 
 **Include Flags (toggle toolsets):**
 - `include_todo` — Todo planning toolset (default: True)
+- `include_current_todos` — Inject the live todo list into the prompt (default: False; on, every mutation invalidates the provider's prompt-cache prefix)
 - `include_filesystem` — Console/filesystem toolset (default: True)
 - `include_subagents` — Task delegation toolset (default: True)
 - `include_skills` — Skill discovery/execution (default: True)
@@ -179,9 +180,10 @@ def dynamic_instructions(ctx: Any) -> str:
     uploads_prompt = ctx.deps.get_uploads_summary()
     if uploads_prompt:
         parts.append(uploads_prompt)
-    if include_todo and _todo_proxy is not None:
-        _todo_proxy._deps = ctx.deps
-        todo_prompt = get_todo_system_prompt(_todo_proxy)
+    if include_todo:
+        parts.append(TODO_SYSTEM_PROMPT)  # static — keeps the cache prefix stable
+        if include_current_todos:
+            parts.append(ctx.deps.get_todo_prompt())
         ...
 ```
 
@@ -324,9 +326,10 @@ def __post_init__(self) -> None:
 
 #### `get_todo_prompt()`
 
-Generates a system prompt section from the current todo list:
+Generates a system prompt section from the current todo list. Only rendered when
+the agent opts in with `include_current_todos=True`:
 
-```pydantic_deep/deps.py#L40-53
+```pydantic_deep/deps.py#L95-114
 def get_todo_prompt(self) -> str:
     if not self.todos:
         return ""
@@ -336,8 +339,9 @@ def get_todo_prompt(self) -> str:
             "pending": "[ ]",
             "in_progress": "[*]",
             "completed": "[x]",
+            "blocked": "[!]",
         }.get(todo.status, "[ ]")
-        lines.append(f"- {status_icon} {todo.content}")
+        lines.append(f"- {status_icon} [{todo.id}] {todo.content}")
     return "\n".join(lines)
 ```
 
@@ -454,7 +458,7 @@ With `extra="forbid"`, any unknown field raises a validation error. The model ha
 - `model`, `instructions`, `output_style`, `styles_dir`, `retries`
 
 **Include Flags:**
-- `include_todo`, `include_filesystem`, `include_subagents`, `include_skills`, `include_builtin_subagents`, `include_plan`, `include_execute`, `include_memory`, `include_checkpoints`, `include_teams`, `web_search`, `web_fetch`, `thinking`, `include_history_archive`
+- `include_todo`, `include_current_todos`, `include_filesystem`, `include_subagents`, `include_skills`, `include_builtin_subagents`, `include_plan`, `include_execute`, `include_memory`, `include_checkpoints`, `include_teams`, `web_search`, `web_fetch`, `thinking`, `include_history_archive`
 
 **Subagent Config:**
 - `subagents`, `skill_directories`, `max_nesting_depth`
@@ -680,11 +684,11 @@ Each model turn:
     ┌─────────────────────────────────────────────────────────┐
     │  dynamic_instructions(ctx)                              │
     │                                                         │
-    │  1. Bind _todo_proxy._deps = ctx.deps                   │
-    │  2. Collect parts:                                      │
+    │  1. Collect parts:                                      │
     │     ├── get_uploads_summary()  (uploaded files)         │
-    │     ├── get_todo_system_prompt() (todos via proxy)      │
+    │     ├── TODO_SYSTEM_PROMPT (static todo workflow)       │
+    │     ├── get_todo_prompt() (only if include_current_todos)│
     │     ├── get_console_system_prompt() (edit format)       │
     │     └── get_subagent_system_prompt() (subagent list)    │
-    │  3. Return joined parts as dynamic instructions         │
+    │  2. Return joined parts as dynamic instructions         │
     └─────────────────────────────────────────────────────────┘

--- a/docs/concepts/agents.md
+++ b/docs/concepts/agents.md
@@ -364,7 +364,9 @@ agent = create_deep_agent(
 # At runtime, the agent sees:
 # 1. Static instructions: "You are a Python expert."  (or BASE_PROMPT if instructions=None)
 # 2. Uploaded files: "## Uploaded Files\n- /uploads/data.csv (1024 bytes, 50 lines)"
-# 3. Todo prompt: "## Current Todos\n- [ ] Analyze data..."
+# 3. Todo prompt: "## Task Management\nUse write_todos to..." (static — pass
+#    include_current_todos=True to also inject the live list, at the cost of the
+#    provider's prompt cache)
 # 4. Console prompt: "## File Operations\nYou can use ls, read_file, write_file..."
 # 5. Subagent prompt: "## Available Subagents\n- code-reviewer: Reviews code..."
 # 6. Skills prompt: "## Available Skills\n- git: Git operations..."

--- a/docs/learn/planning.md
+++ b/docs/learn/planning.md
@@ -128,6 +128,7 @@ Your agent now plans its own work and you can see the plan:
 - `create_deep_agent()` includes the todo tools by default (`include_todo=True`) — `read_todos`, `write_todos`, `add_todo`, `update_todo_status`, `remove_todo`.
 - The agent breaks multi-step tasks into todos, keeps one `in_progress`, and marks each `completed` as it finishes.
 - The plan lives on `deps.todos` — a list of `Todo` objects (`content`, `status`, `active_form`, `id`) you can read during or after the run.
+- The system prompt carries the todo *workflow*, not the live list. Instructions open the provider's prompt-cache prefix, so re-rendering them on every status change would invalidate the whole cached prefix mid-run — the list is already in the message history, and `read_todos` fetches it on demand. Pass `include_current_todos=True` if you want it in the prompt anyway.
 - Subagents get isolated todos by default; set `share_todos=True` for one shared plan across the delegation tree.
 
 Next, let's hand the agent tools of your own.

--- a/pydantic_deep/agent.py
+++ b/pydantic_deep/agent.py
@@ -472,6 +472,7 @@ def create_deep_agent(
     skills: list[Skill] | None = None,
     backend: BackendProtocol | None = None,
     include_todo: bool = True,
+    include_current_todos: bool = False,
     include_filesystem: bool = True,
     include_subagents: bool = True,
     include_skills: bool = True,
@@ -551,6 +552,7 @@ def create_deep_agent(
     skills: list[Skill] | None = None,
     backend: BackendProtocol | None = None,
     include_todo: bool = True,
+    include_current_todos: bool = False,
     include_filesystem: bool = True,
     include_subagents: bool = True,
     include_skills: bool = True,
@@ -630,6 +632,7 @@ def create_deep_agent(  # noqa: C901
     skills: list[Skill] | None = None,
     backend: BackendProtocol | None = None,
     include_todo: bool = True,
+    include_current_todos: bool = False,
     include_filesystem: bool = True,
     include_subagents: bool = True,
     include_skills: bool = True,
@@ -731,6 +734,13 @@ def create_deep_agent(  # noqa: C901
         skills: Skill instances to register directly.
         backend: File storage backend (default: StateBackend).
         include_todo: Whether to include the todo toolset.
+        include_current_todos: Inject the live todo list into the system prompt.
+            Off by default: the instructions open the provider's prompt-cache
+            prefix, so re-rendering them on every todo mutation invalidates the
+            whole cached prefix mid-run. The list is already in the append-only
+            message history (`write_todos` carries it in its own tool call), and
+            `read_todos` is there for an explicit check. Turn on only if you need
+            the list in the prompt and accept the cache cost.
         include_filesystem: Whether to include the filesystem toolset.
         include_subagents: Whether to include the subagent toolset.
         include_skills: Whether to include the skills toolset.
@@ -1435,7 +1445,6 @@ def create_deep_agent(  # noqa: C901
     # toolset-owned prompts are emitted automatically by CombinedToolset.
     instruction_providers = build_instruction_providers(
         include_todo=include_todo,
-        todo_proxy=_todo_proxy,
         include_filesystem=include_filesystem,
         edit_format=edit_format,
         include_subagents=include_subagents,
@@ -1443,6 +1452,7 @@ def create_deep_agent(  # noqa: C901
         web_search=web_search,
         web_fetch=web_fetch,
         tool_search=tool_search,
+        include_current_todos=include_current_todos,
     )
 
     @agent.instructions

--- a/pydantic_deep/deps.py
+++ b/pydantic_deep/deps.py
@@ -93,7 +93,11 @@ class DeepAgentDeps:
                 object.__setattr__(self, "files", raw._files)
 
     def get_todo_prompt(self) -> str:
-        """Generate system prompt section for todos."""
+        """Generate system prompt section for todos.
+
+        Ids are included so the model can address a task with
+        `update_todo_status` without re-reading the list.
+        """
         if not self.todos:
             return ""
 
@@ -105,7 +109,7 @@ class DeepAgentDeps:
                 "completed": "[x]",
                 "blocked": "[!]",
             }.get(todo.status, "[ ]")
-            lines.append(f"- {status_icon} {todo.content}")
+            lines.append(f"- {status_icon} [{todo.id}] {todo.content}")
 
         return "\n".join(lines)
 

--- a/pydantic_deep/instructions.py
+++ b/pydantic_deep/instructions.py
@@ -18,13 +18,12 @@ from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING
 
 from pydantic_ai_backends import get_console_system_prompt
-from pydantic_ai_todo import get_todo_system_prompt
+from pydantic_ai_todo import TODO_SYSTEM_PROMPT
 from subagents_pydantic_ai import get_subagent_system_prompt
 
 if TYPE_CHECKING:
     from pydantic_ai import RunContext
 
-    from pydantic_deep.agent import _DepsTodoProxy
     from pydantic_deep.deps import DeepAgentDeps
     from pydantic_deep.types import SubAgentConfig
 
@@ -37,14 +36,25 @@ def uploads_section(ctx: RunContext[DeepAgentDeps]) -> str:
     return ctx.deps.get_uploads_summary()
 
 
-def make_todo_section(todo_proxy: _DepsTodoProxy) -> InstructionProvider:
-    """Bind the per-run todo proxy and emit the todo-list prompt section."""
+def todo_section(_ctx: RunContext[DeepAgentDeps]) -> str:
+    """Emit the static todo workflow prompt.
 
-    def provider(ctx: RunContext[DeepAgentDeps]) -> str:
-        todo_proxy._deps = ctx.deps
-        return get_todo_system_prompt(todo_proxy)
+    The instructions open the provider's prompt-cache prefix, so re-rendering
+    them with the live task list invalidates the whole cached prefix on every
+    mutating todo call. The list itself is already in the (append-only,
+    cache-friendly) message history — `write_todos` carries it in its own tool
+    call — and `read_todos` is there for an explicit check.
+    """
+    return TODO_SYSTEM_PROMPT
 
-    return provider
+
+def current_todos_section(ctx: RunContext[DeepAgentDeps]) -> str:
+    """Append the run's live task list to the prompt.
+
+    Opt-in only (`include_current_todos=True`): every mutation rewrites the
+    system prompt and costs the provider's cached prefix.
+    """
+    return ctx.deps.get_todo_prompt()
 
 
 def make_console_section(edit_format: str) -> InstructionProvider:
@@ -120,7 +130,6 @@ def web_tools_section(*, web_search: bool, web_fetch: bool) -> str:
 def build_instruction_providers(
     *,
     include_todo: bool,
-    todo_proxy: _DepsTodoProxy | None,
     include_filesystem: bool,
     edit_format: str,
     include_subagents: bool,
@@ -128,6 +137,7 @@ def build_instruction_providers(
     web_search: bool,
     web_fetch: bool,
     tool_search: bool = False,
+    include_current_todos: bool = False,
 ) -> list[InstructionProvider]:
     """Assemble the ordered instruction providers for the enabled features.
 
@@ -136,10 +146,15 @@ def build_instruction_providers(
     sections — the prompt describes how to use the tools, not what they are.
     The console section is kept verbatim either way: it carries the hashline
     edit-format spec the model needs to call `edit_file` correctly.
+
+    The todo section is static unless `include_current_todos` is set, so that
+    todo mutations don't rewrite the prompt-cache prefix mid-run.
     """
     providers: list[InstructionProvider] = [uploads_section]
-    if include_todo and todo_proxy is not None:
-        providers.append(lean_todo_section if tool_search else make_todo_section(todo_proxy))
+    if include_todo:
+        providers.append(lean_todo_section if tool_search else todo_section)
+        if include_current_todos:
+            providers.append(current_todos_section)
     if include_filesystem:
         providers.append(make_console_section(edit_format))
     if include_subagents:

--- a/pydantic_deep/spec.py
+++ b/pydantic_deep/spec.py
@@ -67,6 +67,7 @@ class DeepAgentSpec(BaseModel):
     subagents: list[dict[str, Any]] | None = None
     skill_directories: list[str] | None = None
     include_todo: bool = True
+    include_current_todos: bool = False
     include_filesystem: bool = True
     include_subagents: bool = True
     include_skills: bool = True

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -6,16 +6,17 @@ from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import RunContext
 from pydantic_ai.usage import RunUsage
 from pydantic_ai_backends import StateBackend
+from pydantic_ai_todo import Todo
 
-from pydantic_deep.agent import _DepsTodoProxy
 from pydantic_deep.deps import DeepAgentDeps
 from pydantic_deep.instructions import (
     build_instruction_providers,
+    current_todos_section,
     lean_todo_section,
     make_lean_subagent_section,
     make_subagent_section,
-    make_todo_section,
     render_instructions,
+    todo_section,
     uploads_section,
     web_tools_section,
 )
@@ -32,16 +33,32 @@ def _ctx(deps: DeepAgentDeps | None = None) -> RunContext[DeepAgentDeps]:
     )
 
 
+def _todo(content: str, status: str = "in_progress") -> Todo:
+    return Todo(content=content, active_form=f"{content}ing", status=status)
+
+
 class TestSections:
     def test_uploads_empty_when_no_uploads(self) -> None:
         assert uploads_section(_ctx()) == ""
 
-    def test_todo_section_binds_deps(self) -> None:
-        proxy = _DepsTodoProxy()
-        provider = make_todo_section(proxy)
+    def test_todo_section_is_static_across_mutations(self) -> None:
+        """The todo section opens the prompt-cache prefix, so it must not change
+        when a todo does (issue #182)."""
         ctx = _ctx()
-        provider(ctx)
-        assert proxy._deps is ctx.deps
+        before = todo_section(ctx)
+        ctx.deps.todos = [_todo("Write docs")]
+        assert todo_section(ctx) == before
+        assert "## Current Todos" not in before
+
+    def test_current_todos_section_renders_the_live_list(self) -> None:
+        ctx = _ctx()
+        assert current_todos_section(ctx) == ""
+        todo = _todo("Write docs")
+        ctx.deps.todos = [todo]
+        rendered = current_todos_section(ctx)
+        assert "## Current Todos" in rendered
+        assert "Write docs" in rendered
+        assert todo.id in rendered
 
     def test_subagent_section_empty_without_configs(self) -> None:
         provider = make_subagent_section([])
@@ -102,7 +119,6 @@ class TestBuildAndRender:
     def test_all_features_off_keeps_uploads_only(self) -> None:
         providers = build_instruction_providers(
             include_todo=False,
-            todo_proxy=None,
             include_filesystem=False,
             edit_format="hashline",
             include_subagents=False,
@@ -115,7 +131,6 @@ class TestBuildAndRender:
     def test_all_features_on(self) -> None:
         providers = build_instruction_providers(
             include_todo=True,
-            todo_proxy=_DepsTodoProxy(),
             include_filesystem=True,
             edit_format="hashline",
             include_subagents=True,
@@ -130,7 +145,6 @@ class TestBuildAndRender:
         configs: list[SubAgentConfig] = [{"name": "planner", "description": "Plans"}]
         providers = build_instruction_providers(
             include_todo=True,
-            todo_proxy=_DepsTodoProxy(),
             include_filesystem=True,
             edit_format="hashline",
             include_subagents=True,
@@ -145,10 +159,11 @@ class TestBuildAndRender:
         # The verbose per-tool enumeration is gone.
         assert "read_todos" not in rendered
 
-    def test_todo_skipped_when_proxy_missing(self) -> None:
+    def test_todo_prompt_is_stable_across_mutations_by_default(self) -> None:
+        """A todo mutation must not rewrite the instructions, or the provider's
+        prompt-cache prefix is invalidated on every mutating tool call (#182)."""
         providers = build_instruction_providers(
             include_todo=True,
-            todo_proxy=None,
             include_filesystem=False,
             edit_format="hashline",
             include_subagents=False,
@@ -156,12 +171,52 @@ class TestBuildAndRender:
             web_search=False,
             web_fetch=False,
         )
-        assert len(providers) == 1
+        ctx = _ctx()
+        before = render_instructions(ctx, providers)
+        ctx.deps.todos = [_todo("Write docs")]
+        assert render_instructions(ctx, providers) == before
+        assert "## Current Todos" not in before
+
+    def test_current_todos_opt_in_appends_the_live_list(self) -> None:
+        providers = build_instruction_providers(
+            include_todo=True,
+            include_filesystem=False,
+            edit_format="hashline",
+            include_subagents=False,
+            subagents=[],
+            web_search=False,
+            web_fetch=False,
+            include_current_todos=True,
+        )
+        ctx = _ctx()
+        ctx.deps.todos = [_todo("Write docs")]
+        rendered = render_instructions(ctx, providers)
+        assert "## Current Todos" in rendered
+        assert "Write docs" in rendered
+
+    def test_current_todos_opt_in_composes_with_tool_search(self) -> None:
+        """The lean section replaces the tool inventory, not the explicit
+        opt-in to the live list."""
+        providers = build_instruction_providers(
+            include_todo=True,
+            include_filesystem=False,
+            edit_format="hashline",
+            include_subagents=False,
+            subagents=[],
+            web_search=False,
+            web_fetch=False,
+            tool_search=True,
+            include_current_todos=True,
+        )
+        ctx = _ctx()
+        ctx.deps.todos = [_todo("Write docs")]
+        rendered = render_instructions(ctx, providers)
+        assert "Task Tracking" in rendered  # lean base
+        assert "Write docs" in rendered  # live list
 
     def test_render_joins_nonempty_sections(self) -> None:
         providers = build_instruction_providers(
             include_todo=False,
-            todo_proxy=None,
             include_filesystem=True,
             edit_format="hashline",
             include_subagents=False,


### PR DESCRIPTION
Closes #182.

## The bug

`create_deep_agent` doesn't use `TodoCapability` — it builds its own instruction
providers — so the static-by-default prompt introduced in `pydantic-ai-todo`
0.2.7 never applied here. `make_todo_section` called
`get_todo_system_prompt(proxy)`, which appends `## Current Todos` whenever the
run has any todos. The instructions open the provider's prompt-cache prefix, so
every `write_todos` / `update_todo_status` invalidated the whole cached prefix
mid-run.

Reported by @jb2197 with a clean repro, which reproduces on `main`:

```text
False          # before == after
False True     # "## Current Todos" in before / after
```

The `tool_search=True` path already dodged this (it uses the static
`lean_todo_section`), so only the default path was affected.

## The fix

- The todo section is now the static `TODO_SYSTEM_PROMPT`. The live list moves
  behind `include_current_todos=True` on `create_deep_agent` (also a
  `DeepAgentSpec` field), matching the upstream flag name.
- The opt-in list is appended as its own section, so it composes with
  `tool_search=True` instead of being dropped by the lean todo section.
- The instruction providers no longer touch the todo proxy, so
  `build_instruction_providers` drops its `todo_proxy` argument.
  `_TodoProxyBinder` re-binds the proxy in each tool's own `contextvars`
  context (#148) — that was always the only binding the tools saw, and the
  end-to-end `write_todos` persistence test covers it.
- `DeepAgentDeps.get_todo_prompt()` — unused by the library until now — renders
  the opt-in section, and now includes each todo's id (`- [ ] [id] content`,
  matching upstream) so the model can call `update_todo_status` without
  re-reading the list.

The 0.3.37 CHANGELOG entry claimed pydantic-deep's prompt behavior was
unaffected by the upstream default. It wasn't; that's corrected in place.

## Tests

New coverage in `tests/test_instructions.py`: the section is byte-identical
before and after a mutation (both at the provider level and through the fully
rendered prompt), the opt-in appends the live list, and the opt-in composes with
`tool_search=True`.

`ruff` clean, pyright 0 errors, mypy clean, 2903 tests pass, coverage 100.00%.

## Note

Running the suite locally needs `-p no:examples` right now: `pytest-examples`
autoloads and dies importing `black` 26.5.1 against `pathspec` 0.12.1
(`No module named 'pathspec.patterns.gitignore'`). Pre-existing, unrelated to
this change.
