### PR TITLE
fix(teams): shorten the subagent ask timeout to 60s (0.3.41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.41] - 2026-08-01
+
+### Changed
+
+- **A subagent blocked in `ask_parent` now waits 60s, not 300s.**
+  `subagents-pydantic-ai` defaults to a five-minute wait, which a team member
+  inherits: one that asks a question while the lead is not polling holds its slot
+  for the whole timeout, and five minutes of that is indistinguishable from a hung
+  agent. After the timeout the subagent is told to proceed on its own judgment
+  rather than being cancelled, so the work still finishes.
+
+### Added
+
+- **`create_deep_agent(subagent_ask_timeout_seconds=...)`** and
+  `DEFAULT_SUBAGENT_ASK_TIMEOUT_SECONDS` (60.0), for raising the wait back up when
+  a human is reliably in the loop.
+
 ## [0.3.40] - 2026-08-01
 
 Agent teams were wired to the subagent execution engine but never actually ran a

--- a/pydantic_deep/agent.py
+++ b/pydantic_deep/agent.py
@@ -89,6 +89,7 @@ from pydantic_deep.instructions import build_instruction_providers, render_instr
 from pydantic_deep.models import (
     DEFAULT_IMPROVE_MODEL,
     DEFAULT_MODEL,
+    DEFAULT_SUBAGENT_ASK_TIMEOUT_SECONDS,
     DEFAULT_SUMMARIZATION_MODEL,
 )
 from pydantic_deep.prompts import BASE_PROMPT
