### PR TITLE
fix(teams): repair subagent wiring so members actually run (0.3.40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.40] - 2026-08-01
+
+Agent teams were wired to the subagent execution engine but never actually ran a
+member. Four defects compounded, each of them silent: the tools reported success
+and the team produced nothing.
+
+Requires `subagents-pydantic-ai >= 0.2.12`, which adds the programmatic
+`answer_task` / `steer_task` surface and exposes `SubAgentToolset.registry`.
+
+### Fixed
+
+- **Teams registered members in a registry the subagent engine never reads.** With
+  `subagent_registry=None` — the `create_deep_agent` default — the team block built
+  a fresh `DynamicAgentRegistry()`, so `spawn_team` put its members somewhere the
+  subagent `task` tool does not look and every `assign_task` came back
+  `Error: Unknown subagent`. Teams plus subagents was broken in the default
+  configuration. Teams now share `subagent_toolset.registry`.
+- **A refused delegation was recorded as a started task.** The subagent `task` tool
+  reports an unknown subagent or a busy chat trace as an error string rather than
+  raising, so `assign_task`'s `except` never fired: it set the member to `running`
+  and appended the error to an "Agent running in background" message. The member
+  then sat at `running` forever. A started task is now identified by its `Task ID:`
+  line, and a refusal marks the member `failed` with the reason.
+- **`message_teammate` delivered nothing.** It wrote to `TeamMessageBus`, which no
+  running member reads — a member is a background subagent and only sees what the
+  subagent engine hands it, and `TeamMessageBus.receive()` is called from tests
+  only. It now routes through the engine: `answer_task` when the member is blocked
+  in `ask_parent`, `steer_task` while it runs, and it says plainly when there is
+  nothing to deliver into instead of reporting "Message sent".
+- **A finished member left its shared task `in_progress` forever**, so the lead read
+  completed work as outstanding. `AgentTeam.sync_member` completes the todo when a
+  member completes, and releases the claim when one fails so the lead can reassign
+  it rather than watching a dead member hold it.
+
+### Added
+
+- **`create_team_toolset(subagent_toolset=...)`** — the subagent toolset backing
+  execution, which is what makes `message_teammate` able to deliver. The existing
+  `registry` / `task_fn` / `task_manager` arguments still work.
+- **`TeamMemberHandle.todo_id`**, linking a member to the shared-todo item it
+  claimed so finishing the task can close the todo.
+- **`TestTeamSubagentWiring`** in `tests/test_teams.py`, which fails on each of the
+  four defects independently.
+
+### Changed
+
+- `TestCreateTeamToolset::test_message_teammate` asserted the `"Message sent"` that
+  the third defect shows was a lie; it now asserts the honest outcome.
+
 ## [0.3.39] - 2026-07-26
 
 The pre-`features/` import paths are gone.

--- a/pydantic_deep/agent.py
+++ b/pydantic_deep/agent.py
@@ -1157,14 +1157,21 @@ def create_deep_agent(  # noqa: C901
         # Wire teams to subagent execution engine when both are enabled
         _team_kwargs: dict[str, Any] = {}
         if include_subagents and _subagent_task_manager is not None:
+            # Teams must share the registry the subagent toolset resolves names
+            # against. Handing them a fresh `DynamicAgentRegistry()` registered
+            # members somewhere `task` never looks, so every `assign_task`
+            # returned "Unknown subagent" while the team reported it as running.
             _team_registry = subagent_registry
             if _team_registry is None:
+                _team_registry = getattr(subagent_toolset, "registry", None)
+            if _team_registry is None:  # pragma: no cover - older subagents build
                 _team_registry = DynamicAgentRegistry()
             _team_kwargs["registry"] = _team_registry
             _team_kwargs["task_manager"] = _subagent_task_manager
 
             # Get the task() tool function from the subagent toolset
             if subagent_toolset is not None:  # pragma: no branch
+                _team_kwargs["subagent_toolset"] = subagent_toolset
                 _task_tool = subagent_toolset.tools.get("task")
                 if _task_tool is not None:
                     _team_kwargs["task_fn"] = _task_tool.function

--- a/pydantic_deep/features/teams/primitives.py
+++ b/pydantic_deep/features/teams/primitives.py
@@ -239,6 +239,9 @@ class TeamMemberHandle:
     status: Literal["idle", "running", "completed", "failed"] = "idle"
     result: str | None = None
     error: str | None = None
+    todo_id: str | None = None
+    """The shared-todo item this member's current task came from, so finishing the
+    task can close the todo."""
 
 
 @dataclass
@@ -277,6 +280,9 @@ class AgentTeam:
             created_by="team_lead",
         )
         await self.shared_todos.claim(item_id, member_name)
