### PR TITLE
fix(teams): make spawn_team members inherit lead model, web settings, backend and toolsets

### DIFF
--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -376,7 +376,7 @@ class TeamMember:
     role: str
     description: str
     instructions: str
-    model: str = "anthropic:claude-sonnet-4-6"
+    model: str | None = None        # Inherits the team lead's model when unset
     toolsets: list[Any] = []
 ```
 

--- a/pydantic_deep/agent.py
+++ b/pydantic_deep/agent.py
@@ -1190,6 +1190,7 @@ def create_deep_agent(  # noqa: C901
             # Factory that creates deep agents for team members
             _team_model = model
             _team_edit_fmt = edit_format
+            _team_kwargs["default_model"] = model
 
             def _deep_agent_factory(cfg: dict[str, Any]) -> Any:  # pragma: no cover
                 _team_task_instructions = cfg.get("instructions") or ""

--- a/pydantic_deep/agent.py
+++ b/pydantic_deep/agent.py
@@ -1192,7 +1192,7 @@ def create_deep_agent(  # noqa: C901
             _team_edit_fmt = edit_format
             _team_kwargs["default_model"] = model
 
-            def _deep_agent_factory(cfg: dict[str, Any]) -> Any:  # pragma: no cover
+            def _deep_agent_factory(cfg: dict[str, Any]) -> Any:
                 _team_task_instructions = cfg.get("instructions") or ""
                 _team_instructions = (
                     DEFAULT_INSTRUCTIONS + "\n\n" + _team_task_instructions
@@ -1211,6 +1211,8 @@ def create_deep_agent(  # noqa: C901
                     include_monitoring=False,
                     context_manager=False,
                     cost_tracking=False,
+                    web_search=web_search,
+                    web_fetch=web_fetch,
                     edit_format=_team_edit_fmt,
                 )
 

--- a/pydantic_deep/agent.py
+++ b/pydantic_deep/agent.py
@@ -1213,6 +1213,9 @@ def create_deep_agent(  # noqa: C901
                     cost_tracking=False,
                     web_search=web_search,
                     web_fetch=web_fetch,
+                    backend=backend,
+                    toolsets=toolsets,
+                    extra_toolsets=tuple(cfg.get("toolsets") or []),
                     edit_format=_team_edit_fmt,
                 )
 

--- a/pydantic_deep/features/teams/primitives.py
+++ b/pydantic_deep/features/teams/primitives.py
@@ -12,8 +12,6 @@ from uuid import uuid4
 from pydantic import BaseModel
 from pydantic_ai_backends import BackendProtocol, StateBackend
 
-from pydantic_deep.models import DEFAULT_TEAM_MEMBER_MODEL
-
 
 class TeamMemberSpec(BaseModel):
     """A team member supplied to the `spawn_team` tool."""
@@ -22,7 +20,7 @@ class TeamMemberSpec(BaseModel):
     role: str = "worker"
     description: str = ""
     instructions: str = ""
-    model: str = DEFAULT_TEAM_MEMBER_MODEL
+    model: str | None = None
 
 
 @dataclass
@@ -225,7 +223,7 @@ class TeamMember:
     role: str
     description: str
     instructions: str
-    model: str = DEFAULT_TEAM_MEMBER_MODEL
+    model: str | None = None
     toolsets: list[Any] = field(default_factory=list)
 
 

--- a/pydantic_deep/features/teams/toolset.py
+++ b/pydantic_deep/features/teams/toolset.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
+from pydantic_ai.models import Model
 from pydantic_ai.tools import RunContext
 from pydantic_ai.toolsets.function import FunctionToolset
 from pydantic_ai_backends import StateBackend
@@ -79,6 +80,7 @@ def create_team_toolset(  # noqa: C901
     task_fn: Any | None = None,
     task_manager: Any | None = None,
     subagent_toolset: SubAgentToolset | None = None,
+    default_model: str | Model | None = None,
 ) -> FunctionToolset[Any]:
     """Create a toolset for managing agent teams.
 
@@ -104,6 +106,10 @@ def create_team_toolset(  # noqa: C901
             subagent, so a message has to go through the subagent engine
             (`answer_task` when it is waiting, `steer_task` while it runs).
             Without it, messages are only recorded on the team bus.
+        default_model: Model team members inherit when their spec names no
+            model — typically the team lead's own model. When unset and a
+            member names none either, compilation falls through to the
+            subagent engine's own handling of model-less configs.
 
     Returns:
         A `FunctionToolset` with team management tools.
@@ -149,15 +155,17 @@ def create_team_toolset(  # noqa: C901
             for member in team_members:
                 if registry.exists(member.name):
                     continue
+                resolved_model = member.model or default_model
                 config = SubAgentConfig(
                     name=member.name,
                     description=f"[Team {team_name}] {member.description}",
                     instructions=member.instructions,
-                    model=member.model,
                 )
+                if resolved_model is not None:
+                    config["model"] = resolved_model
                 if agent_factory is not None:
                     config["agent_factory"] = agent_factory
-                compiled = _compile_subagent(config, member.model)
+                compiled = _compile_subagent(config, resolved_model)
                 registry.register(config, compiled.agent)
 
         lines = [f"Team '{team_name}' created with {len(handles)} members:"]

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -1173,6 +1173,64 @@ class TestTeamSubagentWiring:
             assert member_kwargs["web_fetch"] is False
 
     @pytest.mark.asyncio
+    async def test_team_factory_shares_parent_backend_and_toolsets(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Members run on the parent's backend with the parent's toolsets first,
+        then any per-config toolsets appended (mirroring the subagent factory's
+        extra_toolsets plumbing)."""
+        from pydantic_ai.toolsets.function import FunctionToolset
+
+        import pydantic_deep.agent as agent_module
+        from pydantic_deep.features.teams import create_team_toolset as real_team_toolset
+
+        team_kwargs: dict[str, Any] = {}
+
+        def _team_spy(**kwargs: Any) -> Any:
+            team_kwargs.update(kwargs)
+            return real_team_toolset(**kwargs)
+
+        monkeypatch.setattr("pydantic_deep.agent.create_team_toolset", _team_spy)
+
+        create_calls: list[dict[str, Any]] = []
+        real_create = agent_module.create_deep_agent
+
+        def _create_spy(*args: Any, **kwargs: Any) -> Any:
+            create_calls.append(kwargs)
+            return real_create(*args, **kwargs)
+
+        monkeypatch.setattr(agent_module, "create_deep_agent", _create_spy)
+
+        parent_backend = StateBackend()
+        parent_toolset: FunctionToolset[DeepAgentDeps] = FunctionToolset(id="parent-domain")
+        _create_spy(
+            model=TEST_MODEL,
+            include_subagents=True,
+            include_teams=True,
+            include_filesystem=False,
+            include_todo=False,
+            include_skills=False,
+            include_plan=False,
+            include_monitoring=False,
+            context_manager=False,
+            cost_tracking=False,
+            backend=parent_backend,
+            toolsets=[parent_toolset],
+        )
+
+        cfg_toolset: FunctionToolset[DeepAgentDeps] = FunctionToolset(id="cfg-extra")
+        create_calls.clear()
+        factory = team_kwargs["agent_factory"]
+        member_agent = factory({"name": "member", "instructions": "", "toolsets": [cfg_toolset]})
+
+        (member_kwargs,) = create_calls
+        assert member_kwargs["backend"] is parent_backend
+        assert list(member_kwargs["toolsets"]) == [parent_toolset]
+        assert list(member_kwargs["extra_toolsets"]) == [cfg_toolset]
+        assert parent_toolset in member_agent.toolsets
+        assert cfg_toolset in member_agent.toolsets
+
+    @pytest.mark.asyncio
     async def test_spawn_resolves_omitted_model_against_default_model(self):
         """A spec with no model inherits the toolset `default_model` (the lead's)."""
         from pydantic_ai import Agent

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -1122,6 +1122,57 @@ class TestTeamSubagentWiring:
         assert subagents.registry.get_compiled("coder") is not None
 
     @pytest.mark.asyncio
+    async def test_team_factory_forwards_parent_web_settings(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Members inherit the lead's web_search/web_fetch, not hard-enabled web tools."""
+        import pydantic_deep.agent as agent_module
+
+        captured: list[dict[str, Any]] = []
+        real_create = agent_module.create_deep_agent
+
+        def _spy(*args: Any, **kwargs: Any) -> Any:
+            captured.append(kwargs)
+            return real_create(*args, **kwargs)
+
+        monkeypatch.setattr(agent_module, "create_deep_agent", _spy)
+
+        agent = _spy(
+            model=TEST_MODEL,
+            include_subagents=True,
+            include_teams=True,
+            include_filesystem=False,
+            include_todo=False,
+            include_skills=False,
+            include_plan=False,
+            include_monitoring=False,
+            context_manager=False,
+            cost_tracking=False,
+            web_search=False,
+            web_fetch=False,
+        )
+        toolsets: dict[str, Any] = {
+            ts_id: cast(Any, ts) for ts in agent.toolsets if (ts_id := ts.id) is not None
+        }
+        team = toolsets["deep-team"]
+
+        captured.clear()
+        ctx = _make_ctx()
+        await team.tools["spawn_team"].function(
+            ctx,
+            "build",
+            [
+                TeamMemberSpec(name="with-instr", instructions="You code.", model="test"),
+                TeamMemberSpec(name="bare", model="test"),
+            ],
+        )
+
+        assert len(captured) == 2
+        for member_kwargs in captured:
+            assert member_kwargs["web_search"] is False
+            assert member_kwargs["web_fetch"] is False
+
+    @pytest.mark.asyncio
     async def test_spawn_resolves_omitted_model_against_default_model(self):
         """A spec with no model inherits the toolset `default_model` (the lead's)."""
         from pydantic_ai import Agent

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -470,6 +470,18 @@ class TestTeamMessageBus:
             await bus.receive("nobody")
 
 
+class TestTeamMemberSpec:
+    """Tests for TeamMemberSpec model parsing."""
+
+    def test_model_defaults_to_none(self):
+        """An omitted member model stays unset so it can inherit the lead's."""
+        assert TeamMemberSpec(name="x").model is None
+
+    def test_explicit_model_is_kept(self):
+        """A spec that names a model carries it through unchanged."""
+        assert TeamMemberSpec(name="x", model="openai:gpt-5").model == "openai:gpt-5"
+
+
 class TestTeamMember:
     """Tests for TeamMember dataclass."""
 
@@ -492,7 +504,7 @@ class TestTeamMember:
             description="QA tester",
             instructions="Test thoroughly",
         )
-        assert member.model == "anthropic:claude-sonnet-4-6"
+        assert member.model is None
         assert member.toolsets == []
 
 
@@ -1108,6 +1120,65 @@ class TestTeamSubagentWiring:
 
         assert "coder" in subagents.registry.list_agents()
         assert subagents.registry.get_compiled("coder") is not None
+
+    @pytest.mark.asyncio
+    async def test_spawn_resolves_omitted_model_against_default_model(self):
+        """A spec with no model inherits the toolset `default_model` (the lead's)."""
+        from pydantic_ai import Agent
+        from subagents_pydantic_ai import DynamicAgentRegistry
+
+        registry = DynamicAgentRegistry()
+        team = create_team_toolset(
+            registry=registry,
+            agent_factory=lambda cfg: Agent(TestModel()),
+            default_model="openai:gpt-5",
+        )
+        ctx = _make_ctx()
+        await team.tools["spawn_team"].function(
+            ctx, "build", [TeamMemberSpec(name="coder", instructions="You code.")]
+        )
+
+        assert registry.configs["coder"]["model"] == "openai:gpt-5"
+
+    @pytest.mark.asyncio
+    async def test_spawn_honours_an_explicit_member_model(self):
+        """A spec that names a model keeps it instead of the default_model."""
+        from pydantic_ai import Agent
+        from subagents_pydantic_ai import DynamicAgentRegistry
+
+        registry = DynamicAgentRegistry()
+        team = create_team_toolset(
+            registry=registry,
+            agent_factory=lambda cfg: Agent(TestModel()),
+            default_model="openai:gpt-5",
+        )
+        ctx = _make_ctx()
+        await team.tools["spawn_team"].function(
+            ctx,
+            "build",
+            [TeamMemberSpec(name="coder", instructions="You code.", model="openai:gpt-5-mini")],
+        )
+
+        assert registry.configs["coder"]["model"] == "openai:gpt-5-mini"
+
+    @pytest.mark.asyncio
+    async def test_spawn_without_default_model_leaves_the_key_unset(self):
+        """No spec model and no default_model: the config carries no model at all,
+        so the compile path's own default handling applies (no new crash)."""
+        from pydantic_ai import Agent
+        from subagents_pydantic_ai import DynamicAgentRegistry
+
+        registry = DynamicAgentRegistry()
+        team = create_team_toolset(
+            registry=registry,
+            agent_factory=lambda cfg: Agent(TestModel()),
+        )
+        ctx = _make_ctx()
+        await team.tools["spawn_team"].function(
+            ctx, "build", [TeamMemberSpec(name="coder", instructions="You code.")]
+        )
+
+        assert "model" not in registry.configs["coder"]
 
     @pytest.mark.asyncio
     async def test_assign_task_reaches_the_member(self):


### PR DESCRIPTION
## Summary

`spawn_team` builds member agents through the nested `_deep_agent_factory` in `pydantic_deep/agent.py` — a stale duplicate of the module-scope `_make_default_deep_agent_factory` that never received the subagent path's inheritance fixes. Three independent defects compound in that closure, and any one of them alone makes dynamic teams unusable outside a local-filesystem + Anthropic setup:

1. **Omitted member models fall back to a hardcoded `anthropic:claude-sonnet-4-6`** (`DEFAULT_TEAM_MEMBER_MODEL`) instead of the team lead's model; without `ANTHROPIC_API_KEY` the resulting `UserError` escapes the tool call and terminates the entire parent run.
2. **Members are always built with `web_search=True`**, crashing the run with `UserError: WebSearch(local='duckduckgo') requires the duckduckgo optional group` whenever the extra is absent and the lead has web search disabled.
3. **Members receive neither the lead's `backend` nor its domain `toolsets`** — they come up against a default state backend with only filesystem/todo/web tools, so they cannot operate in the parent's sandbox or with its tools (in our runs the workers noticed this themselves and asked the parent for help).

Fixes #198.

## Changes

- `pydantic_deep/features/teams/primitives.py` — `TeamMemberSpec.model` / `TeamMember.model` default to `None`; an omitted member model now means "inherit", not the hardcoded Anthropic default. `DEFAULT_TEAM_MEMBER_MODEL` remains exported for API compatibility but no longer governs any default.
- `pydantic_deep/features/teams/toolset.py` — `create_team_toolset` gains keyword-only `default_model: str | Model | None = None`; `spawn_team` resolves `member.model or default_model` and forwards it to the subagent engine only when set, so a fully unspecified spawn falls through to the engine's own handling.
- `pydantic_deep/agent.py` — deep-agent construction passes the lead's model as `default_model`; the member factory forwards the parent's `web_search`/`web_fetch`, `backend`, and domain `toolsets` (plus per-config `cfg['toolsets']` via `extra_toolsets`), mirroring `_make_default_deep_agent_factory`'s plumbing; the factory's `# pragma: no cover` is removed and the new tests cover it.
- `tests/test_teams.py` — 7 new tests: spec/member defaults, omitted-vs-explicit model resolution through the real wiring, web-flag forwarding, backend/toolsets sharing with order guarantees.
- `docs/api/types.md` — one-line sync of the documented `TeamMember.model` default.

