### PR TITLE
feat: support enterprise oauth transport config for hosted mcp servers

### DIFF
--- a/apps/cli/mcp_store.py
+++ b/apps/cli/mcp_store.py
@@ -10,6 +10,7 @@ secret resolver.
 from __future__ import annotations
 
 import json
+import logging
 import os
 from pathlib import Path
 
@@ -37,6 +38,8 @@ __all__ = [
     "import_claude_code_servers",
 ]
 
+logger = logging.getLogger(__name__)
+
 
 def mcp_config_path() -> Path:
     """Path to the per-project MCP config file."""
@@ -58,17 +61,31 @@ def mcp_oauth_storage() -> object | None:
     Tokens (e.g. for the hosted Figma server) are cached on disk under
     ``~/.pydantic-deep/mcp-oauth`` and keyed by server URL, so authorizing once
     (via ``/mcp`` test) works for the agent too and survives restarts. Returns
-    ``None`` if the disk store backend isn't installed (falls back to in-memory).
+    ``None`` — with a logged warning, since the resulting in-memory fallback
+    means a browser re-auth on every restart — if the disk store backend isn't
+    installed or the store directory can't be created.
     """
     try:
         from key_value.aio.stores.disk import DiskStore
     except Exception:
+        logger.warning(
+            "MCP OAuth tokens will not persist: the disk store backend is not "
+            "installed (pip install 'py-key-value-aio[disk]'); using in-memory "
+            "storage, so hosted servers re-authorize on every restart."
+        )
         return None
     path = Path.home() / ".pydantic-deep" / "mcp-oauth"
     try:
         path.mkdir(parents=True, exist_ok=True)
         return DiskStore(directory=str(path))
-    except Exception:
+    except Exception as exc:
+        logger.warning(
+            "MCP OAuth tokens will not persist: cannot initialise the disk store "
+            "at %s (%s); using in-memory storage, so hosted servers re-authorize "
+            "on every restart.",
+            path,
+            exc,
+        )
         return None
 
 

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -11,6 +11,12 @@ them to an agent via the `mcp_servers` parameter of
     options:
       show_source: false
 
+## HttpClientFactory
+
+::: pydantic_deep.mcp.registry.HttpClientFactory
+    options:
+      show_source: false
+
 ## probe_mcp_server
 
 ::: pydantic_deep.mcp.probe_mcp_server

--- a/docs/learn/web-and-mcp.md
+++ b/docs/learn/web-and-mcp.md
@@ -177,6 +177,78 @@ you can keep a whole shelf of servers defined and switch them on as needed.
     keystore). See [MCP Servers](../learn/web-and-mcp.md) for OAuth, stdio subprocesses,
     and importing servers from Claude Code.
 
+### Hosted OAuth servers
+
+Some hosted servers (Figma, Atlassian) authenticate with an interactive OAuth
+flow instead of a token: set `MCPAuth(kind="oauth")` and the browser opens on
+first connect. Servers that are strict about registration take two more fields —
+explicit `scopes` and a fixed `callback_port` for a pre-registered redirect URI:
+
+```python
+from pydantic_deep import MCPAuth, MCPServerConfig, build_mcp_server
+
+atlassian = MCPServerConfig(
+    name="atlassian",
+    transport="http",
+    url="https://mcp.atlassian.com/v1/mcp/authv2",
+    auth=MCPAuth(
+        kind="oauth",
+        scopes=["read:jira-work", "read:confluence-content.all"],
+        callback_port=8123,
+    ),
+    init_timeout=180,  # leave time for the browser round-trip
+)
+server = build_mcp_server(atlassian)
+```
+
+Pass `oauth_token_storage=` (any `AsyncKeyValue`, e.g. a disk store) to make the
+token survive restarts. Tokens are cached per scope set: change `scopes` and the
+next connect re-authorizes instead of silently reusing a token minted under the
+old permissions.
+
+### Corporate proxies and custom CAs
+
+Behind a TLS-inspecting proxy, both the MCP transport and the OAuth flow
+(discovery, token exchange, refresh) must trust your network. Try the standard
+environment variables first — httpx honours them for every connection:
+
+```bash
+export HTTPS_PROXY="http://proxy.corp.example:8080"
+export SSL_CERT_FILE="/etc/ssl/corp-bundle.pem"
+```
+
+(For `stdio` servers the subprocess doesn't inherit your environment — pass
+what it needs, e.g. `NODE_EXTRA_CA_CERTS`, explicitly via `config.env`.)
+
+When env vars can't express your setup — the CA lives in the OS trust store, the
+proxy wants authentication, or you need mTLS — pass an
+[`HttpClientFactory`][pydantic_deep.mcp.registry.HttpClientFactory]. One factory
+applies to every HTTP-based server in a registry and reaches both the transport
+and the OAuth flow:
+
+```python
+import httpx
+import ssl
+import truststore
+
+from pydantic_deep import MCPRegistry, MCPServerConfig
+
+
+def corporate_client(config: MCPServerConfig) -> httpx.AsyncClient:
+    # Called once per connection — always return a fresh client.
+    return httpx.AsyncClient(
+        proxy="http://proxy.corp.example:8080",
+        verify=truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT),
+    )
+
+
+registry = MCPRegistry(configs, http_client_factory=corporate_client)
+```
+
+The factory must return a **new client on every call**: each connection (and
+each OAuth step) closes the client it used, so a shared instance would be dead
+after the first request.
+
 ## Recap
 
 You gave your agent the world:

--- a/pydantic_deep/mcp/__init__.py
+++ b/pydantic_deep/mcp/__init__.py
@@ -19,6 +19,7 @@ from pydantic_deep.mcp.config import (
 from pydantic_deep.mcp.loader import expand_env_vars, parse_mcp_servers
 from pydantic_deep.mcp.registry import (
     MCP_INSTALL_HINT,
+    HttpClientFactory,
     MCPNotInstalledError,
     MCPProbeResult,
     MCPRegistry,
@@ -46,6 +47,7 @@ __all__ = [
     "MCPNotInstalledError",
     "MCP_INSTALL_HINT",
     "SecretResolver",
+    "HttpClientFactory",
     "auth_satisfied",
     "build_mcp_server",
     "make_resilient",

--- a/pydantic_deep/mcp/config.py
+++ b/pydantic_deep/mcp/config.py
@@ -60,6 +60,14 @@ class MCPAuth:
         client_name: OAuth client name advertised during dynamic client
             registration (``oauth`` only). Some servers (e.g. Figma's hosted MCP
             during beta) allowlist this; leave ``None`` to use the default.
+        scopes: OAuth scopes to request up front (``oauth`` only). Some hosted
+            servers (e.g. Atlassian's) require explicit scopes at registration
+            instead of granting a default set. Cached tokens are namespaced per
+            scope set, so changing this forces a fresh authorization rather
+            than silently reusing a token minted under the old scopes.
+        callback_port: Fixed localhost port for the OAuth redirect URI
+            (``oauth`` only). Needed by servers that validate a pre-registered
+            redirect URI; ``None`` lets the client pick a free port.
     """
 
     secret_key: str = ""