+        handle = self._handles.get(member_name)
+        if handle is not None:
+            handle.todo_id = item_id
         return item_id
 
     async def broadcast(self, message: str) -> None:
@@ -297,6 +303,25 @@ class AgentTeam:
             handle.error = th.error
             handle.status = "failed"
 
+    async def sync_member(self, handle: TeamMemberHandle) -> None:
+        """Refresh a member from the task manager and close its shared todo.
+
+        Without the todo half, a finished member left its task `in_progress` on the
+        shared list forever, so the lead read the work as still outstanding.
+        """
+        self._refresh_from_manager(handle)
+        if handle.todo_id is None:
+            return
+        if handle.status == "completed":
+            await self.shared_todos.complete(handle.todo_id)
+        elif handle.status == "failed":
+            # A failed task is no longer being worked on: release the claim so the
+            # lead can reassign it instead of watching a dead member hold it.
+            item = await self.shared_todos.get(handle.todo_id)
+            if item is not None and item.status == "in_progress":
+                item.status = "pending"
+                item.assigned_to = None
+
     async def wait_all(self) -> dict[str, str]:
         """Wait for all running member tasks to complete."""
         results: dict[str, str] = {}
@@ -312,7 +337,7 @@ class AgentTeam:
                 if task is not None and not task.done():
                     with contextlib.suppress(Exception):
                         await task
-                self._refresh_from_manager(handle)
+                await self.sync_member(handle)
             results[name] = handle.result or handle.error or "no result"
         return results
 

--- a/pydantic_deep/features/teams/toolset.py
+++ b/pydantic_deep/features/teams/toolset.py
@@ -8,7 +8,7 @@ from typing import Any
 from pydantic_ai.tools import RunContext
 from pydantic_ai.toolsets.function import FunctionToolset
 from pydantic_ai_backends import StateBackend