## Testing

- [x] New tests added for any new functionality (required — `make test` enforces 100% coverage)
- [x] All tests pass locally: `make test` — 2792 passed, 0 failed, TOTAL coverage 100.00% (all three touched files at 100%)
- [x] Linting passes: `make lint`
- [x] Type checking passes: `make typecheck` (pyright: 0 errors, 0 warnings; mypy: no issues in 169 source files)
- [x] Security scan passes: `make security`
- [x] Full check suite passes: `make all`

Additionally cross-verified against upstream: on current `main` the issue-#198 crash reproduces exactly (`spawn_team` on a non-Anthropic setup raises the `ANTHROPIC_API_KEY` UserError during member compilation), and on this branch the same flow compiles members with the lead's model, web settings, backend and toolsets. Each fix was also red-verified: reverting it makes its tests fail.

## Related Issues

Fixes #198

## Notes for Reviewers

- The behavior change is intentional and consistent with 0.3.43's direction (no library-chosen silent model defaults): a model-less member now inherits the team lead's model, the same semantics subagent configs already have. Hosts that want Anthropic per member can still pass it explicitly in `TeamMemberSpec.model`.
- `DEFAULT_TEAM_MEMBER_MODEL` is left exported because it is part of the public `features.teams` surface; dropping it would be a separate breaking change.
- Pre-existing, untouched by this PR: duplicate member names are silently overwritten in `AgentTeam.spawn`, and `spawn_team` with zero members reports success — flagging for a possible follow-up.
