### PR TITLE
chore: require `pydantic-ai-backend>=0.2.18` and re-export the async sandbox base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.42] - 2026-08-01
+
+### Changed
+
+- **Requires `pydantic-ai-backend>=0.2.18`**, which is a bug-fix release worth
+  taking: a directory listing reported shell-quoted paths, so a directory with a
+  space in its name was unreachable — the model was handed a path it could not
+  read back; a glob aborted its whole walk on one unreadable entry and returned a
+  silently short listing; and a Kubernetes exec reported an unknown status as
+  success, so every truncated command looked like it had passed.
+
+### Added
+
+- **`AsyncBaseSandbox` and `is_async_backend`** re-exported from
+  `pydantic_deep`, alongside `BaseSandbox`. Subclass `AsyncBaseSandbox` for a
+  sandbox reached over an async transport — asyncssh, an async HTTP SDK — and
+  implement `execute` and `edit` as coroutines; every other file operation is
+  derived from shell commands, as with the synchronous base.
+
+  Prefer it to wrapping async code in a synchronous facade. `ensure_async` cannot
+  see through a facade, so it thread-wraps it and each call then occupies a worker
+  thread that has to hop back onto the event loop; a sandbox whose own recovery
+  path also needs a thread deadlocks against its own pool. `is_async_backend` is
+  the check `ensure_async` performs, exposed so a host can ask the same question.
+
 ## [0.3.41] - 2026-08-01
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `LocalBackend`: Real filesystem operations
 - `DockerSandbox`: Isolated Docker container execution
 - `CompositeBackend`: Combines multiple backends with routing