@@ -482,6 +483,7 @@ def create_deep_agent(
     subagent_registry: DynamicAgentRegistry | None = None,
     subagent_extra_toolsets: Sequence[AbstractToolset[Any]] | None = None,
     subagent_usage_limits: UsageLimits | UsageLimitsFactory | None = None,
+    subagent_ask_timeout_seconds: float = DEFAULT_SUBAGENT_ASK_TIMEOUT_SECONDS,
     include_execute: bool | None = None,
     interrupt_on: dict[str, bool] | None = None,
     output_type: None = None,
@@ -562,6 +564,7 @@ def create_deep_agent(
     subagent_registry: DynamicAgentRegistry | None = None,
     subagent_extra_toolsets: Sequence[AbstractToolset[Any]] | None = None,
     subagent_usage_limits: UsageLimits | UsageLimitsFactory | None = None,
+    subagent_ask_timeout_seconds: float = DEFAULT_SUBAGENT_ASK_TIMEOUT_SECONDS,
     include_execute: bool | None = None,
     interrupt_on: dict[str, bool] | None = None,
     *,
@@ -642,6 +645,7 @@ def create_deep_agent(  # noqa: C901
     subagent_registry: DynamicAgentRegistry | None = None,
     subagent_extra_toolsets: Sequence[AbstractToolset[Any]] | None = None,
     subagent_usage_limits: UsageLimits | UsageLimitsFactory | None = None,
+    subagent_ask_timeout_seconds: float = DEFAULT_SUBAGENT_ASK_TIMEOUT_SECONDS,
     include_execute: bool | None = None,
     interrupt_on: dict[str, bool] | None = None,
     output_type: OutputSpec[OutputDataT] | None = None,
@@ -766,6 +770,12 @@ def create_deep_agent(  # noqa: C901
             and a larger `request_limit` for heavy research/execution ones.
             `None` (default) leaves pydantic-ai's own default in place. Only
             takes effect when `include_subagents=True`.
+        subagent_ask_timeout_seconds: How long a subagent blocked in `ask_parent`
+            waits before giving up and finishing on its own judgment. Defaults to
+            60s rather than the library's 300s: a team member that asks while the
+            lead is not polling holds its slot for the whole timeout, and five
+            minutes of that reads as a hung agent. Raise it when a human is
+            reliably in the loop.
         include_execute: Whether to include the execute tool. If None (default),
             automatically determined based on whether backend is a SandboxProtocol.
             Set to True to force include even when backend is None (useful when
@@ -1089,6 +1099,7 @@ def create_deep_agent(  # noqa: C901
             max_nesting_depth=max_nesting_depth,
             registry=subagent_registry,
             usage_limits=subagent_usage_limits,
+            ask_timeout_seconds=subagent_ask_timeout_seconds,
         )
         all_toolsets.append(subagent_toolset)
         _subagent_task_manager = getattr(subagent_toolset, "task_manager", None)

--- a/pydantic_deep/models.py
+++ b/pydantic_deep/models.py
@@ -30,6 +30,14 @@ DEFAULT_JUDGE_MODEL: Final = "anthropic:claude-haiku-4-5-20251001"
 """Model for the fork-merge autonomous judge."""
 
 DEFAULT_TEAM_MEMBER_MODEL: Final = "anthropic:claude-sonnet-4-6"
+
+DEFAULT_SUBAGENT_ASK_TIMEOUT_SECONDS: Final = 60.0
+"""How long a subagent blocked in `ask_parent` waits for the parent.
+
+Shorter than subagents-pydantic-ai's own 300s default. A team member that asks a
+question while the lead is not polling holds its slot for the entire timeout, and
+five minutes of that is indistinguishable from a hung agent. After the timeout the
+subagent is told to proceed on its own judgment rather than being cancelled."""
 """Default model for spawned agent-team members."""
 
 DEFAULT_REMINDER_MODEL: Final = "anthropic:claude-haiku-4-5-20251001"

--- a/pydantic_deep/spec.py
+++ b/pydantic_deep/spec.py
@@ -47,6 +47,7 @@ from pydantic_ai_backends import StateBackend
 from pydantic_deep.agent import create_deep_agent
 from pydantic_deep.deps import DeepAgentDeps
 from pydantic_deep.features.checkpointing import CheckpointFrequency
+from pydantic_deep.models import DEFAULT_SUBAGENT_ASK_TIMEOUT_SECONDS
 
 
 class DeepAgentSpec(BaseModel):
@@ -89,6 +90,7 @@ class DeepAgentSpec(BaseModel):
     thinking: bool | str = "high"
     include_history_archive: bool = True
     max_nesting_depth: int = 1
+    subagent_ask_timeout_seconds: float = DEFAULT_SUBAGENT_ASK_TIMEOUT_SECONDS
     interrupt_on: dict[str, bool] | None = None
     eviction_token_limit: int | None = 20_000
     max_binary_content: int | None = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-deep"
-version = "0.3.40"
+version = "0.3.41"
 description = "Batteries-included agent harness for Python — tool-calling, sandboxed execution, multi-agent teams, and unlimited context on Pydantic AI"
 readme = "README.md"
 keywords = [

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -1268,3 +1268,50 @@ class TestSyncMemberEdgeCases:
         item = await team.shared_todos.get(item_id)
         assert item is not None
         assert item.status == "completed"
+
+
+class TestSubagentAskTimeout:
+    """A team member that asks must not hold its slot for five minutes."""
+
+    def test_default_is_shortened_for_deep_agents(self):
+        """The library default is 300s; a member asking an unattended lead stalls."""
+        from pydantic_deep.models import DEFAULT_SUBAGENT_ASK_TIMEOUT_SECONDS
+
+        agent = create_deep_agent(
+            model=TEST_MODEL,
+            include_subagents=True,
+            include_teams=True,
+            include_filesystem=False,
+            include_todo=False,
+            include_skills=False,
+            include_plan=False,
+            include_monitoring=False,
+            context_manager=False,
+            cost_tracking=False,
+        )
+        toolsets: dict[str, Any] = {
+            ts_id: cast(Any, ts) for ts in agent.toolsets if (ts_id := ts.id) is not None
+        }
+
+        assert DEFAULT_SUBAGENT_ASK_TIMEOUT_SECONDS == 60.0
+        assert toolsets["deep-subagents"]._ask_timeout_seconds == 60.0
+
+    def test_callers_can_override_it(self):
+        agent = create_deep_agent(
+            model=TEST_MODEL,
+            include_subagents=True,
+            include_filesystem=False,
+            include_todo=False,
+            include_skills=False,
+            include_plan=False,
+            include_teams=False,
+            include_monitoring=False,
+            context_manager=False,
+            cost_tracking=False,
+            subagent_ask_timeout_seconds=5.0,
+        )
+        toolsets: dict[str, Any] = {
+            ts_id: cast(Any, ts) for ts in agent.toolsets if (ts_id := ts.id) is not None
+        }
+
+        assert toolsets["deep-subagents"]._ask_timeout_seconds == 5.0


### PR DESCRIPTION
Follow-up to #191. A subagent blocked in `ask_parent` inherited
`subagents-pydantic-ai`'s 300-second default. A team member that asks a question
while the lead is not polling holds its slot for the whole timeout, and five
minutes of that is indistinguishable from a hung agent — I hit it while testing
#191 and a `TestModel` run sat there until it was killed.

After the timeout the subagent is told to proceed on its own judgment rather than
being cancelled, so the work still finishes; the change only shortens how long it
waits first.

## Changes

- `DEFAULT_SUBAGENT_ASK_TIMEOUT_SECONDS = 60.0` in `pydantic_deep/models.py`.
- `create_deep_agent(subagent_ask_timeout_seconds=...)` on all three overloads,
  passed through to `create_subagent_toolset` (0.2.12 exposes it).
- Modelled on `DeepAgentSpec` — the repo's own `test_serializable_factory_params_are_modeled`
  drift guard caught the omission, which is exactly what it is for.
- Two tests: the default applies to the toolset the agent builds, and callers can
  override it.

Raise it when a human is reliably in the loop.

Verified locally: ruff, pyright, mypy (169 files), bandit, mkdocs, **2785 tests**,
coverage 100%.