@@ -69,10 +77,14 @@ class MCPAuth:
     value_template: str = "Bearer {token}"
     instructions: str = ""
     client_name: str | None = None
+    scopes: list[str] = field(default_factory=list)
+    callback_port: int | None = None
 
     def __post_init__(self) -> None:
         if self.kind in _SECRET_AUTH_KINDS and not self.secret_key:
             raise MCPConfigError(f"{self.kind} MCP auth requires a non-empty secret_key")
+        if self.callback_port is not None and self.callback_port <= 0:
+            raise MCPConfigError(f"callback_port must be positive, got {self.callback_port}")
         # Fail fast on a template that would raise at `render_value` time —
         # extra placeholders (`{foo}`) or unbalanced literal braces (B13).
         try:
@@ -97,6 +109,8 @@ class MCPAuth:
             value_template=data.get("value_template", "Bearer {token}"),
             instructions=data.get("instructions", ""),
             client_name=data.get("client_name"),
+            scopes=list(data.get("scopes", [])),
+            callback_port=data.get("callback_port"),
         )
 
 

--- a/pydantic_deep/mcp/registry.py
+++ b/pydantic_deep/mcp/registry.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
 import logging
 import os
 import re
@@ -23,7 +24,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
 
-from pydantic_deep.mcp.config import _SECRET_AUTH_KINDS, MCPServerConfig
+from pydantic_deep.mcp.config import _SECRET_AUTH_KINDS, MCPAuth, MCPServerConfig
 from pydantic_deep.mcp.resources import create_mcp_resources_toolset
 
 