+- `BaseSandbox` / `AsyncBaseSandbox`: Bases for a custom sandbox — implement
+  `execute` and `edit` and every file operation is derived from shell commands.
+  Use the async one for a natively async transport (asyncssh, an async SDK)
+  rather than a sync facade, which `ensure_async` cannot see through and which
+  deadlocks against its own thread pool under load.
 
 **Toolsets (`pydantic_deep/features/<name>/toolset.py`)**
 - `TodoToolset`: Task planning and tracking tools (read_todos, write_todos) - from [pydantic-ai-todo](https://github.com/vstorm-co/pydantic-ai-todo)

--- a/docs/api/backends.md
+++ b/docs/api/backends.md
@@ -15,6 +15,7 @@ from pydantic_deep import (
     CompositeBackend,
     DockerSandbox,
     BaseSandbox,
+    AsyncBaseSandbox,
     # Protocols
     BackendProtocol,
     SandboxProtocol,
@@ -46,6 +47,26 @@ from pydantic_deep import (
 | `StateBackend` | In-memory storage for testing | [Link](https://vstorm-co.github.io/pydantic-ai-backend/concepts/backends/#statebackend) |
 | `DockerSandbox` | Docker container execution | [Link](https://vstorm-co.github.io/pydantic-ai-backend/concepts/docker/) |
 | `CompositeBackend` | Route by path prefix | [Link](https://vstorm-co.github.io/pydantic-ai-backend/concepts/backends/#compositebackend) |
+
+## Writing your own backend
+
+Subclass one of the two bases rather than implementing `BackendProtocol` by hand:
+each derives every file operation from shell commands, so you implement `execute`
+and `edit` and get the rest.
+
+| Base | For a sandbox reached | Notes |
+|---|---|---|
+| `BaseSandbox` | synchronously — a socket, a subprocess | |
+| `AsyncBaseSandbox` | over an async transport — `asyncssh`, an async HTTP SDK | Implement `execute` and `edit` as coroutines |
+
+Pick `AsyncBaseSandbox` for a natively async sandbox rather than wrapping it in a
+synchronous facade: `ensure_async` cannot see through a facade, so it thread-wraps
+it and every call then occupies a worker thread that has to hop back onto the
+event loop. A sandbox whose own recovery path also needs a thread deadlocks
+against its own pool. `is_async_backend` is the check `ensure_async` uses, exposed
+so a host can ask the same question.
+
+See [Writing your own backend](https://vstorm-co.github.io/pydantic-ai-backend/concepts/backends/#writing-your-own-backend).
 
 ## Console Toolset
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -34,6 +34,7 @@ from pydantic_deep import (
     LocalBackend,
     CompositeBackend,
     BaseSandbox,
+    AsyncBaseSandbox,
     DockerSandbox,
 
     # Processors

--- a/pydantic_deep/__init__.py
+++ b/pydantic_deep/__init__.py
@@ -48,6 +48,7 @@ Example:
 
 from pydantic_ai_backends import (
     BUILTIN_RUNTIMES,
+    AsyncBaseSandbox,
     BackendProtocol,
     BaseSandbox,
     CompositeBackend,
@@ -67,6 +68,7 @@ from pydantic_ai_backends import (
     create_console_toolset,
     get_console_system_prompt,
     get_runtime,
+    is_async_backend,
 )
 from pydantic_ai_shields import (
     BudgetExceededError,
@@ -343,6 +345,8 @@ __all__ = [
     "StateBackend",
     "CompositeBackend",
     "BaseSandbox",
+    "AsyncBaseSandbox",
+    "is_async_backend",
     "DockerSandbox",
     # Runtimes
     "RuntimeConfig",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-deep"
-version = "0.3.41"
+version = "0.3.42"
 description = "Batteries-included agent harness for Python — tool-calling, sandboxed execution, multi-agent teams, and unlimited context on Pydantic AI"
 readme = "README.md"
 keywords = [
@@ -42,7 +42,7 @@ classifiers = [
 dependencies = [
     "pydantic-ai-slim[web-fetch]>=2.0.0",
     "pydantic-ai-todo>=0.2.7",
-    "pydantic-ai-backend[console]>=0.2.16",
+    "pydantic-ai-backend[console]>=0.2.18",
     "summarization-pydantic-ai>=0.1.11",
     "subagents-pydantic-ai>=0.2.12",
     "pydantic-ai-shields>=0.3.4",
@@ -52,7 +52,7 @@ dependencies = [
 
 [project.optional-dependencies]
 # Docker sandbox support
-sandbox = ["pydantic-ai-backend[docker]>=0.2.16"]
+sandbox = ["pydantic-ai-backend[docker]>=0.2.18"]
 # YAML support for skills (pyyaml-based frontmatter parsing)
 yaml = ["pyyaml>=6.0"]
 # CLI tools + TUI (terminal assistant)


### PR DESCRIPTION
Bumps to 0.2.18 and picks up its new public API. **Supersedes #192**, the open renovate bump to 0.2.17.

## Why this one is worth taking

0.2.18 is a bug-fix release, and three of the fixes are reachable from here:

- `ls_info` reported **shell-quoted** paths, so a directory with a space in its name was unreachable — the model was handed `'/my work'/notes.md`, sent it back to `read`, and got a failure it could not recover from.
- `glob_info` aborted its whole walk on one unreadable entry and returned a **silently short** listing. Four matching files with one bad entry returned one.
- A Kubernetes exec reported an unknown status as **success**, so every truncated command looked like it had passed — and leaked a websocket per failed command.

Also in 0.2.18: `is_async_backend` was announced as public API in 0.2.17 but never actually exported, and no blanket `# pragma: no cover` remains in that package — removing them is what found three of the four bugs.

## What is new here

`AsyncBaseSandbox` and `is_async_backend` are re-exported alongside `BaseSandbox`, and documented in `docs/api/backends.md` with the one thing worth knowing: subclass the async base for a natively async sandbox rather than wrapping it in a synchronous facade.

`ensure_async` cannot see through a facade, so it thread-wraps it and each call then occupies a worker thread that has to hop back onto the event loop; a sandbox whose own recovery path also needs a thread deadlocks against its own pool. That is not theoretical — it came from a deployment where it froze a whole single-loop runtime rather than one tool call.

## Verification

2785 tests pass against 0.2.18 with no source changes needed, 100% coverage, pyright clean.

I checked the integration points before trusting that: `ensure_async`, the `AsyncBackendAdapter` unwrapping in `deps.py`, and `SessionManager` — 0.2.18 changed async detection and the session lifecycle, and all of it is additive here. `unwrap_backend` uses `getattr(backend, "unwrap", ...)`, so a natively async backend passes through unchanged.

## One unrelated note

`uv run ruff format --check` reports 50 files on `main` as well, because it resolves ruff 0.16.1 from PATH while this project pins `<0.16`. Under the locked 0.14.10 everything is formatted and lint is clean. Not caused by this PR, but worth pinning down if it ever reaches CI.