-from subagents_pydantic_ai import SubAgentConfig
+from subagents_pydantic_ai import SubAgentConfig, SubAgentToolset
 from subagents_pydantic_ai.toolset import _compile_subagent
 
 from pydantic_deep.features.teams.primitives import (
@@ -53,6 +53,23 @@ Call this when all team tasks are complete or the team is no longer needed. \
 This stops all running members and releases resources."""
 
 
+_TASK_ID_PREFIX = "Task ID:"
+
+
+def _extract_task_id(result: str) -> str | None:
+    """The background task id from a subagent `task` result, if it started one.
+
+    A refused delegation comes back as an error string with no `Task ID:` line,
+    which is how `assign_task` tells "started" from "rejected".
+    """
+    for line in result.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(_TASK_ID_PREFIX):
+            task_id = stripped[len(_TASK_ID_PREFIX) :].strip()
+            return task_id or None
+    return None
+
+
 def create_team_toolset(  # noqa: C901
     *,
     id: str | None = None,
@@ -61,6 +78,7 @@ def create_team_toolset(  # noqa: C901
     agent_factory: Callable[..., Any] | None = None,
     task_fn: Any | None = None,
     task_manager: Any | None = None,
+    subagent_toolset: SubAgentToolset | None = None,
 ) -> FunctionToolset[Any]:
     """Create a toolset for managing agent teams.
 
@@ -71,14 +89,21 @@ def create_team_toolset(  # noqa: C901
     Args:
         id: Toolset identifier. Defaults to `"deep-team"`.
         descriptions: Optional mapping of tool name to custom description.
-        registry: `DynamicAgentRegistry` for registering team members
-            as subagents at runtime.
+        registry: `DynamicAgentRegistry` for registering team members as
+            subagents at runtime. This must be the registry the subagent toolset
+            resolves names against — `subagent_toolset.registry` — or
+            `assign_task` cannot find the members it registered.
         agent_factory: Callable `(SubAgentConfig) -> Agent` used to
             create member agents. Passed as `agent_factory` on the
             SubAgentConfig so `_compile_subagent` uses it.
         task_fn: The subagent `task()` tool function. When provided,
             `assign_task` calls it to execute via the subagent engine.
         task_manager: Subagent `TaskManager` for checking task status.
+        subagent_toolset: The subagent toolset backing execution. Required for
+            `message_teammate` to actually deliver: a member is a background
+            subagent, so a message has to go through the subagent engine
+            (`answer_task` when it is waiting, `steer_task` while it runs).
+            Without it, messages are only recorded on the team bus.
 
     Returns:
         A `FunctionToolset` with team management tools.
@@ -172,21 +197,30 @@ def create_team_toolset(  # noqa: C901
                     subagent_type=member_name,
                     mode="async",
                 )
-                handle.status = "running"
-                # Extract task_id from subagent result if available
-                if "Task ID:" in str(result):
-                    for part in str(result).split():
-                        if len(part) == 8 and part.isalnum():
-                            handle.task_id = part
-                            break
-                return (
-                    f"Task assigned to '{member_name}' (todo: {item_id}). "
-                    f"Agent running in background.\n{result}"
-                )
             except Exception as e:
                 handle.status = "failed"
                 handle.error = str(e)
                 return f"Error starting task for '{member_name}': {e}"
+
+            # The subagent `task` tool reports a refused delegation (an unknown
+            # subagent, a busy chat trace) as an error string rather than raising.
+            # Treating that as a started task left the member "running" forever,
+            # so the team looked alive and never produced a result.
+            task_id = _extract_task_id(str(result))
+            if task_id is None:
+                handle.status = "failed"
+                handle.error = str(result)
+                return (
+                    f"Error starting task for '{member_name}': the subagent engine "
+                    f"did not start a background task.\n{result}"
+                )
+
+            handle.task_id = task_id
+            handle.status = "running"
+            return (
+                f"Task assigned to '{member_name}' (todo: {item_id}). "
+                f"Agent running in background.\n{result}"
+            )
 
         return f"Task assigned to '{member_name}' (ID: {item_id})"
 
@@ -211,14 +245,10 @@ def create_team_toolset(  # noqa: C901
                 th = task_manager.get_handle(handle.task_id)
                 if th is not None:
                     status = th.status.value
-                    if th.result:
-                        handle.result = th.result
-                        handle.status = "completed"
-                        status = "completed"
-                    elif th.error:
-                        handle.error = th.error
-                        handle.status = "failed"
-                        status = "failed"
+                    # Also closes the member's shared todo once it finishes.
+                    await team.sync_member(handle)
+                    if handle.status in ("completed", "failed"):
+                        status = handle.status
 
             status_line = f"- {name}: {status}"
             if handle.status == "completed" and handle.result:
@@ -254,8 +284,27 @@ def create_team_toolset(  # noqa: C901
             available = ", ".join(team._handles.keys())
             return f"Error: Member '{member_name}' not found. Available: {available}"
 
+        handle = team._handles[member_name]
+        # The team bus is the peer-to-peer record, but nothing running reads it:
+        # a member is a background subagent, and it only sees messages the
+        # subagent engine delivers. Writing to the bus alone reported success and
+        # delivered nothing.
         await team.message_bus.send("team_lead", member_name, message)
-        return f"Message sent to '{member_name}'"
+
+        if handle.task_id is None or subagent_toolset is None:
+            return (
+                f"Message recorded for '{member_name}', but it has no running task "
+                f"to deliver it to. Assign a task first."
+            )
+
+        if subagent_toolset.answer_task(handle.task_id, message):
+            return f"Answer delivered to '{member_name}', which was waiting for one."
+        if await subagent_toolset.steer_task(handle.task_id, message):
+            return f"Message delivered to '{member_name}'; it will be applied on its next step."
+        return (
+            f"Message recorded for '{member_name}', but its task is no longer "
+            f"running (status: {handle.status}), so nothing was delivered."
+        )
 
     @toolset.tool(description=_descs.get("dissolve_team", DISSOLVE_TEAM_DESCRIPTION))
     async def dissolve_team(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-deep"
-version = "0.3.39"
+version = "0.3.40"
 description = "Batteries-included agent harness for Python — tool-calling, sandboxed execution, multi-agent teams, and unlimited context on Pydantic AI"
 readme = "README.md"
 keywords = [

--- a/tests/test_instructions.py
+++ b/tests/test_instructions.py
@@ -65,7 +65,13 @@ class TestSections:
         assert provider(_ctx()) == ""
 
     def test_subagent_section_lists_specialists(self) -> None:
-        configs: list[SubAgentConfig] = [{"name": "researcher", "description": "Researches things"}]
+        configs: list[SubAgentConfig] = [
+            {
+                "name": "researcher",
+                "description": "Researches things",
+                "instructions": "Research.",
+            }
+        ]
         provider = make_subagent_section(configs)
         assert "researcher" in provider(_ctx())
 
@@ -94,8 +100,12 @@ class TestSections:
 
     def test_lean_subagent_section_lists_roster_only(self) -> None:
         configs: list[SubAgentConfig] = [
-            {"name": "planner", "description": "Plans things"},
-            {"name": "research", "description": "Researches things"},
+            {"name": "planner", "description": "Plans things", "instructions": "Plan."},
+            {
+                "name": "research",
+                "description": "Researches things",
+                "instructions": "Research.",
+            },
         ]
         text = make_lean_subagent_section(configs)(_ctx())
         assert "planner" in text and "research" in text
@@ -142,7 +152,9 @@ class TestBuildAndRender:
         assert len(providers) == 5
 
     def test_tool_search_swaps_in_lean_sections(self) -> None:
-        configs: list[SubAgentConfig] = [{"name": "planner", "description": "Plans"}]
+        configs: list[SubAgentConfig] = [
+            {"name": "planner", "description": "Plans", "instructions": "Plan."}
+        ]
         providers = build_instruction_providers(
             include_todo=True,
             include_filesystem=True,

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -527,7 +527,7 @@ class TestPerSubagentMemory:
         _inject_subagent_memory_toolset(config, None)
 
         assert "toolsets" in config
-        memory_toolsets = [
+        memory_toolsets: list[Any] = [
             t for t in config["toolsets"] if type(t).__name__ == "AgentMemoryToolset"
         ]
         assert len(memory_toolsets) == 1

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -850,16 +850,20 @@ class TestCreateTeamToolset:
         assert "Build feature" in result
         assert "@alice" in result
 
-    async def test_message_teammate(self):
-        """message_teammate sends a message."""
+    async def test_message_teammate_records_but_cannot_deliver_without_a_task(self):
+        """Without a running task there is nothing to deliver into, and it says so.
+
+        This used to report "Message sent to 'alice'" while the message sat on a
+        queue no running member ever reads.
+        """
         toolset = create_team_toolset()
         ctx = _make_ctx()
         await toolset.tools["spawn_team"].function(ctx, "team1", [TeamMemberSpec(name="alice")])
         result = await toolset.tools["message_teammate"].function(
             ctx, "alice", "Please review this"
         )
-        assert "Message sent" in result
         assert "alice" in result
+        assert "no running task" in result
 
     async def test_message_teammate_no_team(self):
         """message_teammate errors if no team."""
@@ -1027,3 +1031,198 @@ class TestTeamsExports:
         from pydantic_deep.features.teams import create_team_toolset
 
         assert create_team_toolset is not None
+
+
+class TestTeamSubagentWiring:
+    """Regressions for teams wired to the subagent execution engine.
+
+    Each of these shipped as a silent failure: the tools reported success and the
+    team never produced a result.
+    """
+
+    @staticmethod
+    def _subagent_toolset() -> Any:
+        from subagents_pydantic_ai import create_subagent_toolset
+
+        return create_subagent_toolset(
+            id="deep-subagents",
+            include_general_purpose=False,
+            registry=None,
+        )
+
+    @staticmethod
+    def _team(subagent_toolset: Any, **overrides: Any) -> Any:
+        from pydantic_ai import Agent
+
+        kwargs: dict[str, Any] = {
+            "registry": subagent_toolset.registry,
+            "task_manager": subagent_toolset.task_manager,
+            "task_fn": subagent_toolset.tools["task"].function,
+            "subagent_toolset": subagent_toolset,
+            "agent_factory": lambda cfg: Agent(
+                TestModel(call_tools=[], custom_output_text="member done")
+            ),
+        }
+        kwargs.update(overrides)
+        return create_team_toolset(**kwargs)
+
+    @pytest.mark.asyncio
+    async def test_default_agent_shares_the_subagent_registry(self):
+        """`create_deep_agent()` must not give teams a registry `task` never reads.
+
+        With `subagent_registry=None` (the default) teams used to build a fresh
+        `DynamicAgentRegistry()`, so members were registered somewhere the subagent
+        `task` tool never looked and every `assign_task` failed.
+        """
+        agent = create_deep_agent(
+            model=TEST_MODEL,
+            include_subagents=True,
+            include_teams=True,
+            include_filesystem=False,
+            include_todo=False,
+            include_skills=False,
+            include_plan=False,
+            include_monitoring=False,
+            context_manager=False,
+            cost_tracking=False,
+        )
+        toolsets = {ts.id: ts for ts in agent.toolsets if getattr(ts, "id", None)}
+        subagents = toolsets.get("deep-subagents")
+        team = toolsets.get("deep-team")
+        assert subagents is not None
+        assert team is not None
+
+        # Drive the toolsets the agent actually built, so the assertion covers
+        # `create_deep_agent`'s wiring rather than this test's own.
+        ctx = _make_ctx()
+        # `model="test"` keeps the real `_deep_agent_factory` off a live provider.
+        await team.tools["spawn_team"].function(
+            ctx,
+            "build",
+            [TeamMemberSpec(name="coder", instructions="You code.", model="test")],
+        )
+
+        assert "coder" in subagents.registry.list_agents()
+        assert subagents.registry.get_compiled("coder") is not None
+
+    @pytest.mark.asyncio
+    async def test_assign_task_reaches_the_member(self):
+        subagents = self._subagent_toolset()
+        team = self._team(subagents)
+        ctx = _make_ctx()
+        await team.tools["spawn_team"].function(
+            ctx, "build", [TeamMemberSpec(name="coder", instructions="You code.")]
+        )
+
+        result = await team.tools["assign_task"].function(ctx, "coder", "write a parser")
+
+        assert "Agent running in background" in result
+        assert "Unknown subagent" not in result
+        await asyncio.gather(*subagents.task_manager.tasks.values(), return_exceptions=True)
+        status = await team.tools["check_teammates"].function(ctx)
+        assert "coder: completed" in status
+        assert "member done" in status
+
+    @pytest.mark.asyncio
+    async def test_assign_task_reports_a_refused_delegation(self):
+        """The subagent `task` tool returns an error string rather than raising.
+
+        Treating that as a started task left the member `running` forever.
+        """
+        subagents = self._subagent_toolset()
+        team = self._team(subagents, registry=None)
+        ctx = _make_ctx()
+        await team.tools["spawn_team"].function(
+            ctx, "build", [TeamMemberSpec(name="ghost", instructions="You code.")]
+        )
+
+        result = await team.tools["assign_task"].function(ctx, "ghost", "do it")
+
+        assert "Error starting task" in result
+        status = await team.tools["check_teammates"].function(ctx)
+        assert "ghost: failed" in status
+        assert "ghost: running" not in status
+
+    @pytest.mark.asyncio
+    async def test_completed_member_closes_its_shared_todo(self):
+        """A finished member used to leave its task `in_progress` forever."""
+        subagents = self._subagent_toolset()
+        team = self._team(subagents)
+        ctx = _make_ctx()
+        await team.tools["spawn_team"].function(
+            ctx, "build", [TeamMemberSpec(name="coder", instructions="You code.")]
+        )
+        await team.tools["assign_task"].function(ctx, "coder", "write a parser")
+        await asyncio.gather(*subagents.task_manager.tasks.values(), return_exceptions=True)
+
+        status = await team.tools["check_teammates"].function(ctx)
+
+        assert "[completed] write a parser" in status
+
+    @pytest.mark.asyncio
+    async def test_failed_member_releases_its_shared_todo(self):
+        """A dead member must not hold a claim the lead could reassign."""
+        subagents = self._subagent_toolset()
+        team = self._team(subagents)
+        ctx = _make_ctx()
+        await team.tools["spawn_team"].function(
+            ctx, "build", [TeamMemberSpec(name="coder", instructions="You code.")]
+        )
+        await team.tools["assign_task"].function(ctx, "coder", "write a parser")
+        await asyncio.gather(*subagents.task_manager.tasks.values(), return_exceptions=True)
+
+        # Force the underlying subagent task to look failed.
+        handle = next(iter(subagents.task_manager.handles.values()))
+        handle.result = None
+        handle.error = "boom"
+
+        status = await team.tools["check_teammates"].function(ctx)
+
+        assert "coder: failed" in status
+        assert "[pending] write a parser" in status
+
+    @pytest.mark.asyncio
+    async def test_message_teammate_answers_a_waiting_member(self):
+        """The team bus is not read by anything running; delivery goes via subagents."""
+        from pydantic_ai import Agent
+        from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart
+        from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+        def model_fn(messages: list[Any], info: AgentInfo) -> ModelResponse:
+            if not [m for m in messages if isinstance(m, ModelResponse)]:
+                return ModelResponse(
+                    parts=[ToolCallPart(tool_name="ask_parent", args={"question": "which?"})]
+                )
+            return ModelResponse(parts=[TextPart(content="answered")])
+
+        subagents = self._subagent_toolset()
+        team = self._team(subagents, agent_factory=lambda cfg: Agent(FunctionModel(model_fn)))
+        ctx = _make_ctx()
+        await team.tools["spawn_team"].function(
+            ctx, "build", [TeamMemberSpec(name="coder", instructions="You code.")]
+        )
+        await team.tools["assign_task"].function(ctx, "coder", "write a parser")
+
+        for _ in range(50):
+            await asyncio.sleep(0.01)
+            if "waiting_for_answer" in await team.tools["check_teammates"].function(ctx):
+                break
+
+        result = await team.tools["message_teammate"].function(ctx, "coder", "Python")
+
+        assert "Answer delivered" in result
+        await asyncio.gather(*subagents.task_manager.tasks.values(), return_exceptions=True)
+        assert "coder: completed" in await team.tools["check_teammates"].function(ctx)
+
+    @pytest.mark.asyncio
+    async def test_message_teammate_without_a_running_task_says_so(self):
+        subagents = self._subagent_toolset()
+        team = self._team(subagents)
+        ctx = _make_ctx()
+        await team.tools["spawn_team"].function(
+            ctx, "build", [TeamMemberSpec(name="coder", instructions="You code.")]
+        )
+
+        result = await team.tools["message_teammate"].function(ctx, "coder", "hello")
+
+        assert "no running task" in result

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -1086,7 +1086,11 @@ class TestTeamSubagentWiring:
             context_manager=False,
             cost_tracking=False,
         )
-        toolsets = {ts.id: ts for ts in agent.toolsets if getattr(ts, "id", None)}
+        # `agent.toolsets` is typed as the abstract base; the concrete toolsets
+        # carry the `tools` / `registry` surface these assertions read.
+        toolsets: dict[str, Any] = {
+            ts_id: cast(Any, ts) for ts in agent.toolsets if (ts_id := ts.id) is not None
+        }
         subagents = toolsets.get("deep-subagents")
         team = toolsets.get("deep-team")
         assert subagents is not None


### PR DESCRIPTION
Agent teams delegate execution to the subagent engine, and never actually ran a
member. Four defects compounded, each of them silent — the tools reported success
and the team produced nothing, so the lead saw work perpetually "running".

> **Stacked on #186** (`0.3.39`), which this branch was built on. Base is `0.3.39`,
> not `main`.
>
> **Requires `subagents-pydantic-ai >= 0.2.12`** — vstorm-co/pydantic-ai-subagents#58.
> `message_teammate` calls `SubAgentToolset.answer_task` / `steer_task`, and the
> registry fix reads `SubAgentToolset.registry`; neither exists in 0.2.11. The
> dependency floor is deliberately **not** raised here, because 0.2.12 is not on
> PyPI yet and the lock could not resolve. Merge after that release, then let
> renovate raise the floor (cf. #189).

## The four defects

**1. Teams registered members in a registry the subagent engine never reads.**

With `subagent_registry=None` — the `create_deep_agent` default — the team block in
`agent.py` built a fresh `DynamicAgentRegistry()`. `spawn_team` registered members
into it; the subagent `task` tool resolves names against its own. Every
`assign_task` came back `Error: Unknown subagent`. Teams plus subagents was broken
in the default configuration:

```
registered in team registry: ['coder']
visible to subagent toolset: []
assign: Task assigned to 'coder'. Agent running in background.
Error: Unknown subagent 'coder'. Available:
```

Teams now share `subagent_toolset.registry`.

**2. A refused delegation was recorded as a started task.**

The subagent `task` tool reports an unknown subagent, or a busy chat trace, as an
error *string* rather than raising — so `assign_task`'s `except` never fired. It set
the member to `running` and appended the error text to an "Agent running in
background" message, and the member sat at `running` forever. A started task is now
identified by its `Task ID:` line, and a refusal marks the member `failed` with the
reason.

**3. `message_teammate` delivered nothing.**

It wrote to `TeamMessageBus`, which nothing running reads: a member is a background
subagent and only sees what the subagent engine hands it, and
`TeamMessageBus.receive()` is called from tests only. The tool reported "Message
sent to 'alice'" and the message sat on a queue forever.

It now routes through the engine — `answer_task` when the member is blocked in
`ask_parent`, `steer_task` while it runs — and says plainly when there is nothing to
deliver into. End to end, a member can now ask a question and get an answer:

```
msg: Answer delivered to 'coder', which was waiting for one.
- coder: completed
```

**4. Shared todos never closed.**

A finished member left its task `in_progress` on the shared list, so the lead read
completed work as outstanding. `AgentTeam.sync_member` completes the todo when a
member completes, and *releases the claim* when one fails, so the lead can reassign
it instead of watching a dead member hold it.

## Changes

- `agent.py`: the team registry falls back to `subagent_toolset.registry`, and the
  toolset itself is passed through as `subagent_toolset`.
- `features/teams/toolset.py`: `_extract_task_id` decides started-vs-refused;
  `message_teammate` delivers through the subagent engine; `check_teammates` syncs
  through `AgentTeam.sync_member`.
- `features/teams/primitives.py`: `TeamMemberHandle.todo_id` links a member to the
  item it claimed; `AgentTeam.sync_member` closes or releases that todo.
- `create_team_toolset` gains `subagent_toolset`. The existing `registry` /
  `task_fn` / `task_manager` arguments are unchanged.

## Tests

`TestTeamSubagentWiring` — 7 tests, each failing on its own defect (verified by
reverting the fixes one at a time). `test_default_agent_shares_the_subagent_registry`
drives the toolsets `create_deep_agent` actually builds, so it covers the wiring
rather than the test's own setup.

`TestCreateTeamToolset::test_message_teammate` asserted the `"Message sent"` that
defect 3 shows was a lie. It now asserts the honest outcome and is renamed to say
what it checks.

Full suite: **2781 passed**.

## Not changed

Team members get `ask_parent` with the subagent default 300-second timeout, so a
member that asks while the lead is not polling blocks for five minutes. That is a
policy decision rather than a bug — `subagents-pydantic-ai` 0.2.12 exposes
`ask_timeout_seconds` if we want teams to set something shorter.