@@ -43,6 +44,7 @@ def _stdio_log_file(name: str) -> Path:
 
 
 if TYPE_CHECKING:
+    import httpx
     from pydantic_ai._run_context import RunContext
     from pydantic_ai.toolsets import AbstractToolset
     from pydantic_ai.toolsets.abstract import ToolsetTool
@@ -51,6 +53,7 @@ logger = logging.getLogger("pydantic_deep.mcp")
 
 __all__ = [
     "SecretResolver",
+    "HttpClientFactory",
     "MCPRegistry",
     "MCPProbeResult",
     "MCPNotInstalledError",
@@ -62,6 +65,16 @@ __all__ = [
 
 SecretResolver = Callable[[str], "str | None"]
 """Resolves a secret key (e.g. ``"GITHUB_MCP_PAT"``) to its token, or ``None``."""
+
+HttpClientFactory = Callable[[MCPServerConfig], "httpx.AsyncClient"]
+"""Builds an ``httpx.AsyncClient`` for a server config (corporate proxy,
+custom CA / OS trust store, mTLS, authenticated proxy headers, …).
+
+Every HTTP-based connection goes through it — the MCP transport *and* each
+step of the OAuth flow (discovery, registration, token exchange, refresh) —
+and each call site closes the client it receives, so the factory must return
+a **fresh client per call**, never a shared instance.
+"""
 
 MCP_INSTALL_HINT = (
     "MCP support requires the optional 'mcp' extra: "
@@ -111,11 +124,104 @@ def auth_satisfied(config: MCPServerConfig, resolver: SecretResolver | None = No
     return bool(resolver(auth.secret_key))
 
 
+def _adapt_http_client_factory(
+    factory: HttpClientFactory, config: MCPServerConfig
+) -> Callable[..., httpx.AsyncClient]:
+    """Adapt a per-config client factory to the MCP SDK's factory protocol.
+
+    FastMCP invokes the factory once per connection (transport traffic and each
+    OAuth step) and closes every client it receives, so each call must produce
+    a fresh client. The keyword arguments FastMCP passes are applied on top of
+    the caller's client — ``auth`` in particular carries the OAuth object and
+    dropping it would leave requests unauthenticated.
+    """
+
+    def make_client(
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+        auth: httpx.Auth | None = None,
+    ) -> httpx.AsyncClient:
+        client = factory(config)
+        if headers:
+            client.headers.update(headers)
+        if timeout is not None:
+            client.timeout = timeout
+        if auth is not None:
+            client.auth = auth
+        return client
+
+    return make_client
+
+
+def _scoped_token_storage(storage: Any, scopes: Sequence[str]) -> Any:
+    """Namespace an OAuth token store by the requested scope set.
+
+    FastMCP keys cached tokens by server URL only, so after a config's
+    ``scopes`` change the token minted under the old set would silently keep
+    being used. Prefixing the store's keys with a scope-set hash forces a
+    fresh authorization per scope set (switching back reuses the old token).
+    """
+    from key_value.aio.wrappers.prefix_keys import PrefixKeysWrapper
+
+    digest = hashlib.sha256(",".join(sorted(scopes)).encode()).hexdigest()[:16]
+    return PrefixKeysWrapper(key_value=storage, prefix=f"scopes-{digest}")
+
+
+def _build_oauth(
+    config: MCPServerConfig,
+    auth: MCPAuth,
+    *,
+    oauth_token_storage: Any | None,
+    client_factory: Callable[..., httpx.AsyncClient] | None,
+) -> Any:
+    """Construct the FastMCP ``OAuth`` object for an ``oauth``-kind config."""
+    from fastmcp.client.auth.oauth import OAuth
+
+    oauth_kwargs: dict[str, Any] = {"mcp_url": cast(str, config.url)}
+    if oauth_token_storage is not None:
+        storage = oauth_token_storage
+        if auth.scopes:
+            storage = _scoped_token_storage(storage, auth.scopes)
+        oauth_kwargs["token_storage"] = storage
+    if auth.client_name:
+        oauth_kwargs["client_name"] = auth.client_name
+    if auth.scopes:
+        oauth_kwargs["scopes"] = list(auth.scopes)
+    if auth.callback_port is not None:
+        oauth_kwargs["callback_port"] = auth.callback_port
+    if client_factory is not None:
+        oauth_kwargs["httpx_client_factory"] = client_factory
+    return OAuth(**oauth_kwargs)
+
+
+def _build_http_transport(
+    config: MCPServerConfig,
+    client_factory: Callable[..., httpx.AsyncClient],
+    *,
+    headers: dict[str, str] | None = None,
+    auth: Any | None = None,
+) -> Any:
+    """Build the FastMCP HTTP/SSE transport explicitly.
+
+    ``MCPToolset(url, ...)`` offers no way to hand an ``httpx_client_factory``
+    to the transport it builds internally, so a config with a client factory
+    constructs the transport itself — chosen from ``config.transport`` rather
+    than inferred from the URL — and passes it to the toolset.
+    """
+    from fastmcp.client.transports import SSETransport, StreamableHttpTransport
+
+    transport_cls = SSETransport if config.transport == "sse" else StreamableHttpTransport
+    return transport_cls(
+        cast(str, config.url), headers=headers, auth=auth, httpx_client_factory=client_factory
+    )
+
+
 def _build_raw_mcp_toolset(
     config: MCPServerConfig,
     resolver: SecretResolver | None = None,
     *,
     oauth_token_storage: Any | None = None,
+    http_client_factory: HttpClientFactory | None = None,
 ) -> AbstractToolset[Any]:
     """Build the bare ``MCPToolset`` for a config (before any prefix wrapping).
 
@@ -160,22 +266,48 @@ def _build_raw_mcp_toolset(
         toolset = MCPToolset(transport, id=config.name, **extra)
     elif auth is not None and auth.kind == "oauth":  # http/sse interactive OAuth
         url = cast(str, config.url)
-        # A persistent token store and/or a custom client name require a real
-        # OAuth object; otherwise the lightweight "oauth" string is enough.
-        if oauth_token_storage is not None or auth.client_name:
-            from fastmcp.client.auth.oauth import OAuth
-
-            oauth_kwargs: dict[str, Any] = {"mcp_url": url}
-            if oauth_token_storage is not None:
-                oauth_kwargs["token_storage"] = oauth_token_storage
-            if auth.client_name:
-                oauth_kwargs["client_name"] = auth.client_name
-            toolset = MCPToolset(url, auth=OAuth(**oauth_kwargs), id=config.name, **extra)
+        client_factory = (
+            _adapt_http_client_factory(http_client_factory, config)
+            if http_client_factory is not None
+            else None
+        )
+        # Anything beyond the plain interactive flow — a persistent token store,
+        # custom client name, explicit scopes / callback port, or a custom http
+        # client — requires a real OAuth object; otherwise the lightweight
+        # "oauth" string is enough.
+        if (
+            oauth_token_storage is not None
+            or auth.client_name
+            or auth.scopes
+            or auth.callback_port is not None
+            or client_factory is not None
+        ):
+            oauth = _build_oauth(
+                config,
+                auth,
+                oauth_token_storage=oauth_token_storage,
+                client_factory=client_factory,
+            )
+            if client_factory is not None:
+                # The factory must reach both sides: the OAuth flow gets it via
+                # _build_oauth, the transport's own connections get it here.
+                transport = _build_http_transport(config, client_factory, auth=oauth)
+                toolset = MCPToolset(transport, id=config.name, **extra)
+            else:
+                toolset = MCPToolset(url, auth=oauth, id=config.name, **extra)
         else:
             toolset = MCPToolset(url, auth="oauth", id=config.name, **extra)
     else:  # http / sse — FastMCP infers the transport from the URL
         url = cast(str, config.url)
-        toolset = MCPToolset(url, headers=headers or None, id=config.name, **extra)
+        if http_client_factory is not None:
+            transport = _build_http_transport(
+                config,
+                _adapt_http_client_factory(http_client_factory, config),
+                headers=headers or None,
+            )
+            toolset = MCPToolset(transport, id=config.name, **extra)
+        else:
+            toolset = MCPToolset(url, headers=headers or None, id=config.name, **extra)
 
     return cast("AbstractToolset[Any]", toolset)
 
@@ -206,6 +338,7 @@ def build_mcp_server(
     resolver: SecretResolver | None = None,
     *,
     oauth_token_storage: Any | None = None,
+    http_client_factory: HttpClientFactory | None = None,
 ) -> AbstractToolset[Any]:
     """Build a connected pydantic-ai MCP toolset from a config.
 
@@ -233,13 +366,25 @@ def build_mcp_server(
             server, the token survives restarts and is shared between the
             connection test and the agent (FastMCP keys tokens by server URL).
             When ``None``, FastMCP uses in-memory storage (token re-auth per
-            client/restart).
+            client/restart). With ``auth.scopes`` set, the store is namespaced
+            per scope set so a scope change forces a fresh authorization.
+        http_client_factory: Escape hatch for network environments that env
+            vars can't express (authenticated proxies, OS trust stores, mTLS).
+            Applied to the server's HTTP transport *and* its OAuth flow, so a
+            single factory covers discovery, token exchange, refresh and
+            regular traffic. See :data:`HttpClientFactory` for the contract.
+            Ignored for ``stdio`` servers.
 
     Raises:
         MCPNotInstalledError: if the ``mcp`` optional dependency is missing.
     """
     resolver = resolver or _default_resolver
-    raw = _build_raw_mcp_toolset(config, resolver, oauth_token_storage=oauth_token_storage)
+    raw = _build_raw_mcp_toolset(
+        config,
+        resolver,
+        oauth_token_storage=oauth_token_storage,
+        http_client_factory=http_client_factory,
+    )
     return _apply_tool_prefix(raw, config)
 
 
@@ -364,9 +509,11 @@ class MCPRegistry:
         resolver: SecretResolver | None = None,
         *,
         oauth_token_storage: Any | None = None,
+        http_client_factory: HttpClientFactory | None = None,
     ) -> None:
         self._resolver: SecretResolver = resolver or _default_resolver
         self._oauth_token_storage = oauth_token_storage
+        self._http_client_factory = http_client_factory
         self._configs: dict[str, MCPServerConfig] = {}
         for config in configs or []:
             self._configs[config.name] = config
@@ -406,7 +553,10 @@ class MCPRegistry:
 
     def build(self, config: MCPServerConfig) -> AbstractToolset[Any]:
         return build_mcp_server(
-            config, self._resolver, oauth_token_storage=self._oauth_token_storage
+            config,
+            self._resolver,
+            oauth_token_storage=self._oauth_token_storage,
+            http_client_factory=self._http_client_factory,
         )
 
     def build_active(
@@ -430,7 +580,10 @@ class MCPRegistry:
             if self.status(config) != "ready":
                 continue
             raw = _build_raw_mcp_toolset(
-                config, self._resolver, oauth_token_storage=self._oauth_token_storage
+                config,
+                self._resolver,
+                oauth_token_storage=self._oauth_token_storage,
+                http_client_factory=self._http_client_factory,
             )
             servers.append(
                 make_resilient(_apply_tool_prefix(raw, config), config.name, on_degraded)

--- a/tests/test_cli_mcp.py
+++ b/tests/test_cli_mcp.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any, cast
 
@@ -151,7 +152,9 @@ def test_mcp_oauth_storage_persistent(
     assert (home / ".pydantic-deep" / "mcp-oauth").exists()
 
 
-def test_mcp_oauth_storage_missing_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_mcp_oauth_storage_missing_backend(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     import builtins
 
     real_import = builtins.__import__
@@ -162,7 +165,28 @@ def test_mcp_oauth_storage_missing_backend(monkeypatch: pytest.MonkeyPatch) -> N
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", _fake_import)
-    assert mcp_store.mcp_oauth_storage() is None
+    # The in-memory fallback means a browser re-auth on every restart, so it
+    # must be loud — a silent downgrade reads as "OAuth is broken".
+    with caplog.at_level(logging.WARNING, logger="apps.cli.mcp_store"):
+        assert mcp_store.mcp_oauth_storage() is None
+    assert "will not persist" in caplog.text
+
+
+def test_mcp_oauth_storage_disk_failure_warns(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+    def _boom(self: Path, *args: object, **kwargs: object) -> None:
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(Path, "mkdir", _boom)
+    with caplog.at_level(logging.WARNING, logger="apps.cli.mcp_store"):
+        assert mcp_store.mcp_oauth_storage() is None
+    assert "will not persist" in caplog.text
+    assert "read-only filesystem" in caplog.text
 
 
 # ── import from Claude Code ──────────────────────────────────────────────

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -169,6 +169,203 @@ def test_registry_threads_oauth_storage(tmp_path: Path) -> None:
     reg.add(cfg)
     ts = reg.build(cfg)
     assert _transport(ts).url == "https://mcp.figma.com/mcp"
+
+
+# ── oauth scopes / callback_port / http client factory ──────────────────
+
+
+def test_mcpauth_oauth_fields_roundtrip() -> None:
+    auth = MCPAuth(kind="oauth", scopes=["read:jira", "write:jira"], callback_port=8123)
+    assert MCPAuth.from_dict(auth.to_dict()) == auth
+    # Configs written before these fields existed load with safe defaults.
+    legacy = MCPAuth.from_dict({"kind": "oauth"})
+    assert legacy.scopes == []
+    assert legacy.callback_port is None
+
+
+def test_mcpauth_rejects_non_positive_callback_port() -> None:
+    with pytest.raises(MCPConfigError):
+        MCPAuth(kind="oauth", callback_port=0)
+    with pytest.raises(MCPConfigError):
+        MCPAuth(kind="oauth", callback_port=-1)
+
+
+def test_build_oauth_forwards_scopes_and_callback_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import fastmcp.client.auth.oauth as oauth_mod
+
+    captured: dict[str, Any] = {}
+
+    class _FakeOAuth:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr(oauth_mod, "OAuth", _FakeOAuth)
+    cfg = MCPServerConfig(
+        name="atlassian",
+        transport="http",
+        url="https://mcp.atlassian.com/v1/mcp/authv2",
+        auth=MCPAuth(kind="oauth", scopes=["read:jira-work"], callback_port=8123),
+    )
+    ts = build_mcp_server(cfg, lambda k: None)
+    assert captured["mcp_url"] == "https://mcp.atlassian.com/v1/mcp/authv2"
+    assert captured["scopes"] == ["read:jira-work"]
+    assert captured["callback_port"] == 8123
+    assert "token_storage" not in captured
+    assert _transport(ts).auth is not None
+
+
+def test_build_oauth_scopes_namespace_token_storage(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import fastmcp.client.auth.oauth as oauth_mod
+    from key_value.aio.stores.disk import DiskStore
+    from key_value.aio.wrappers.prefix_keys import PrefixKeysWrapper
+
+    captured: dict[str, Any] = {}
+
+    class _FakeOAuth:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr(oauth_mod, "OAuth", _FakeOAuth)
+    store = DiskStore(directory=str(tmp_path / "oauth"))
+
+    scoped = MCPServerConfig(
+        name="a",
+        transport="http",
+        url="https://x/mcp",
+        auth=MCPAuth(kind="oauth", scopes=["read:jira"]),
+    )
+    build_mcp_server(scoped, lambda k: None, oauth_token_storage=store)
+    scoped_storage = captured["token_storage"]
+    assert isinstance(scoped_storage, PrefixKeysWrapper)
+
+    # Without scopes the store is passed through untouched, so tokens cached
+    # before this feature existed keep working.
+    captured.clear()
+    plain = MCPServerConfig(
+        name="b", transport="http", url="https://x/mcp", auth=MCPAuth(kind="oauth")
+    )
+    build_mcp_server(plain, lambda k: None, oauth_token_storage=store)
+    plain_storage = captured["token_storage"]
+    assert plain_storage is store
+
+
+def test_scoped_token_storage_namespaces_by_scope_set() -> None:
+    from key_value.aio.stores.memory import MemoryStore
+
+    from pydantic_deep.mcp.registry import _scoped_token_storage
+
+    store = MemoryStore()
+    a = _scoped_token_storage(store, ["read:jira", "write:jira"])
+    b = _scoped_token_storage(store, ["write:jira", "read:jira"])
+    c = _scoped_token_storage(store, ["read:jira"])
+    # The namespace is a function of the scope *set*: order doesn't matter,
+    # but a different set gets its own slot so the old token can't be reused.
+    assert a.prefix == b.prefix
+    assert a.prefix != c.prefix
+
+
+def test_http_client_factory_reaches_oauth_and_transport() -> None:
+    import httpx
+
+    def factory(config: MCPServerConfig) -> httpx.AsyncClient:
+        return httpx.AsyncClient()
+
+    cfg = MCPServerConfig(
+        name="atlassian", transport="http", url="https://x/mcp", auth=MCPAuth(kind="oauth")
+    )
+    ts = build_mcp_server(cfg, lambda k: None, http_client_factory=factory)
+    transport = _transport(ts)
+    oauth = transport.auth
+    # Configuring only the transport would just move the failure from
+    # `initialize` to the first token refresh — both sides need the factory.
+    assert transport.httpx_client_factory is not None
+    assert oauth.httpx_client_factory is transport.httpx_client_factory
+    assert oauth.httpx_client_factory is not httpx.AsyncClient
+
+
+async def test_adapted_factory_returns_fresh_client_and_applies_kwargs() -> None:
+    import httpx
+
+    from pydantic_deep.mcp.registry import _adapt_http_client_factory
+
+    cfg = MCPServerConfig(name="a", transport="http", url="https://x/mcp")
+    made: list[httpx.AsyncClient] = []
+
+    def factory(config: MCPServerConfig) -> httpx.AsyncClient:
+        assert config is cfg
+        client = httpx.AsyncClient(headers={"Proxy-Authorization": "Negotiate abc"})
+        made.append(client)
+        return client
+
+    adapted = _adapt_http_client_factory(factory, cfg)
+    auth = httpx.Auth()
+    first = adapted()  # the OAuth flow calls with no arguments
+    second = adapted(headers={"X-H": "1"}, timeout=httpx.Timeout(7.0), auth=auth)
+    # Each call site `async with`es (and closes) its client, so a shared
+    # instance would be dead after the first use — every call must be fresh.
+    assert first is not second
+    assert second.headers["X-H"] == "1"
+    assert second.headers["Proxy-Authorization"] == "Negotiate abc"
+    assert second.auth is auth
+    assert second.timeout == httpx.Timeout(7.0)
+    for client in made:
+        await client.aclose()
+
+
+def test_build_http_with_factory_keeps_resolved_headers() -> None:
+    import httpx
+    from fastmcp.client.transports import StreamableHttpTransport
+
+    cfg = MCPServerConfig(
+        name="internal",
+        transport="http",
+        url="https://x/mcp",
+        headers={"X-Extra": "1"},
+        auth=MCPAuth(secret_key="K", kind="bearer"),
+    )
+    ts = build_mcp_server(cfg, lambda k: "tok", http_client_factory=lambda c: httpx.AsyncClient())
+    transport = _transport(ts)
+    assert isinstance(transport, StreamableHttpTransport)
+    assert transport.headers["Authorization"] == "Bearer tok"
+    assert transport.headers["X-Extra"] == "1"
+    assert transport.httpx_client_factory is not None
+
+
+def test_build_sse_with_factory_uses_sse_transport() -> None:
+    import httpx
+    from fastmcp.client.transports import SSETransport
+
+    cfg = MCPServerConfig(name="legacy", transport="sse", url="https://x/sse")
+    ts = build_mcp_server(cfg, lambda k: None, http_client_factory=lambda c: httpx.AsyncClient())
+    assert isinstance(_transport(ts), SSETransport)
+
+
+def test_build_stdio_ignores_http_client_factory() -> None:
+    import httpx
+
+    cfg = MCPServerConfig(name="local", transport="stdio", command="echo")
+    ts = build_mcp_server(cfg, lambda k: None, http_client_factory=lambda c: httpx.AsyncClient())
+    assert ts is not None
+
+
+def test_registry_threads_http_client_factory() -> None:
+    import httpx
+
+    def factory(config: MCPServerConfig) -> httpx.AsyncClient:
+        return httpx.AsyncClient()
+
+    reg = MCPRegistry(resolver=lambda k: None, http_client_factory=factory)
+    cfg = MCPServerConfig(name="plain", transport="http", url="https://x/mcp")
+    reg.add(cfg)
+    assert _transport(reg.build(cfg)).httpx_client_factory is not None
+    servers = reg.build_active()
+    assert len(servers) == 1
+    resilient = cast(Any, servers[0])
+    assert _transport(resilient.wrapped).httpx_client_factory is not None
 
 
 def test_config_requires_auth_property() -> None:


### PR DESCRIPTION
## Summary

Hosted OAuth MCP servers (Figma, Atlassian) can now be configured for enterprise
environments declaratively: `MCPAuth` gains explicit `scopes` and a fixed
`callback_port`, and a new `http_client_factory` escape hatch threads a custom
`httpx.AsyncClient` (authenticated proxy, OS trust store, mTLS) through both the
MCP transport and every step of the OAuth flow. Cached OAuth tokens are
namespaced per scope set, so changing `scopes` forces a fresh authorization
instead of silently reusing a token minted under the old permissions.

## Added

- Added `scopes` and `callback_port` to `MCPAuth` in `pydantic_deep/mcp/config.py` —
  validated, round-tripped through `to_dict`/`from_dict`, forwarded to FastMCP's
  `OAuth(...)` in `pydantic_deep/mcp/registry.py`.
- Added `HttpClientFactory` type and `http_client_factory=` kwarg on `MCPRegistry`
  and `build_mcp_server`. The factory is adapted to the MCP SDK's factory protocol
  (`_adapt_http_client_factory`: fresh client per call, with the `headers`/`timeout`/`auth`
  kwargs FastMCP passes applied on top) and reaches both the OAuth object and the
  transport, so discovery, token exchange, refresh and regular traffic all go
  through it.
- Added `_scoped_token_storage`: wraps the OAuth token store in a
  `PrefixKeysWrapper` keyed by a hash of the sorted scope set.
- Added docs: "Hosted OAuth servers" and "Corporate proxies and custom CAs"
  sections in `docs/learn/web-and-mcp.md` (env vars first, factory as last
  resort), plus `HttpClientFactory` in `docs/api/mcp.md`.

## Changed

- A config built with a client factory now constructs its
  `StreamableHttpTransport`/`SSETransport` explicitly (chosen from
  `config.transport`, not inferred from the URL), because `MCPToolset(url, ...)`
  has no way to carry an `httpx_client_factory` to the transport it builds
  internally. Configs without a factory build exactly as before.
- `mcp_oauth_storage()` in `apps/cli/mcp_store.py` logs a warning on both
  failure paths (missing disk backend, store init error) instead of silently
  degrading to in-memory token storage.

## Testing

- Added 13 tests across `tests/test_mcp.py` and `tests/test_cli_mcp.py`:
  field round-trip and validation, `OAuth` kwargs forwarding, factory identity
  asserted on both the OAuth object and the transport, fresh-client-per-call
  adapter contract, scope-set namespacing (order-insensitive, pass-through
  without scopes), SSE and stdio paths, registry threading, CLI fallback warnings.
- Ran `make lint`, `make typecheck` (pyright) and `make typecheck-mypy` — clean.
- Ran `make test` — 2811 passed, 100% coverage.
- Ran `mkdocs build` — no warnings.

## Related Issue

Closes #183 

## Notes for Reviewers

- Setting `scopes` on a server with an existing cached token triggers a one-time
  browser re-auth: the store key gains a scope-hash prefix, so the old
  un-prefixed token is deliberately not found. Configs without `scopes` keep
  using their existing tokens unchanged.
- The factory contract requires a fresh `httpx.AsyncClient` per call — both the
  transport and each OAuth step close the client they receive, so a shared
  instance would be dead after the first request. This is documented on
  `HttpClientFactory` and in the docs example.
- Deliberately out of scope, per the issue thread: a serializable `tls_verify`
  config field and an `atlassian` builtin catalogue entry.
- Verified with unit tests only — no access to an Atlassian tenant or a
  Negotiate proxy; the reporter offered to test end-to-end from their side.